### PR TITLE
fix: a heading offers the anchor each renderer generates, not mkdocs' alone

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -317,16 +317,25 @@ func headingSlug(title string) string {
 }
 
 // stripInlineMarkup removes the emphasis, code, and link syntax that a
-// heading may carry — the slug is built from the rendered text. Underscores
-// survive: `_` is emphasis only around a word, and inside a code span it is
-// part of the name, so a heading about `reasoning_content` keeps it — both
-// renderers do.
+// heading may carry — the slug is built from the rendered text. Code spans
+// are taken out first and their contents kept whole, because that is where
+// the two kinds of underscore part company: `reasoning_content` keeps its
+// underscore in the anchor, while the ones around _word_ are emphasis that
+// renders away and must not reach the slug.
 func stripInlineMarkup(s string) string {
 	s = mdLink.ReplaceAllString(s, "")
-	for _, mark := range []string{"`", "**", "*"} {
-		s = strings.ReplaceAll(s, mark, "")
+	var b strings.Builder
+	for i, part := range strings.Split(s, "`") {
+		if i%2 == 1 {
+			b.WriteString(part) // inside a code span: the text is the name
+			continue
+		}
+		for _, mark := range []string{"**", "*", "__", "_"} {
+			part = strings.ReplaceAll(part, mark, "")
+		}
+		b.WriteString(part)
 	}
-	return strings.ReplaceAll(strings.ReplaceAll(s, "[", ""), "]", "")
+	return strings.ReplaceAll(strings.ReplaceAll(b.String(), "[", ""), "]", "")
 }
 
 // mermaidBlock is one fenced ```mermaid block with its starting line number.

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -259,25 +259,48 @@ func anchorIDs(path string) (map[string]bool, bool) {
 		if m == nil {
 			continue
 		}
-		slug := headingSlug(explicitID.ReplaceAllString(m[1], ""))
-		if slug == "" {
-			continue
+		for _, slug := range headingAnchors(explicitID.ReplaceAllString(m[1], "")) {
+			if n := seen[slug]; n > 0 {
+				ids[fmt.Sprintf("%s-%d", slug, n)] = true
+			} else {
+				ids[slug] = true
+			}
+			seen[slug]++
 		}
-		if n := seen[slug]; n > 0 {
-			ids[fmt.Sprintf("%s-%d", slug, n)] = true
-		} else {
-			ids[slug] = true
-		}
-		seen[slug]++
 	}
 	return ids, true
 }
 
-// headingSlug reproduces Python-Markdown's toc slugify, which is what
-// mkdocs uses: drop everything that is not a word character, whitespace,
-// or a hyphen, then collapse runs of whitespace and hyphens into one
-// hyphen. An em dash disappears rather than becoming a separator, which
-// is precisely the case that is easy to get wrong by hand.
+// headingAnchors returns every anchor one heading offers, because the two
+// renderers a repository's Markdown meets disagree. Python-Markdown's toc
+// slugify — what mkdocs uses — collapses runs of hyphens; GitHub does not,
+// so `## Files & skills` is `files-skills` on a site and `files--skills` on
+// github.com. Which renderer the reader used is not knowable from here, and
+// the same file is routinely read through both, so a heading is credited
+// with both spellings: the check exists to catch an anchor no heading
+// generates at all, not to enforce a dialect. Deduplicated, because the two
+// agree for most headings and the caller counts these for the `-1`, `-2`
+// suffixes duplicate headings get.
+func headingAnchors(title string) []string {
+	github := headingSlug(title)
+	mkdocs := github
+	for strings.Contains(mkdocs, "--") {
+		mkdocs = strings.ReplaceAll(mkdocs, "--", "-")
+	}
+	switch github {
+	case "":
+		return nil
+	case mkdocs:
+		return []string{github}
+	}
+	return []string{github, mkdocs}
+}
+
+// headingSlug maps a heading's text to GitHub's anchor: lower case, drop
+// everything that is not a word character, whitespace, or a hyphen, and turn
+// each remaining separator into one hyphen. An em dash disappears rather than
+// becoming a separator — it leaves the two hyphens its surrounding spaces
+// made, which is precisely the case that is easy to get wrong by hand.
 func headingSlug(title string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(stripInlineMarkup(title)) {
@@ -290,18 +313,17 @@ func headingSlug(title string) string {
 			b.WriteRune(r) // \w matches unicode letters and digits too
 		}
 	}
-	slug := b.String()
-	for strings.Contains(slug, "--") {
-		slug = strings.ReplaceAll(slug, "--", "-")
-	}
-	return strings.Trim(slug, "-")
+	return strings.Trim(b.String(), "-")
 }
 
 // stripInlineMarkup removes the emphasis, code, and link syntax that a
-// heading may carry — the slug is built from the rendered text.
+// heading may carry — the slug is built from the rendered text. Underscores
+// survive: `_` is emphasis only around a word, and inside a code span it is
+// part of the name, so a heading about `reasoning_content` keeps it — both
+// renderers do.
 func stripInlineMarkup(s string) string {
 	s = mdLink.ReplaceAllString(s, "")
-	for _, mark := range []string{"`", "**", "*", "__", "_"} {
+	for _, mark := range []string{"`", "**", "*"} {
 		s = strings.ReplaceAll(s, mark, "")
 	}
 	return strings.ReplaceAll(strings.ReplaceAll(s, "[", ""), "]", "")

--- a/internal/docs/docs_test.go
+++ b/internal/docs/docs_test.go
@@ -446,7 +446,7 @@ func TestAnAnchorThatNoHeadingGeneratesIsBroken(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "target.md"), "# Page\n\n## Contract 1 — P-CONTROL: the agent stays in control\n\nbody\n")
 	src := filepath.Join(dir, "src.md")
-	mustWrite(t, src, "See [it](target.md#contract-1--p-control-the-agent-stays-in-control).\n")
+	mustWrite(t, src, "See [it](target.md#contract-2-the-agent-stays-in-control).\n")
 
 	got := RelativeRefs(dir, src)
 	if len(got) != 1 {
@@ -458,15 +458,22 @@ func TestAnAnchorThatNoHeadingGeneratesIsBroken(t *testing.T) {
 }
 
 // The same link with the slug the heading actually generates is fine —
-// em dash dropped, colon dropped, runs of separators collapsed, exactly
-// as Python-Markdown's toc slugify does it.
+// em dash dropped, colon dropped — in either dialect: mkdocs collapses the
+// run of separators the dropped characters leave, github.com keeps it, and
+// the same page is read through both.
 // proved by: made the slug keep punctuation — the correct link is then
-// reported as broken, which is worse than not checking at all.
+// reported as broken, which is worse than not checking at all; and dropped
+// the github spelling — every heading with an `&`, an em dash, or a colon
+// then reads as a broken reference on the renderer most repositories use.
 func TestTheRealSlugResolves(t *testing.T) {
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, "target.md"), "# Page\n\n## Contract 1 — P-CONTROL: the agent stays in control\n")
+	mustWrite(t, filepath.Join(dir, "target.md"), "# Page\n\n## Contract 1 — P-CONTROL: the agent stays in control\n\n## Files & skills\n\n### DeepSeek: `reasoning_content`\n")
 	for _, link := range []string{
 		"target.md#contract-1-p-control-the-agent-stays-in-control",
+		"target.md#contract-1--p-control-the-agent-stays-in-control",
+		"target.md#files-skills",
+		"target.md#files--skills",
+		"target.md#deepseek-reasoning_content",
 		"target.md#page",
 	} {
 		src := filepath.Join(dir, "src.md")

--- a/internal/docs/docs_test.go
+++ b/internal/docs/docs_test.go
@@ -467,13 +467,14 @@ func TestAnAnchorThatNoHeadingGeneratesIsBroken(t *testing.T) {
 // then reads as a broken reference on the renderer most repositories use.
 func TestTheRealSlugResolves(t *testing.T) {
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, "target.md"), "# Page\n\n## Contract 1 — P-CONTROL: the agent stays in control\n\n## Files & skills\n\n### DeepSeek: `reasoning_content`\n")
+	mustWrite(t, filepath.Join(dir, "target.md"), "# Page\n\n## Contract 1 — P-CONTROL: the agent stays in control\n\n## Files & skills\n\n### DeepSeek: `reasoning_content`\n\n## Hello _world_\n")
 	for _, link := range []string{
 		"target.md#contract-1-p-control-the-agent-stays-in-control",
 		"target.md#contract-1--p-control-the-agent-stays-in-control",
 		"target.md#files-skills",
 		"target.md#files--skills",
 		"target.md#deepseek-reasoning_content",
+		"target.md#hello-world",
 		"target.md#page",
 	} {
 		src := filepath.Join(dir, "src.md")


### PR DESCRIPTION
## What

A heading is now credited with every anchor it can offer: GitHub's spelling and mkdocs' spelling. The docs reference check stops reporting correct links as broken references.

## Why

Closes #56. `headingSlug` reproduced Python-Markdown's toc slugify — which mkdocs uses — in every repository, including ones with no mkdocs site whose Markdown is only ever read on github.com. GitHub does not collapse runs of hyphens, so `## Files & skills` is `files--skills` there and `files-skills` under mkdocs. Every heading containing an ampersand, an em dash, an arrow, or a colon followed by a space therefore had a working anchor the checker called broken — blocking, with no knob, so the only route to a clean gate was rewording public headings and breaking inbound links.

Separately, `stripInlineMarkup` deleted `_` and `__`. An underscore inside a code span is part of the name, not emphasis, so ``### DeepSeek: `reasoning_content` `` was unreachable under *both* flavours.

## How

`headingAnchors` returns the GitHub slug and, when it differs, the collapsed mkdocs one; `anchorIDs` registers both (deduplicated, so the `-1`/`-2` suffixes duplicate headings get still count correctly).

**The decision worth questioning:** the issue proposed detecting the flavour from `mkdocs.yml` plus a `[docs] anchor_flavour` override. I did neither. Detection is wrong for the common case — a repo with a mkdocs site whose README still renders on github.com, this one included — and a knob forces a choice where both renderers are genuinely in use. Accepting both spellings removes the entire false-positive class with no config surface. The cost is a real false negative: an anchor written in one dialect that the repo's other renderer will not resolve goes unreported. That trade favours never blocking a correct link.

## Testing

`go test ./...` and `go vet ./...` clean; `procoder check` clean for this diff.

One existing test encoded the bug — `TestAnAnchorThatNoHeadingGeneratesIsBroken` used `#contract-1--p-control-…` as its "dead" anchor, which is exactly the valid GitHub spelling. It now uses a genuinely dead anchor, and `TestTheRealSlugResolves` asserts both spellings of three headings resolve, including the snake_case code span.

## Notes for the reviewer

Start at `headingAnchors` in `internal/docs/docs.go`. The test file change is the interesting half: the first hunk is a test whose premise was the bug.
