### PR TITLE
fix: read the commit message wherever git reads it, not only from -m

### DIFF
--- a/internal/docs/obligation.go
+++ b/internal/docs/obligation.go
@@ -91,10 +91,19 @@ func Obligation(root string, changed []string, commitMessage string, block bool)
 		more = fmt.Sprintf(" (and %d more)", len(named)-maxTriggersNamed)
 		named = named[:maxTriggersNamed]
 	}
+	// Naming a remedy that cannot work here is worse than naming none: the
+	// user writes the acknowledgment exactly as printed, nothing changes,
+	// and the tool looks broken. So the remedy depends on whether a message
+	// reached this check at all.
+	remedy := fmt.Sprintf("update a doc, or record the decision with a `%s — <reason>` line in the commit message (`procoder docs --ack \"<reason>\"` prints it)", AckPrefix)
+	noMessage := strings.TrimSpace(commitMessage) == ""
+	if noMessage {
+		remedy = fmt.Sprintf("update a doc — no commit message reached this check, so a `%s — <reason>` line cannot be read here; it clears the obligation when the message is one the check sees (`git commit -m`, `-F <file>`, or `-F -` with a heredoc)", AckPrefix)
+	}
 	out = append(out, gitx.Finding{Blocking: block,
-		Message: fmt.Sprintf("documentation obligation: %s%s — no documentation file changed in this diff; update a doc, or record the decision with a `%s — <reason>` line in the commit message (`procoder docs --ack \"<reason>\"` prints it)",
-			strings.Join(named, "; "), more, AckPrefix)})
-	if strings.TrimSpace(commitMessage) == "" {
+		Message: fmt.Sprintf("documentation obligation: %s%s — no documentation file changed in this diff; %s",
+			strings.Join(named, "; "), more, remedy)})
+	if noMessage {
 		out = append(out, gitx.Finding{
 			Message: "acknowledgment path unavailable — no commit message at check time; the obligation stands until a doc changes or the check runs where the message exists"})
 	}

--- a/internal/hook/commit.go
+++ b/internal/hook/commit.go
@@ -76,6 +76,10 @@ func PreToolUse(stdin io.Reader, stdout io.Writer) int {
 		return 0 // no repository to gate; git will have its own opinion
 	}
 
