### PR TITLE
docs: serve the site from procoder.azrty.com, and fix the stale listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,14 @@
 {
   "name": "procoder",
-  "owner": { "name": "Pascal Watteel" },
+  "owner": {
+    "name": "Pascal Watteel"
+  },
   "plugins": [
     {
       "name": "procoder",
       "source": "./",
-      "description": "Six-rung ship gate: SAFE, TRUE, OBVIOUS, ALONE, FAST, MEANT."
+      "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
+      "homepage": "https://procoder.azrty.com/"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@ into `architecture.md` had an anchor that no heading generated.
 
 Documentation, after reading it as a user rather than as its author.
 
-- **Serena joins the provenance map.** [Influences](https://azrtydxb.github.io/procoder/influences/)
+- **Serena joins the provenance map.** [Influences](https://procoder.azrty.com/influences/)
   covered superpowers and ponytail but not serena, whose navigation half
   Procoder took into the binary — `index find` / `refs` / `outline` /
   `callers` / `impls` / `rename`, plus `lint --types` and `.procoder/` as

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ in control — nothing ever touches your code behind its back.
 That's Claude Code; Procoder also ships adapters for **every agent** —
 Cursor, Windsurf, Cline, Kilo Code, Roo, Kiro, Codex CLI, Copilot CLI,
 Gemini, OpenCode, and anything that reads `AGENTS.md`. See
-[Every agent](https://azrtydxb.github.io/procoder/portability/).
+[Every agent](https://procoder.azrty.com/portability/).
 
 ## Before / after
 
@@ -147,7 +147,7 @@ means two sets of instructions competing for the same agent:
   not adopted: the binary computes the rename and hands you the diff.
 
 Full provenance map, including where the serena replacement stops:
-[Influences](https://azrtydxb.github.io/procoder/influences/).
+[Influences](https://procoder.azrty.com/influences/).
 
 ## Configuration
 
@@ -156,21 +156,21 @@ edited, and the repo's version always wins over the built-in default:
 `config.toml` (policies, thresholds), `PRINCIPLES.md`, the github
 templates, the docs/security rules, the review rubric, the lessons
 ledger. Full reference:
-[Configuration](https://azrtydxb.github.io/procoder/configuration/).
+[Configuration](https://procoder.azrty.com/configuration/).
 
 ## The docs
 
 The full story lives on the site, organised the way the
 [Divio documentation system](https://docs.divio.com/documentation-system/)
 splits it: the tutorial
-([Getting started](https://azrtydxb.github.io/procoder/getting-started/)),
+([Getting started](https://procoder.azrty.com/getting-started/)),
 the how-to guides
-([Ship a change](https://azrtydxb.github.io/procoder/workflow/)),
+([Ship a change](https://procoder.azrty.com/workflow/)),
 the reference
-([every command](https://azrtydxb.github.io/procoder/commands/)), and
+([every command](https://procoder.azrty.com/commands/)), and
 the explanation
-([the quality chain](https://azrtydxb.github.io/procoder/quality-chain/),
-[how it's built](https://azrtydxb.github.io/procoder/architecture/)).
+([the quality chain](https://procoder.azrty.com/quality-chain/),
+[how it's built](https://procoder.azrty.com/architecture/)).
 
 ## What the reports mean
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+procoder.azrty.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Procoder
 site_description: A harness that makes AI coders work like senior developers.
-site_url: https://azrtydxb.github.io/procoder/
+site_url: https://procoder.azrty.com/
 repo_url: https://github.com/azrtydxb/procoder
 
 theme:


### PR DESCRIPTION
**Draft on purpose — merging this before DNS resolves takes the docs offline.**

Publishing a `CNAME` makes GitHub redirect `azrtydxb.github.io/procoder` → `procoder.azrty.com`. If the record isn't live yet, both addresses fail. So: record first, merge second.

## What I need you to add in Route 53

In the hosted zone for **`azrty.com`**:

| field | value |
|---|---|
| Record name | `procoder` |
| Type | **CNAME** |
| Value | `azrtydxb.github.io` |
| TTL | 300 |

**Note the value has no `/procoder` path and no trailing dot in the console** — it's the *user* Pages host, not the project URL. GitHub routes to the right repo from the CNAME file in the artifact.

If Route 53 won't let you CNAME that name (it will — it's a subdomain, not the apex), an ALIAS is not needed here.

## What's in the PR

- `docs/CNAME` → `procoder.azrty.com`, **verified to land in the built site** so a redeploy can't silently drop the domain back to github.io. This is the mechanism; a setting in the web UI is not.
- `mkdocs.yml` `site_url`
- Every absolute link in README and CHANGELOG — 10 references across 3 files, no `github.io` URL left.

## Sequence from here

1. You add the record above.
2. Tell me, or I'll poll — I'll confirm `procoder.azrty.com` resolves to GitHub's Pages IPs.
3. I rebase onto main (protection requires up-to-date) and merge.
4. Pages picks up the domain from the CNAME; I verify the site serves and then **enable Enforce HTTPS** once GitHub finishes provisioning the certificate — that can take a few minutes after DNS goes live.

Nothing here is urgent and nothing breaks while it sits in draft.