### PR TITLE
audit: honest scopes for secrets and eslint

### DIFF
--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -358,6 +358,22 @@ func run(args []string) int {
 				return 1
 			}
 			paths = changed
+		} else {
+			// a directory argument means its files — lint switches on file
+			// extension, so an unexpanded directory would silently lint nothing
+			var expanded []string
+			for _, p := range paths {
+				abs := p
+				if !filepath.IsAbs(abs) {
+					abs = filepath.Join(root, abs)
+				}
+				if info, err := os.Stat(abs); err == nil && info.IsDir() {
+					expanded = append(expanded, gitx.FilesUnder(root, p)...)
+				} else {
+					expanded = append(expanded, p)
+				}
+			}
+			paths = expanded
 		}
 		cfg := config.Load(root)
 		findings := lint.Files(root, paths, cfg.LintBlock)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -115,7 +115,10 @@ func Run(root string, out func(string)) int {
 	// Collect is the gate's shared slice: git hygiene, templates, workflow
 	// lint, CI hygiene, infrastructure, and documentation in one pass
 	report("hygiene (git, workflows, CI, infra, docs)", gitcmd.Collect(root, cfg, files))
-	report("secrets (gitleaks)", security.Secrets(root, []string{root}))
+	// the file set, not the directory: dir mode would read gitignored
+	// trees (node_modules/, target/, local caches) and stamp fingerprints
+	// with absolute paths — see SecretsTree
+	report("secrets (gitleaks)", security.SecretsTree(root, files))
 	report("lint", lint.Files(root, files, cfg.LintBlock))
 
 	out("## scorecard")

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -52,6 +52,22 @@ func ChangedFiles(root string) ([]string, error) {
 	return files, nil
 }
 
+// FilesUnder lists the gate's file set beneath dir: tracked plus
+// untracked-but-not-ignored. Paths are absolute.
+func FilesUnder(root, dir string) []string {
+	out, err := git(root, "ls-files", "--cached", "--others", "--exclude-standard", "--", dir)
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, line := range strings.Split(out, "\n") {
+		if line != "" {
+			files = append(files, filepath.Join(root, line))
+		}
+	}
+	return files
+}
+
 // CurrentBranch, or "" when detached.
 func CurrentBranch(root string) string {
 	b, err := git(root, "branch", "--show-current")

--- a/internal/gitx/gitx_test.go
+++ b/internal/gitx/gitx_test.go
@@ -35,6 +35,22 @@ func commit(t *testing.T, dir, msg string) {
 	}
 }
 
+// FilesUnder scopes to the directory and honours gitignore — the set a
+// directory argument to `procoder lint` expands into.
+func TestFilesUnderScopesAndHonoursGitignore(t *testing.T) {
+	dir := repo(t)
+	os.MkdirAll(filepath.Join(dir, "web", "node_modules"), 0o755)
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("node_modules/\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "web", "app.js"), []byte("x\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "web", "node_modules", "dep.js"), []byte("x\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "top.js"), []byte("x\n"), 0o644)
+
+	got := FilesUnder(dir, "web")
+	if len(got) != 1 || got[0] != filepath.Join(dir, "web", "app.js") {
+		t.Fatalf("want only web/app.js (untracked in, gitignored and out-of-dir excluded), got %v", got)
+	}
+}
+
 func TestConflictMarkersAreFoundWithLineNumbers(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "a.txt")

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -336,27 +337,57 @@ func hasGolangciConfig(root string) bool {
 	return false
 }
 
-// lintJS runs eslint. The project's config always wins; where none exists,
-// a generated baseline of eslint's BUILT-IN core rules fills the void —
-// procoder still imposes nothing on the repo (the file lives in the temp
-// dir), and baseline findings are labeled as such. eslint v10 dropped the
-// unix formatter from core, so both paths parse JSON.
+// lintJS runs eslint. The project's config always wins and is resolved the
+// way eslint itself resolves flat config — the nearest eslint config
+// ascending from each linted file — so a config in a subdirectory (web/,
+// packages/app/) counts, not just one at the repo root. Files under a
+// config are linted from that config's directory; only files no config
+// covers get the baseline of eslint's BUILT-IN core rules — procoder still
+// imposes nothing on the repo (the file lives in the temp dir), and
+// baseline findings are labeled as such. eslint v10 dropped the unix
+// formatter from core, so both paths parse JSON.
 func lintJS(root string, files []string, block bool) []gitx.Finding {
-	bin := tools.Resolve(Eslint, root)
-	if HasEslintConfig(root) {
-		if bin == "" {
-			return notChecked(files[0], "eslint")
-		}
-		raw, err := execute(root, bin, append([]string{"--format", "json"}, files...))
-		return parseEslintJSON(raw, err, files[0], "lint", block)
-	}
-	// no project config: plain JS gets the built-in-rules baseline;
-	// TypeScript needs a parser eslint core does not carry, and installing
-	// one would be imposing — TS is out of scope until the project carries
-	// a config, whether or not eslint itself is installed.
-	var jsFiles []string
-	var out []gitx.Finding
+	byCfg := map[string][]string{}
+	var uncovered []string
 	for _, f := range files {
+		if dir := nearestEslintConfigDir(root, f); dir != "" {
+			byCfg[dir] = append(byCfg[dir], f)
+		} else {
+			uncovered = append(uncovered, f)
+		}
+	}
+	var out []gitx.Finding
+	cfgDirs := make([]string, 0, len(byCfg))
+	for d := range byCfg {
+		cfgDirs = append(cfgDirs, d)
+	}
+	sort.Strings(cfgDirs)
+	for _, dir := range cfgDirs {
+		fs := byCfg[dir]
+		// a project-local eslint may live beside the config, not the root
+		bin := tools.Resolve(Eslint, dir)
+		if bin == "" {
+			bin = tools.Resolve(Eslint, root)
+		}
+		if bin == "" {
+			out = append(out, notChecked(fs[0], "eslint")...)
+			continue
+		}
+		// run from the config's directory: eslint's own config search starts
+		// there, so the nearest config is the one that gets used
+		raw, err := execute(dir, bin, append([]string{"--format", "json"}, fs...))
+		out = append(out, parseEslintJSON(raw, err, fs[0], "lint", block)...)
+	}
+	if len(uncovered) == 0 {
+		return out
+	}
+	bin := tools.Resolve(Eslint, root)
+	// no config covers these files: plain JS gets the built-in-rules
+	// baseline; TypeScript needs a parser eslint core does not carry, and
+	// installing one would be imposing — TS is out of scope until the
+	// project carries a config, whether or not eslint itself is installed.
+	var jsFiles []string
+	for _, f := range uncovered {
 		switch strings.ToLower(filepath.Ext(f)) {
 		case ".ts", ".tsx":
 			out = append(out, gitx.Finding{File: f,
@@ -467,16 +498,41 @@ func errStr(err error) string {
 	return err.Error()
 }
 
-// HasEslintConfig reports whether the project carries an eslint config —
-// the condition for eslint being in scope at all.
+// eslintConfigNames are the config files eslint recognises, flat first.
+var eslintConfigNames = []string{"eslint.config.js", "eslint.config.mjs", "eslint.config.cjs",
+	"eslint.config.ts", ".eslintrc", ".eslintrc.json", ".eslintrc.js", ".eslintrc.yml", ".eslintrc.yaml"}
+
+// HasEslintConfig reports whether the project carries an eslint config at
+// its root — the condition for eslint being in scope at all.
 func HasEslintConfig(root string) bool {
-	for _, name := range []string{"eslint.config.js", "eslint.config.mjs", "eslint.config.cjs",
-		"eslint.config.ts", ".eslintrc", ".eslintrc.json", ".eslintrc.js", ".eslintrc.yml", ".eslintrc.yaml"} {
+	for _, name := range eslintConfigNames {
 		if fileExists(filepath.Join(root, name)) {
 			return true
 		}
 	}
 	return false
+}
+
+// nearestEslintConfigDir ascends from the file's directory to the repo root
+// looking for an eslint config, the way eslint resolves flat config. Empty
+// means no config covers the file.
+func nearestEslintConfigDir(root, file string) string {
+	dir := filepath.Dir(file)
+	for {
+		for _, name := range eslintConfigNames {
+			if fileExists(filepath.Join(dir, name)) {
+				return dir
+			}
+		}
+		if dir == root {
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // run resolves the tool, executes it, and parses the shared finding shape.

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -128,6 +128,52 @@ func TestConfiglessTSIsOutOfScopeButJSGetsTheBaseline(t *testing.T) {
 	}
 }
 
+// The nearest config wins, ascending from the linted file — a config in a
+// subdirectory (web/, packages/app/) counts, not just one at the repo root.
+func TestNearestEslintConfigAscendsFromTheFile(t *testing.T) {
+	root := t.TempDir()
+	webDir := filepath.Join(root, "web")
+	os.MkdirAll(filepath.Join(webDir, "src"), 0o755)
+	os.WriteFile(filepath.Join(webDir, "eslint.config.mjs"), []byte("export default []\n"), 0o644)
+
+	if got := nearestEslintConfigDir(root, filepath.Join(webDir, "src", "app.jsx")); got != webDir {
+		t.Fatalf("file under web/ must resolve to web/'s config, got %q", got)
+	}
+	if got := nearestEslintConfigDir(root, filepath.Join(root, "tool.js")); got != "" {
+		t.Fatalf("file outside any config's tree must be uncovered, got %q", got)
+	}
+
+	os.WriteFile(filepath.Join(root, ".eslintrc.json"), []byte("{}\n"), 0o644)
+	if got := nearestEslintConfigDir(root, filepath.Join(webDir, "src", "app.jsx")); got != webDir {
+		t.Fatalf("the NEAREST config must win over the root's, got %q", got)
+	}
+	if got := nearestEslintConfigDir(root, filepath.Join(root, "tool.js")); got != root {
+		t.Fatalf("root config must cover root-level files, got %q", got)
+	}
+}
+
+// A file covered by a subdirectory config is linted under THAT config, not
+// the procoder baseline — the audit path regression from issue #28.
+func TestSubdirConfigWinsOverTheBaseline(t *testing.T) {
+	if tools.Resolve(Eslint, "") == "" {
+		t.Skip("eslint not installed; the resolution logic is tested above")
+	}
+	root := t.TempDir()
+	webDir := filepath.Join(root, "web")
+	os.MkdirAll(webDir, 0o755)
+	// a permissive config: everything the baseline would flag is allowed
+	os.WriteFile(filepath.Join(webDir, "eslint.config.mjs"),
+		[]byte("export default [{ rules: {} }]\n"), 0o644)
+	f := filepath.Join(webDir, "app.js")
+	os.WriteFile(f, []byte("var x = 1\nif (x == 2) { }\n"), 0o644)
+
+	for _, g := range Files(root, []string{f}, false) {
+		if strings.Contains(g.Message, "procoder baseline") {
+			t.Fatalf("the repo's own config must win over the baseline: %+v", g)
+		}
+	}
+}
+
 func TestShellcheckFindsARealProblem(t *testing.T) {
 	if tools.Resolve(Shellcheck, "") == "" {
 		t.Skip("shellcheck not installed; parser tests carry the logic")

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"procoder/internal/gitx"
@@ -77,66 +78,135 @@ func Secrets(root string, paths []string) []gitx.Finding {
 		if _, err := os.Stat(p); err != nil {
 			continue
 		}
-		report := filepath.Join(os.TempDir(), fmt.Sprintf("procoder-gitleaks-%d.json", time.Now().UnixNano()))
-		common := []string{"--report-format", "json", "--report-path", report,
-			"--no-banner", "--exit-code", "1"}
-		ctx, cancel := context.WithTimeout(context.Background(), secretsTimeout)
-		cmd := exec.CommandContext(ctx, bin, append([]string{"dir", p}, common...)...) // nosemgrep -- resolved from the fixed tool table, never user input
-		cmd.Dir = root
-		var errb bytes.Buffer
-		cmd.Stderr = &errb
-		runErr := cmd.Run()
-		cancel()
-		if ctx.Err() == context.DeadlineExceeded {
-			out = append(out, gitx.Finding{File: p, Blocking: true,
-				Message: fmt.Sprintf("gitleaks gave no answer in %s — the path was NOT checked (security)", secretsTimeout)})
+		out = append(out, scanOne(bin, root, p)...)
+	}
+	return out
+}
+
+// scanOne runs gitleaks over one source path. src is handed to gitleaks
+// verbatim and workdir is where it runs from, so a relative src keeps the
+// report's paths — and therefore .gitleaksignore fingerprints — relative.
+func scanOne(bin, workdir, src string) []gitx.Finding {
+	var out []gitx.Finding
+	report := filepath.Join(os.TempDir(), fmt.Sprintf("procoder-gitleaks-%d.json", time.Now().UnixNano()))
+	common := []string{"--report-format", "json", "--report-path", report,
+		"--no-banner", "--exit-code", "1"}
+	ctx, cancel := context.WithTimeout(context.Background(), secretsTimeout)
+	cmd := exec.CommandContext(ctx, bin, append([]string{"dir", src}, common...)...) // nosemgrep -- resolved from the fixed tool table, never user input
+	cmd.Dir = workdir
+	var errb bytes.Buffer
+	cmd.Stderr = &errb
+	runErr := cmd.Run()
+	cancel()
+	if ctx.Err() == context.DeadlineExceeded {
+		return []gitx.Finding{{File: src, Blocking: true,
+			Message: fmt.Sprintf("gitleaks gave no answer in %s — the path was NOT checked (security)", secretsTimeout)}}
+	}
+	if bytes.Contains(errb.Bytes(), []byte(`unknown command "dir"`)) {
+		// gitleaks before v8.19 has no `dir`; the same scan is spelled
+		// `detect --no-git --source` there — apt still ships that era
+		ctx2, cancel2 := context.WithTimeout(context.Background(), secretsTimeout)
+		legacy := exec.CommandContext(ctx2, bin, append([]string{"detect", "--no-git", "--source", src}, common...)...) // nosemgrep -- resolved from the fixed tool table, never user input
+		legacy.Dir = workdir
+		errb.Reset()
+		legacy.Stderr = &errb
+		runErr = legacy.Run()
+		cancel2()
+		if ctx2.Err() == context.DeadlineExceeded {
+			return []gitx.Finding{{File: src, Blocking: true,
+				Message: fmt.Sprintf("gitleaks gave no answer in %s — the path was NOT checked (security)", secretsTimeout)}}
+		}
+	}
+	raw, readErr := os.ReadFile(report)
+	os.Remove(report)
+	if readErr != nil {
+		return []gitx.Finding{{File: src, Blocking: true,
+			Message: "gitleaks produced no report — the path was NOT checked: " + firstLine(errb.String()) + " (security)"}}
+	}
+	var leaks []struct {
+		File      string `json:"File"`
+		StartLine int    `json:"StartLine"`
+		RuleID    string `json:"RuleID"`
+	}
+	if json.Unmarshal(raw, &leaks) != nil {
+		return []gitx.Finding{{File: src, Blocking: true,
+			Message: "gitleaks report unreadable — the path was NOT checked (security)"}}
+	}
+	for _, l := range leaks {
+		// gitleaks echoes the path as given for file scans and prefixes
+		// it for directory scans — normalise to one shape
+		loc := l.File
+		if !filepath.IsAbs(loc) && loc != src {
+			loc = filepath.Join(src, loc)
+		}
+		// the finding names the rule and location — NEVER the secret
+		out = append(out, gitx.Finding{File: loc, Line: l.StartLine, Blocking: true,
+			Message: fmt.Sprintf("secret detected (%s) — remove it and rotate the credential; committed secrets live in history forever (security)", l.RuleID)})
+	}
+	_ = runErr // exit 1 just means leaks; they are already collected
+	return out
+}
+
+// SecretsTree scans the audit's file set — tracked plus untracked,
+// gitignored excluded — in ONE gitleaks pass. gitleaks's dir mode walks
+// everything under a path with no notion of gitignore, so the files are
+// mirrored (hardlink, copy fallback) into a temp tree and THAT is scanned,
+// relative to its own root. That is what (1) keeps gitignored content out
+// of the scan, which is also what keeps real repos inside the time budget,
+// and (2) makes finding fingerprints repo-relative, so a committed
+// .gitleaksignore (mirrored along with the rest) works on every checkout.
+func SecretsTree(root string, files []string) []gitx.Finding {
+	bin := tools.Resolve(Gitleaks, root)
+	if bin == "" {
+		return []gitx.Finding{{Blocking: true,
+			Message: "NOT checked — gitleaks is not installed; run `procoder init` (security)"}}
+	}
+	tmp, err := os.MkdirTemp("", "procoder-secrets-")
+	if err != nil {
+		return []gitx.Finding{{Blocking: true,
+			Message: "secrets NOT checked — cannot stage the scan tree: " + err.Error() + " (security)"}}
+	}
+	defer os.RemoveAll(tmp)
+	var out []gitx.Finding
+	staged, skipped := 0, 0
+	for _, f := range files {
+		rel, err := filepath.Rel(root, f)
+		if err != nil || strings.HasPrefix(rel, "..") {
 			continue
 		}
-		if bytes.Contains(errb.Bytes(), []byte(`unknown command "dir"`)) {
-			// gitleaks before v8.19 has no `dir`; the same scan is spelled
-			// `detect --no-git --source` there — apt still ships that era
-			ctx2, cancel2 := context.WithTimeout(context.Background(), secretsTimeout)
-			legacy := exec.CommandContext(ctx2, bin, append([]string{"detect", "--no-git", "--source", p}, common...)...) // nosemgrep -- resolved from the fixed tool table, never user input
-			legacy.Dir = root
-			errb.Reset()
-			legacy.Stderr = &errb
-			runErr = legacy.Run()
-			cancel2()
-			if ctx2.Err() == context.DeadlineExceeded {
-				out = append(out, gitx.Finding{File: p, Blocking: true,
-					Message: fmt.Sprintf("gitleaks gave no answer in %s — the path was NOT checked (security)", secretsTimeout)})
+		info, err := os.Lstat(f)
+		if err != nil || !info.Mode().IsRegular() {
+			continue // symlinks and specials have no content of their own
+		}
+		dst := filepath.Join(tmp, rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			skipped++
+			continue
+		}
+		if os.Link(f, dst) != nil { // cross-device temp: fall back to a copy
+			data, err := os.ReadFile(f)
+			if err != nil || os.WriteFile(dst, data, 0o600) != nil {
+				skipped++
 				continue
 			}
 		}
-		raw, readErr := os.ReadFile(report)
-		os.Remove(report)
-		if readErr != nil {
-			out = append(out, gitx.Finding{File: p, Blocking: true,
-				Message: "gitleaks produced no report — the path was NOT checked: " + firstLine(errb.String()) + " (security)"})
-			continue
+		staged++
+	}
+	if skipped > 0 {
+		out = append(out, gitx.Finding{Blocking: true,
+			Message: fmt.Sprintf("%d file(s) could not be staged for the secrets scan — they were NOT checked (security)", skipped)})
+	}
+	if staged == 0 {
+		return out
+	}
+	for _, f := range scanOne(bin, tmp, ".") {
+		// map the mirror's relative paths back into the repository
+		if f.File == "." || f.File == "" {
+			f.File = ""
+		} else if !filepath.IsAbs(f.File) {
+			f.File = filepath.Join(root, f.File)
 		}
-		var leaks []struct {
-			File      string `json:"File"`
-			StartLine int    `json:"StartLine"`
-			RuleID    string `json:"RuleID"`
-		}
-		if json.Unmarshal(raw, &leaks) != nil {
-			out = append(out, gitx.Finding{File: p, Blocking: true,
-				Message: "gitleaks report unreadable — the path was NOT checked (security)"})
-			continue
-		}
-		for _, l := range leaks {
-			// gitleaks echoes the path as given for file scans and prefixes
-			// it for directory scans — normalise to one shape
-			loc := l.File
-			if !filepath.IsAbs(loc) && loc != p {
-				loc = filepath.Join(p, loc)
-			}
-			// the finding names the rule and location — NEVER the secret
-			out = append(out, gitx.Finding{File: loc, Line: l.StartLine, Blocking: true,
-				Message: fmt.Sprintf("secret detected (%s) — remove it and rotate the credential; committed secrets live in history forever (security)", l.RuleID)})
-		}
-		_ = runErr // exit 1 just means leaks; they are already collected
+		out = append(out, f)
 	}
 	return out
 }

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -49,6 +49,38 @@ func TestCleanFileIsSilent(t *testing.T) {
 	}
 }
 
+// The audit's tree scan covers ONLY the given file set — a secret in a file
+// outside the set (gitignored in real life) must not surface — reports
+// repo paths, and honours a committed repo-relative .gitleaksignore.
+func TestSecretsTreeScopeAndRelativeFingerprints(t *testing.T) {
+	if tools.Resolve(Gitleaks, "") == "" {
+		t.Skip("gitleaks not installed")
+	}
+	root := t.TempDir()
+	token := "ghp_" + "x9J2mQ8v" + "LpZ4tR7n" + "W3kY6bC1" + "dF5gH0aSeD"
+	inScope := filepath.Join(root, "src", "cfg.py")
+	os.MkdirAll(filepath.Dir(inScope), 0o755)
+	os.WriteFile(inScope, []byte("token = \""+token+"\"\n"), 0o644)
+	ignored := filepath.Join(root, "node_modules", "cache.py")
+	os.MkdirAll(filepath.Dir(ignored), 0o755)
+	os.WriteFile(ignored, []byte("token = \""+token+"\"\n"), 0o644)
+
+	got := SecretsTree(root, []string{inScope})
+	if len(got) != 1 || !got[0].Blocking || got[0].File != inScope {
+		t.Fatalf("want one blocking finding at %s, got %+v", inScope, got)
+	}
+
+	// a repo-relative fingerprint in .gitleaksignore must suppress it —
+	// the whole point of scanning relative; the rule name comes from the
+	// finding itself so the test survives gitleaks ruleset renames
+	ruleID := got[0].Message[strings.Index(got[0].Message, "(")+1 : strings.Index(got[0].Message, ")")]
+	ignoreFile := filepath.Join(root, ".gitleaksignore")
+	os.WriteFile(ignoreFile, []byte("src/cfg.py:"+ruleID+":1\n"), 0o644)
+	if got := SecretsTree(root, []string{inScope, ignoreFile}); len(got) != 0 {
+		t.Fatalf("repo-relative fingerprint must suppress the finding: %+v", got)
+	}
+}
+
 // Missing scanners are blocking NOT-checked, never silence — a security
 // check that quietly didn't run is worse than a red one.
 func TestMissingToolsReadAsBlockingNotChecked(t *testing.T) {


### PR DESCRIPTION
Fixes #27, fixes #28.

**Secrets (#27):** `procoder audit` no longer runs gitleaks dir-mode over the repo root. `security.SecretsTree` mirrors the audit's own file set (tracked plus untracked, gitignored excluded — hardlink with copy fallback) into a temp tree and scans that in one pass, relative to its root. Gitignored trees (`node_modules/`, `target/`, browser-profile caches) are never read — which also brings real repos back inside the 60s budget — and finding fingerprints come out repo-relative, so a committed `.gitleaksignore` with standard `path:rule:line` entries works on every checkout. Files that cannot be staged surface as a blocking NOT-checked count, never silence.

**Lint (#28):** eslint config resolution now ascends from each linted file to the repo root, the way eslint itself resolves flat config — so `web/eslint.config.mjs` wins over the procoder baseline. Files are grouped per nearest config and linted from that config's directory (with a project-local eslint resolved beside it); only files no config covers get the labeled baseline. Also fixed the adjacent trap from the report: `procoder lint web/src` used to lint nothing silently (the dispatcher switches on file extension) — directory arguments now expand to their git file set.

Runnable checks: `TestSecretsTreeScopeAndRelativeFingerprints` (scope + relative-fingerprint suppression, live gitleaks), `TestNearestEslintConfigAscendsFromTheFile`, `TestSubdirConfigWinsOverTheBaseline` (live eslint), `TestFilesUnderScopesAndHonoursGitignore`.

#26 needs no change here — the CommandCoverage check was scoped to the procoder source tree in #24 and shipped in v0.22.1.