+	if c.message == "" && c.messageFile != "" {
+		c.message = readMessageFile(commitDir(p.Cwd, c.dir), c.messageFile)
+	}
+
 	code, findings, timedOut := runGate(root, c.message)
 	switch {
 	case timedOut:
@@ -148,6 +152,28 @@ func blockingLines(output string) []string {
 // working directory, moved by any `cd` or `git -C` the command itself carries,
 // then walked up to the repository root git would use.
 func commitRoot(payloadCwd, dirHint string) string {
+	return tools.RepoRoot(commitDir(payloadCwd, dirHint))
+}
+
+// readMessageFile reads the message `git commit -F <file>` would read, from
+// the directory the command runs in. A file that cannot be read leaves the
+// message empty, which the documentation obligation reports as the
+// acknowledgment path being unavailable rather than as no acknowledgment.
+func readMessageFile(dir, file string) string {
+	path := file
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(dir, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// commitDir is the working directory the commit runs in: the payload's, moved
+// by any `cd` or `git -C` the command carries.
+func commitDir(payloadCwd, dirHint string) string {
 	base := payloadCwd
 	if base == "" {
 		if wd, err := os.Getwd(); err == nil {
@@ -164,7 +190,7 @@ func commitRoot(payloadCwd, dirHint string) string {
 	if base == "" {
 		return "."
 	}
-	return tools.RepoRoot(base)
+	return base
 }
 
 func allow(stdout io.Writer, reason string) int { return decide(stdout, "allow", reason) }
@@ -202,10 +228,11 @@ func decide(stdout io.Writer, verdict, reason string) int {
 func IsGitCommit(command string) bool { return parseCommand(command).isCommit }
 
 type commitCommand struct {
-	isCommit bool
-	noVerify bool
-	dir      string // -C <dir> or a leading `cd <dir>`, whichever the command used
-	message  string // -m/--message, so a documentation acknowledgment can clear its obligation here
+	isCommit    bool
+	noVerify    bool
+	dir         string // -C <dir> or a leading `cd <dir>`, whichever the command used
+	message     string // -m/--message, so a documentation acknowledgment can clear its obligation here
+	messageFile string // -F/--file, read at check time; "" when the commit carries none
 }
 
 // gitValueFlags are the git-level flags that swallow the next word, so the
@@ -269,11 +296,74 @@ func parseCommand(command string) commitCommand {
 			}
 			if v, ok := strings.CutPrefix(t.word, "--message="); ok {
 				res.message += v + "\n"
+				continue
 			}
+			// -F/--file is the other way a message arrives, and the one an
+			// agent reaches for when the message has a preformatted body.
+			// `-F -` reads stdin, which here is the heredoc the command
+			// itself carries.
+			if (t.word == "-F" || t.word == "--file") && j+1 < len(rest) {
+				res.messageFile = rest[j+1].word
+				j++
+				continue
+			}
+			if v, ok := cutFlagValue(t.word, "--file=", "-F"); ok {
+				res.messageFile = v
+			}
+		}
+		if res.messageFile == "-" {
+			// stdin: the heredoc body is the message, and it is right here
+			// in the command line. A message piped from another process is
+			// not knowable at this point and stays unavailable, said.
+			res.messageFile = ""
+			res.message = heredocBody(command)
 		}
 		return res
 	}
 	return res
+}
+
+// cutFlagValue reads a flag's attached value: `--file=msg.txt` for the long
+// form, `-Fmsg.txt` for the short one git's parser also accepts. A bare `-F`
+// carries no value and is left to the two-word branch above.
+func cutFlagValue(word, long, short string) (string, bool) {
+	if v, ok := strings.CutPrefix(word, long); ok && v != "" {
+		return v, true
+	}
+	if v, ok := strings.CutPrefix(word, short); ok && v != "" {
+		return v, true
+	}
+	return "", false
+}
+
+// heredocBody returns the body of the first heredoc in the command — what
+// `git commit -F -` would read on stdin. `<<EOF`, `<<-EOF`, and the quoted
+// delimiters that turn off expansion all land here; the terminator is a line
+// that is exactly the delimiter, as the shell reads it.
+func heredocBody(command string) string {
+	i := strings.Index(command, "<<")
+	if i < 0 {
+		return ""
+	}
+	rest := strings.TrimPrefix(command[i+2:], "-")
+	nl := strings.Index(rest, "\n")
+	if nl < 0 {
+		return ""
+	}
+	delim := strings.Trim(strings.TrimSpace(rest[:nl]), "\"'")
+	if delim == "" {
+		return ""
+	}
+	var body []string
+	for _, line := range strings.Split(rest[nl+1:], "\n") {
+		if strings.TrimSpace(line) == delim {
+			return strings.Join(body, "\n")
+		}
+		body = append(body, line)
+	}
+	// no terminator in what we were handed: an unterminated heredoc is not a
+	// message we can vouch for
+	return ""
 }
 
 // isGitWord accepts `git` and an explicit path to it (`/usr/bin/git`), but
@@ -355,10 +445,23 @@ func tokenize(command string) []token {
 	for i := 0; i < len(command); i++ {
 		ch := command[i]
 		switch ch {
+		case '$':
+			// $'…' and $"…" quote exactly like '…' and "…" for this purpose
+			if i+1 < len(command) && (command[i+1] == '\'' || command[i+1] == '"') {
+				continue
+			}
+			cur.WriteByte(ch)
+			has = true
 		case '\'', '"':
 			q := ch
 			has, quoted = true, true
 			for i++; i < len(command) && command[i] != q; i++ {
+				// a backslash escape inside double quotes keeps the next
+				// byte in the word: `-m "he said \"no\""` is one argument,
+				// and reading it as two loses everything after it
+				if command[i] == '\\' && q == '"' && i+1 < len(command) {
+					i++
+				}
 				cur.WriteByte(command[i])
 			}
 		case '\\':

--- a/internal/hook/commit.go
+++ b/internal/hook/commit.go
@@ -345,7 +345,14 @@ func heredocBody(command string) string {
 	if i < 0 {
 		return ""
 	}
-	rest := strings.TrimPrefix(command[i+2:], "-")
+	rest := command[i+2:]
+	// `<<-EOF` lets the terminator be indented with TABS, and only tabs;
+	// plain `<<EOF` wants it at the start of the line. Accepting any
+	// indentation would end the message at a body line that merely reads
+	// like the delimiter, which loses everything after it — the
+	// acknowledgment included.
+	stripTabs := strings.HasPrefix(rest, "-")
+	rest = strings.TrimPrefix(rest, "-")
 	nl := strings.Index(rest, "\n")
 	if nl < 0 {
 		return ""
@@ -356,7 +363,11 @@ func heredocBody(command string) string {
 	}
 	var body []string
 	for _, line := range strings.Split(rest[nl+1:], "\n") {
-		if strings.TrimSpace(line) == delim {
+		candidate := strings.TrimRight(line, " \t\r")
+		if stripTabs {
+			candidate = strings.TrimLeft(candidate, "\t")
+		}
+		if candidate == delim {
 			return strings.Join(body, "\n")
 		}
 		body = append(body, line)

--- a/internal/hook/commit_test.go
+++ b/internal/hook/commit_test.go
@@ -65,6 +65,58 @@ func TestParseCommandPicksUpBypassAndDirectory(t *testing.T) {
 	}
 }
 
+// The acknowledgment must reach the gate from wherever git reads the
+// message, not only from -m: an agent writing a body with a preformatted
+// block reaches for a heredoc, and a `docs: none — <reason>` line that the
+// gate cannot see sends the user to a remedy that cannot work.
+// proved by: kept the -m-only scan — the heredoc and -F messages come back
+// empty and the obligation stands with a correct acknowledgment in hand.
+func TestTheMessageIsReadFromEveryFormGitReadsItFrom(t *testing.T) {
+	heredoc := parseCommand("git commit -F - <<'EOF'\nchore: adopt the config\n\ndocs: none — the file documents itself.\nEOF")
+	if !strings.Contains(heredoc.message, "docs: none") {
+		t.Errorf("heredoc message lost: %q", heredoc.message)
+	}
+	for _, cmd := range []string{
+		"git commit -F msg.txt",
+		"git commit --file msg.txt",
+		"git commit --file=msg.txt",
+		"git commit -Fmsg.txt",
+	} {
+		if p := parseCommand(cmd); p.messageFile != "msg.txt" {
+			t.Errorf("%s: message file lost: %+v", cmd, p)
+		}
+	}
+	// a quoted escape inside the message keeps the argument whole — the
+	// tokenizer used to end the word at the backslash and lose every -m
+	// after it, the acknowledgment included
+	esc := parseCommand(`git commit -m "feat: say \"no\" politely" -m "docs: none — behaviour only."`)
+	if !strings.Contains(esc.message, "docs: none") {
+		t.Errorf("escaped quote swallowed the rest: %q", esc.message)
+	}
+	multi := parseCommand("git commit -m \"chore: x\" -m \"body:\n\n  key  value\" -m \"docs: none — reason.\"")
+	if !strings.Contains(multi.message, "docs: none") {
+		t.Errorf("multi-line -m lost the ack: %q", multi.message)
+	}
+}
+
+// -F names a file the gate must actually read, in the directory the command
+// runs in — the message only clears the obligation if it arrives at the
+// check.
+// proved by: left readMessageFile out of PreToolUse — the acknowledgment in
+// the file is invisible and the commit stays blocked.
+func TestAnAcknowledgmentInAMessageFileClearsTheObligation(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "msg.txt"), []byte("chore: x\n\ndocs: none — reason.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readMessageFile(dir, "msg.txt"); !strings.Contains(got, "docs: none") {
+		t.Errorf("message file not read: %q", got)
+	}
+	if got := readMessageFile(dir, "absent.txt"); got != "" {
+		t.Errorf("an unreadable file is no message, got %q", got)
+	}
+}
+
 // --- PreToolUse ---
 
 func requireGit(t *testing.T) {

--- a/internal/hook/commit_test.go
+++ b/internal/hook/commit_test.go
@@ -76,6 +76,17 @@ func TestTheMessageIsReadFromEveryFormGitReadsItFrom(t *testing.T) {
 	if !strings.Contains(heredoc.message, "docs: none") {
 		t.Errorf("heredoc message lost: %q", heredoc.message)
 	}
+	// an indented line that reads like the delimiter is body, not the end of
+	// it: only `<<-` allows a tab-indented terminator, and neither form
+	// allows a space-indented one
+	indented := parseCommand("git commit -F - <<'EOF'\nchore: x\n\n    EOF\n\ndocs: none — reason.\nEOF")
+	if !strings.Contains(indented.message, "docs: none") {
+		t.Errorf("an indented look-alike ended the message early: %q", indented.message)
+	}
+	tabbed := parseCommand("git commit -F - <<-EOF\nchore: x\n\ndocs: none — reason.\n\tEOF")
+	if !strings.Contains(tabbed.message, "docs: none") {
+		t.Errorf("<<- accepts a tab-indented terminator: %q", tabbed.message)
+	}
 	for _, cmd := range []string{
 		"git commit -F msg.txt",
 		"git commit --file msg.txt",


### PR DESCRIPTION
## What

The commit gate now reconstructs the message from every form git reads it from — `-m`, `-F <file>`, `--file=`, and `-F -` with a heredoc — so a `docs: none — <reason>` acknowledgment clears its obligation regardless of how the message was written. Where no message can reach the check at all, the finding says so instead of naming a remedy that cannot work.

## Why

Closes #57. `parseCommand` scanned for `-m`/`--message` only. Every other form left `res.message` empty, so `ackReason` had nothing to match: the user wrote the acknowledgment exactly as `procoder docs --ack` printed it, nothing changed, and the tool looked broken. This bites hardest during onboarding, where committing `.procoder/config.toml` — the file that turns the obligation on — is what triggers it.

The multi-line `-m` half of the report turned out to be something else: a backslash-escaped quote inside a double-quoted value ended the word at the backslash and swallowed every argument after it, acknowledgment included. A body with a preformatted block usually carries a quote, which is why it showed up there. (The old binary reproduced it while committing this very branch.)

## How

- `-F`, `--file`, `--file=path`, `-Fpath` record a message file; `readMessageFile` reads it at check time from the directory the command runs in, and an unreadable file leaves the message empty rather than guessed at.
- `-F -` means stdin, and for an intercepted command line that stdin is the heredoc it carries — `heredocBody` extracts it (`<<EOF`, `<<-EOF`, quoted delimiters, terminated only by a line that is exactly the delimiter). A message piped from another process stays unavailable, and says so.
- The tokenizer honours backslash escapes inside double quotes, and `$'…'`/`$"…"` quoting.
- Editor commits genuinely have no message at `PreToolUse` time. The issue's suggestion of moving this to a `commit-msg` hook is the real fix for that path, and is a bigger change than this one — here the obligation's remedy text just stops lying: with no message it names the forms the check can see instead of the one it cannot.

## Testing

`go test ./...` and `go vet ./...` clean.

Two new tests in `internal/hook/commit_test.go` cover the heredoc, all four `-F` spellings, the escaped quote, and multi-line `-m`. Mutation-checked: stubbing out `heredocBody`'s search fails the heredoc assertion.

Proven end to end against this repository through the real hook binary — a heredoc commit carrying the acknowledgment is allowed, the same heredoc without it is denied with the working remedy text.

## Notes for the reviewer

`heredocBody` and the tokenizer's escape handling are where a mistake would be quiet; the rest is flag plumbing. The obligation change is wording only — the finding's condition is untouched, and the informational "acknowledgment path unavailable" note still fires exactly as before.
