### PR TITLE
docs: the community files the front door was missing

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,33 @@
+name: Documentation issue
+description: The docs are wrong, stale, or silent — a page that misleads, a command the site never explains, a claim the code no longer backs.
+labels: [documentation]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: The page and section — a URL on the docs site, or a path like `docs/commands.md`. "Nowhere" is a valid answer if the problem is that it isn't documented at all.
+      placeholder: "docs/configuration.md, the [lint] section"
+    validations:
+      required: true
+  - type: textarea
+    id: says
+    attributes:
+      label: What it says (or doesn't)
+      description: Quote the current text, or state what is missing. Paste it, don't paraphrase it.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: reality
+    attributes:
+      label: What is actually true
+      description: What the code or the tool really does, and how you know — the command you ran, the output you got, the source file that contradicts the page.
+    validations:
+      required: true
+  - type: input
+    id: procoder-version
+    attributes:
+      label: procoder version
+      description: From `procoder version` — docs drift is often version drift.
+      placeholder: "1.0.1"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+pascal@watteel.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ tells you which tools this repository wants and how to install them.
 procoder governs its own repository. Before opening a PR:
 
 ```sh
-go run ./cmd/procoder check    # formatting over your changed files
-go run ./cmd/procoder git      # hygiene: markers, junk, message shape
+go run ./cmd/procoder check    # the full commit gate over your changed files
+go run ./cmd/procoder git      # the pre-finish status: branch, hygiene, templates
 go test ./...
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to procoder
+
+Thanks for considering a contribution. procoder is a quality gate that holds
+other repositories to a standard, so it holds itself to the same one — the
+bar here is deliberately boring: small diffs, root causes, and a runnable
+check for every piece of non-trivial logic.
+
+## Before you write code
+
+Open an issue first for anything beyond a small fix — a new check, a new
+platform, a behavior change. The issue templates ask for what a reviewer
+needs; a short conversation there saves a large diff being reworked later.
+
+Bug fixes go to the root cause. Before editing, find every caller of what
+you are about to touch — one guard where all paths converge beats a patch in
+the one path the issue named.
+
+## Setting up
+
+The CLI is a single Go module (Go 1.23, see `go.mod`), no build system
+beyond the toolchain:
+
+```sh
+go build ./cmd/procoder     # the binary
+go test ./...               # the suite
+```
+
+Some tests exercise real tools (gitleaks, eslint, shellcheck, ...) and skip
+themselves when the tool is not installed. `go run ./cmd/procoder doctor`
+tells you which tools this repository wants and how to install them.
+
+## The gate applies here too
+
+procoder governs its own repository. Before opening a PR:
+
+```sh
+go run ./cmd/procoder check    # formatting over your changed files
+go run ./cmd/procoder git      # hygiene: markers, junk, message shape
+go test ./...
+```
+
+CI runs the same gate plus the test matrix on macOS, Ubuntu, and Windows —
+anything red there blocks the merge.
+
+A few repo-specific rules:
+
+- **Don't rebuild `dist/`.** The per-platform binaries under `dist/` are
+  stamped with the release version and rebuilt by the maintainer at release
+  time; a PR that touches them will be asked to drop those changes.
+- **Don't bump versions.** The version lives in several manifests at once
+  and moves only in release commits.
+- **Changelog entries ride releases**, not PRs — describe the change well in
+  the PR body and it will be told in `CHANGELOG.md` when it ships.
+- **Every non-trivial change leaves a test behind** — the smallest thing
+  that fails if the logic breaks.
+
+## Pull requests
+
+Fill in the PR template — What, Why, How, Testing. "Tests pass" needs the
+command that proved it. Keep commits in the repo's voice: a lowercase,
+present-tense subject that says what the change does.
+
+Documentation for user-visible behavior lives in `docs/` (the mkdocs site)
+and in the command's usage text; a change that alters what a user sees
+updates both, and the docs gate will tell you if a reference went stale.
+
+## Reporting security issues
+
+Not in a public issue — see [SECURITY.md](SECURITY.md).
+
+## Conduct
+
+Participation in this project is covered by the
+[Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## What

Fills the two gaps in GitHub's community-standards checklist — a code of conduct and contributing guidelines — and adds a third issue template for documentation drift.

## Why

The repo's community profile showed Code of conduct and Contributing as missing. The existing issue templates cover bugs and features but not "the docs say X, the tool does Y", which is its own class of report for a project with a docs gate.

## How

- `CODE_OF_CONDUCT.md`: Contributor Covenant 2.1, enforcement contact set to the maintainer's email.
- `CONTRIBUTING.md`: written for this repo specifically — the self-hosted gate (`check`, `git`, tests), the tools-may-skip test caveat, and the repo rules an outsider can't guess (dist/ and versions are release-only, changelog entries ride releases).
- `.github/ISSUE_TEMPLATE/docs_issue.yml`: quote-what-it-says / what-is-true / how-you-know, in the voice of the existing two templates.

## Testing

`procoder check` over the three files (3 clean), `procoder git` hygiene clean. Content-only change; no code touched.