### PR TITLE
fix(audit): show blocking findings before the section cap truncates

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -46,7 +46,7 @@ func Run(root string, out func(string)) int {
 		}
 		totalBlocking += blocking
 		out(fmt.Sprintf("## %s — %d finding(s), %d blocking", name, len(findings), blocking))
-		shown := findings
+		shown := orderForDisplay(findings)
 		if len(shown) > maxPerSection {
 			shown = shown[:maxPerSection]
 		}
@@ -128,6 +128,24 @@ func Run(root string, out func(string)) int {
 	}
 	out("  this repository would pass the procoder gate")
 	return 0
+}
+
+// orderForDisplay partitions blocking findings ahead of info ones (stable
+// within each group) so the section cap can never hide a BLOCK behind
+// info lines.
+func orderForDisplay(findings []gitx.Finding) []gitx.Finding {
+	ordered := make([]gitx.Finding, 0, len(findings))
+	for _, f := range findings {
+		if f.Blocking {
+			ordered = append(ordered, f)
+		}
+	}
+	for _, f := range findings {
+		if !f.Blocking {
+			ordered = append(ordered, f)
+		}
+	}
+	return ordered
 }
 
 // scopedFiles lists what the gate itself would consider: tracked plus

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,33 @@
+package audit
+
+import (
+	"fmt"
+	"testing"
+
+	"procoder/internal/gitx"
+)
+
+// A BLOCK finding sitting past the section cap must still be shown:
+// orderForDisplay puts blocking findings first, so truncation only ever
+// drops info lines.
+func TestOrderForDisplayBlockingSurvivesCap(t *testing.T) {
+	var findings []gitx.Finding
+	for i := range maxPerSection + 5 {
+		findings = append(findings, gitx.Finding{Message: fmt.Sprintf("info %d", i)})
+	}
+	findings = append(findings, gitx.Finding{Blocking: true, Message: "block A"})
+	findings = append(findings, gitx.Finding{Blocking: true, Message: "block B"})
+
+	ordered := orderForDisplay(findings)
+	if len(ordered) != len(findings) {
+		t.Fatalf("ordering changed length: got %d, want %d", len(ordered), len(findings))
+	}
+	if ordered[0].Message != "block A" || ordered[1].Message != "block B" {
+		t.Fatalf("blocking findings not first (stable): got %q, %q", ordered[0].Message, ordered[1].Message)
+	}
+	for i, f := range ordered[2:] {
+		if want := fmt.Sprintf("info %d", i); f.Message != want {
+			t.Fatalf("info order not stable at %d: got %q, want %q", i, f.Message, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Blocking findings are now partitioned ahead of info findings (stable within each group) before the per-section display cap of 15 is applied, so a BLOCK line can never disappear into the "… N more" tail.

## Why

Running `procoder audit` on eva-website reported "5 blocking" in the hygiene section header but displayed only 1 BLOCK line: the other 4 sat behind 30+ info doc-drift findings in collection order and were truncated. The scorecard total was honest, but the actionable lines were invisible — the operator had to re-run individual domain commands to find out what was blocking.

## How

Extracted a tiny `orderForDisplay` helper in `internal/audit/audit.go` that does a stable two-pass partition (blocking first), applied only to display order — counts and totals are untouched. The formatting section needs no change: all its findings are blocking.

## Testing

`go test ./internal/audit/` — new `TestOrderForDisplayBlockingSurvivesCap` places 2 BLOCK findings after `maxPerSection+5` info findings and asserts they land in the first two display slots with stable order in both groups. `go build ./...` and `go vet` clean.

## Notes for the reviewer

One helper plus one call-site change; the test file is new.