### PR TITLE
ci: release assets need distinct file names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,9 @@ jobs:
           # gh takes an asset's NAME from the file name; `path#text` sets only
           # its display label. Five files all called `procoder` therefore
           # upload as five assets called `procoder`, and the second one fails.
+          # cleared, not just created: a reused workspace could leave files
+          # behind and the count would then pass or fail for the wrong reason
+          rm -rf /tmp/assets
           mkdir -p /tmp/assets
           cp dist/darwin-arm64/procoder      /tmp/assets/procoder-darwin-arm64
           cp dist/darwin-amd64/procoder      /tmp/assets/procoder-darwin-amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,25 @@ jobs:
             exit 1
           fi
           head -3 /tmp/notes.md
+      - name: stage the binaries under names that do not collide
+        run: |
+          # gh takes an asset's NAME from the file name; `path#text` sets only
+          # its display label. Five files all called `procoder` therefore
+          # upload as five assets called `procoder`, and the second one fails.
+          mkdir -p /tmp/assets
+          cp dist/darwin-arm64/procoder      /tmp/assets/procoder-darwin-arm64
+          cp dist/darwin-amd64/procoder      /tmp/assets/procoder-darwin-amd64
+          cp dist/linux-amd64/procoder       /tmp/assets/procoder-linux-amd64
+          cp dist/linux-arm64/procoder       /tmp/assets/procoder-linux-arm64
+          cp dist/windows-amd64/procoder.exe /tmp/assets/procoder-windows-amd64.exe
+          # five files, five distinct names, or the upload is not worth trying
+          count=$(find /tmp/assets -type f -exec basename {} \; | sort -u | wc -l)
+          if [ "$count" -ne 5 ]; then
+            echo "expected 5 distinctly named assets, staged $count" >&2
+            find /tmp/assets -type f -exec ls -l {} + >&2
+            exit 1
+          fi
+          find /tmp/assets -type f -exec ls -l {} +
       - name: publish the release with the platform binaries
         env:
           GH_TOKEN: ${{ github.token }}
@@ -144,11 +163,11 @@ jobs:
             --title "$GITHUB_REF_NAME" \
             --notes-file /tmp/notes.md \
             --latest \
-            dist/darwin-arm64/procoder#procoder-darwin-arm64 \
-            dist/darwin-amd64/procoder#procoder-darwin-amd64 \
-            dist/linux-amd64/procoder#procoder-linux-amd64 \
-            dist/linux-arm64/procoder#procoder-linux-arm64 \
-            dist/windows-amd64/procoder.exe#procoder-windows-amd64.exe
+            /tmp/assets/procoder-darwin-arm64 \
+            /tmp/assets/procoder-darwin-amd64 \
+            /tmp/assets/procoder-linux-amd64 \
+            /tmp/assets/procoder-linux-arm64 \
+            /tmp/assets/procoder-windows-amd64.exe
 
   docs:
     # Build and publish the documentation site — domain 5's delivery leg.

--- a/.procoder/github/LESSONS.md
+++ b/.procoder/github/LESSONS.md
@@ -213,3 +213,16 @@ does. `procoder lessons` flags entries with no adaptation.
   guard and the comment beside it promised to prevent. Now
   `grep -q '[^[:space:]]'`, proved both ways before pushing
 
+## 2026-08-20 v1.0.1 (CI) — release assets uploaded under one colliding name
+
+- Class: judgment
+- Missed by: rubric
+- Adaptation: REVIEW.md rubric line "a third-party tool's semantics come
+  from its own help or docs". `gh release create path#label` was read as
+  renaming the asset; it sets the display label, so all five binaries
+  uploaded as `procoder` and the second collided. The binaries are staged
+  under distinct names now, with a guard that counts them and refuses at
+  four. The deeper miss is what was verified: the awk extraction was run
+  against the real changelog, the upload was assumed — the part that
+  could not be tested locally is the part that broke
+

--- a/.procoder/github/LESSONS.md
+++ b/.procoder/github/LESSONS.md
@@ -222,7 +222,7 @@ does. `procoder lessons` flags entries with no adaptation.
   renaming the asset; it sets the display label, so all five binaries
   uploaded as `procoder` and the second collided. The binaries are staged
   under distinct names now, with a guard that counts them and refuses at
-  four. The deeper miss is what was verified: the awk extraction was run
+  anything other than five. The deeper miss is what was verified: the awk extraction was run
   against the real changelog, the upload was assumed — the part that
-  could not be tested locally is the part that broke
+  could not be tested locally is the part that broke.
 

--- a/.procoder/github/REVIEW.md
+++ b/.procoder/github/REVIEW.md
@@ -51,6 +51,10 @@ Check every hunk for:
 - Docs voice: professional product documentation — no personal names,
   no project-history anecdotes, no first-person diary; history belongs
   in the changelog and lessons ledger, not the docs.
+- A third-party tool's semantics come from its own help or docs, not from
+  what the syntax looks like it should mean. `gh`'s `path#text` sets an
+  asset's display LABEL; the name still comes from the file. One line of
+  `--help` separates a working release job from a red one.
 - Guards test the property they claim to test. `-s` is size, not
   content; a zero exit is "the command ran", not "the command found
   what you wanted"; a non-nil slice is not a non-empty one. A guard that


### PR DESCRIPTION
**The release job failed on its first real run — the run it existed for.**

## What went wrong

```
gh release create dist/darwin-arm64/procoder#procoder-darwin-arm64 …
→ HTTP 404 (…/assets?label=procoder-darwin-arm64&name=procoder)
```

I wrote `path#label` believing it renamed the asset. `gh release create --help` says otherwise:

> To define a **display label** for an asset, append text starting with `#` after the file name.

The name still comes from the file. Five files called `procoder` uploaded as five assets called `procoder`; the second collided.

**Nothing partial was published** — `gh` removed the release object when the upload failed, so `v1.0.1` currently has a tag and no release.

## The fix

Binaries are staged under distinct names before upload, with a guard that **counts them and refuses at anything but five**. Run both directions locally this time: five distinct names from the real `dist/`, one from a deliberately collided staging directory.

## The lesson worth keeping

Two things went wrong, and the second matters more.

I verified the awk extraction against the real changelog before shipping it. I **assumed** the upload. The part that couldn't be tested locally is the part that broke — and one line of `--help` would have caught it.

New rubric line:

> A third-party tool's semantics come from its own help or docs, not from what the syntax looks like it should mean.

Ledger: **27 learned, 0 unlearned**.

---

`actionlint` clean, gate `0 blocking`. After this merges I'll re-push the `v1.0.1` tag — safe, because no release was ever published for it.