### PR TITLE
docs: run CommandCoverage only inside the procoder source tree

### DIFF
--- a/internal/docs/coverage.go
+++ b/internal/docs/coverage.go
@@ -20,9 +20,15 @@ var Commands = []string{
 
 // CommandCoverage reports commands the documentation never mentions —
 // correctness checks can't see absence, so completeness gets its own
-// check. Only runs when the repo has a docs/ site directory; a repo
-// without one is not claiming comprehensive docs.
+// check. This is a self-check: Commands is procoder's own list, so it
+// only runs inside the procoder source tree itself (go.mod declares
+// `module procoder`) — any other repo does not ship these commands and
+// must not be gated on documenting them. It also needs a docs/ site
+// directory; a repo without one is not claiming comprehensive docs.
 func CommandCoverage(root string) []gitx.Finding {
+	if !isProcoderRepo(root) {
+		return nil
+	}
 	dir := filepath.Join(root, "docs")
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 		return nil
@@ -53,4 +59,20 @@ func CommandCoverage(root string) []gitx.Finding {
 		}
 	}
 	return out
+}
+
+// isProcoderRepo reports whether root is the procoder source tree: the one
+// repository that ships the Commands list and therefore owes each command a
+// documentation mention.
+func isProcoderRepo(root string) bool {
+	raw, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.SplitN(string(raw), "\n", 4) {
+		if strings.TrimSpace(line) == "module procoder" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/docs/coverage_test.go
+++ b/internal/docs/coverage_test.go
@@ -1,0 +1,49 @@
+package docs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCommandCoverageSkipsRepositoriesThatAreNotProcoder(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "go.mod", "module example.com/some/library\n\ngo 1.22\n")
+	write(t, root, "README.md", "# lib\n")
+	write(t, root, "docs/index.md", "docs site with no procoder mentions\n")
+
+	if got := CommandCoverage(root); len(got) != 0 {
+		t.Fatalf("a repo that does not ship the commands must not be gated on documenting them, got %+v", got)
+	}
+}
+
+func TestCommandCoverageReportsMissingCommandsInTheProcoderRepo(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "go.mod", "module procoder\n\ngo 1.22\n")
+	var mentions strings.Builder
+	for _, cmd := range Commands {
+		if cmd == "audit" {
+			continue // the one we leave undocumented
+		}
+		mentions.WriteString("`procoder " + cmd + "`\n")
+	}
+	write(t, root, "docs/reference.md", mentions.String())
+	write(t, root, "README.md", "# procoder\n")
+
+	got := CommandCoverage(root)
+	if len(got) != 1 {
+		t.Fatalf("want exactly the one undocumented command, got %d: %+v", len(got), got)
+	}
+	if !got[0].Blocking || !strings.Contains(got[0].Message, "procoder audit") {
+		t.Fatalf("finding must block and name the command: %+v", got[0])
+	}
+}
+
+func TestCommandCoverageStillNeedsADocsSite(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "go.mod", "module procoder\n\ngo 1.22\n")
+	write(t, root, "README.md", "# procoder\n")
+
+	if got := CommandCoverage(root); len(got) != 0 {
+		t.Fatalf("no docs/ directory means no comprehensive-docs claim, got %+v", got)
+	}
+}


### PR DESCRIPTION
## What

`CommandCoverage` now runs only when the audited repository is the procoder source tree itself (`go.mod` declares `module procoder`). Any other repository is no longer gated on mentioning `procoder <cmd>` in its documentation.

## Why

The check holds documentation to procoder's **own** `Commands` list — it is a self-check — but it fired on any repo with a `docs/` directory. Onboarding an unrelated Go library (go-ai-sdk) with `procoder audit` produced 24 blocking `documentation never mentions procoder <cmd>` findings for commands that repo does not ship, forcing a filler docs page to pass the gate.

## How

A small `isProcoderRepo` helper reads `go.mod` and looks for the `module procoder` line — the one unambiguous marker of the source tree that ships the commands. The docs/-site guard and the corpus scan are unchanged, so the self-check behaves exactly as before inside this repo.

## Testing

`go test ./...` — all packages pass. New tests in `internal/docs/coverage_test.go` pin the three behaviors: a non-procoder repo with a docs site is skipped; the procoder repo reports a missing command as blocking and names it; a procoder tree without `docs/` still reports nothing.

## Notes for the reviewer

Start at `internal/docs/coverage.go` — the diff is one guard plus the helper. `internal/docs/report.go`'s two call sites are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)