### PR TITLE
fix: ask the documentation question of the branch, and compare like with like

### DIFF
--- a/docs/quality-chain.md
+++ b/docs/quality-chain.md
@@ -124,6 +124,27 @@ prints. One code path, so the three can never disagree and no argument
 about "it passes locally" is possible. Unchecked counts as failing.
 There is no side door.
 
+## What the documentation obligation asks, and of what
+
+A public-surface change with no documentation change is a question the
+gate refuses to leave silent: a symbol appeared or went, a CLI string
+moved, a configuration file changed, or a document names a file you
+touched. It clears two ways, both explicit — change a document, or
+record `docs: none — <reason>` in the commit message, where a reviewer
+sees it.
+
+The question is asked of the branch's work, not of whichever slice is
+uncommitted. Writing the doc in one commit and the code in the next is
+ordinary practice, so a document changed anywhere in the commits your
+branch carries answers it. On the default branch there is no such range
+and only the pending diff counts.
+
+The public surface itself is compared like with like: the previous
+revision of each file, read by the same parser that reads the current
+one. Two different definitions of "exported" produce phantom findings —
+a capitalised local constant is exported in Go and in no other language
+— and a phantom finding that blocks is worse than no finding at all.
+
 ## Why escapes have to close their class
 
 Before a PR exists, the pre-PR self-review reads the diff with fresh

--- a/internal/docs/obligation.go
+++ b/internal/docs/obligation.go
@@ -72,7 +72,7 @@ func Obligation(root string, changed []string, commitMessage string, block bool)
 		}
 		docChanged = true
 	}
-	if docChanged {
+	if docChanged || branchDocChanged(root, corpus) {
 		return nil // the question was asked and answered by editing a document
 	}
 	if reason := ackReason(commitMessage); reason != "" {
@@ -99,6 +99,38 @@ func Obligation(root string, changed []string, commitMessage string, block bool)
 			Message: "acknowledgment path unavailable — no commit message at check time; the obligation stands until a doc changes or the check runs where the message exists"})
 	}
 	return out
+}
+
+// branchDocChanged reports whether a documentation file changed earlier in
+// this branch's work — the commits it carries that the default branch does
+// not. The gate judges what is about to be committed, which is right for
+// formatting and lint, but the documentation question is asked of the change
+// as a whole: writing the doc in one commit and the code in the next is
+// ordinary practice, and demanding a `docs: none` acknowledgment for work
+// that IS documented is the tool contradicting itself.
+//
+// On the default branch there is no such range and only the pending diff
+// counts. Any git failure means no evidence of an answer, never a claim of
+// one.
+func branchDocChanged(root string, corpus map[string]bool) bool {
+	base := gitx.DefaultBranch(root)
+	if base == "" || base == gitx.CurrentBranch(root) {
+		return false
+	}
+	out, err := exec.Command("git", "-C", root, "diff", "--name-only", base+"...HEAD").Output()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		rel := strings.TrimSpace(line)
+		if rel == "" || strings.HasPrefix(rel, stateDir) {
+			continue
+		}
+		if IsMarkdownFile(rel) && corpus[rel] {
+			return true
+		}
+	}
+	return false
 }
 
 // ackReason returns the reason from a `docs: none — <reason>` line, or "" when
@@ -156,10 +188,16 @@ func mentionTriggers(root string, changed []string) []string {
 // back out of it rather than re-deriving the match.
 const driftPrefix = "mentions changed file "
 
-// surfaceTriggers computes the public-surface half: what the index knew the
-// changed files defined against what they define now. Returns the triggers and
-// the honesty notes — a repository with no index cannot have its public surface
-// computed, and says so instead of reading clean.
+// surfaceTriggers computes the public-surface half: what the changed files
+// defined before against what they define now. Returns the triggers and the
+// honesty notes — a repository where the comparison cannot be made says so
+// instead of reading clean.
+//
+// The "before" comes from git where git has it, read with the same parser as
+// the "now". Comparing two different definitions of exported surface produces
+// phantom findings: the index calls every capitalised tag exported, which is
+// the rule in Go and nowhere else, so a JavaScript `const ROOT` reads as an
+// exported symbol removed on every run. Like against like, or not at all.
 func surfaceTriggers(root string, code []string) (triggers []string, notes []gitx.Finding) {
 	var source []string
 	for _, rel := range code {
@@ -172,6 +210,18 @@ func surfaceTriggers(root string, code []string) (triggers []string, notes []git
 	}
 	triggers = append(triggers, literalTriggers(root, source)...)
 	if len(source) == 0 {
+		return triggers, notes
+	}
+	if hasGitHistory(root) {
+		for _, rel := range source {
+			path := filepath.Join(root, filepath.FromSlash(rel))
+			now := exportedSymbols(path)
+			// a file git does not know yet is new, and everything it exports
+			// is an addition — the same answer the index path gives
+			old, _ := gitShow(root, rel)
+			was := exportedSymbolsIn(old, languageOf(rel))
+			triggers = append(triggers, symbolTriggers(rel, now, was)...)
+		}
 		return triggers, notes
 	}
 	known, err := indexedSymbols(root)
@@ -194,12 +244,7 @@ func surfaceTriggers(root string, code []string) (triggers []string, notes []git
 			unindexed = append(unindexed, rel)
 			continue
 		}
-		for _, name := range sortedDiff(now, was) {
-			triggers = append(triggers, fmt.Sprintf("exported symbol %s added in %s", name, rel))
-		}
-		for _, name := range sortedDiff(was, now) {
-			triggers = append(triggers, fmt.Sprintf("exported symbol %s removed or renamed in %s", name, rel))
-		}
+		triggers = append(triggers, symbolTriggers(rel, now, was)...)
 	}
 	if len(unindexed) > 0 {
 		notes = append(notes, gitx.Finding{
@@ -207,6 +252,26 @@ func surfaceTriggers(root string, code []string) (triggers []string, notes []git
 				len(unindexed), strings.Join(firstFew(unindexed), ", "))})
 	}
 	return triggers, notes
+}
+
+// symbolTriggers states the difference between two public surfaces of one
+// file, in the order a reader wants it: what appeared, then what went.
+func symbolTriggers(rel string, now, was map[string]bool) []string {
+	var out []string
+	for _, name := range sortedDiff(now, was) {
+		out = append(out, fmt.Sprintf("exported symbol %s added in %s", name, rel))
+	}
+	for _, name := range sortedDiff(was, now) {
+		out = append(out, fmt.Sprintf("exported symbol %s removed or renamed in %s", name, rel))
+	}
+	return out
+}
+
+// hasGitHistory reports whether this repository has a commit to compare
+// against. Without one there is no "before", and the index is the only
+// witness left.
+func hasGitHistory(root string) bool {
+	return exec.Command("git", "-C", root, "rev-parse", "HEAD").Run() == nil
 }
 
 func firstFew(in []string) []string {
@@ -391,14 +456,20 @@ var (
 // module, or crate can reach. Deliberately syntactic — no toolchain, no
 // network, the same answer on every machine.
 func exportedSymbols(path string) map[string]bool {
-	out := map[string]bool{}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return out
+		return map[string]bool{}
 	}
-	lang := languageOf(filepath.ToSlash(path))
+	return exportedSymbolsIn(string(data), languageOf(filepath.ToSlash(path)))
+}
+
+// exportedSymbolsIn is the same reading applied to content the caller already
+// has — a previous revision out of git, which must be read by exactly the
+// parser that reads the current one for the difference to mean anything.
+func exportedSymbolsIn(body, lang string) map[string]bool {
+	out := map[string]bool{}
 	inGroup := false
-	for _, line := range strings.Split(string(data), "\n") {
+	for _, line := range strings.Split(body, "\n") {
 		switch lang {
 		case "go":
 			if inGroup {

--- a/internal/docs/obligation_test.go
+++ b/internal/docs/obligation_test.go
@@ -291,7 +291,10 @@ func TestUnwalkableTreeIsReportedNotSilentlyEmpty(t *testing.T) {
 	}
 }
 
-// gitRun runs one git command in the fixture, failing the test if it cannot.
+// gitRun runs one git command in the fixture. A git that cannot do the work
+// skips the test rather than failing it: these tests are about the
+// obligation, not about the machine's git, and the fixture above already
+// skips where git is absent entirely.
 func gitRun(t *testing.T, root string, args ...string) {
 	t.Helper()
 	full := append([]string{"-C", root, "-c", "user.email=t@example.com", "-c", "user.name=t"}, args...)

--- a/internal/docs/obligation_test.go
+++ b/internal/docs/obligation_test.go
@@ -290,3 +290,73 @@ func TestUnwalkableTreeIsReportedNotSilentlyEmpty(t *testing.T) {
 		t.Fatal("an unwalkable tree must be reported, never read as a clean corpus")
 	}
 }
+
+// gitRun runs one git command in the fixture, failing the test if it cannot.
+func gitRun(t *testing.T, root string, args ...string) {
+	t.Helper()
+	full := append([]string{"-C", root, "-c", "user.email=t@example.com", "-c", "user.name=t"}, args...)
+	if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+		t.Skipf("git %v unavailable (%v): %s", args, err, out)
+	}
+}
+
+// Writing the documentation in one commit and the code in the next is
+// ordinary practice. The obligation is asked of the branch's work, not of
+// whichever slice happens to be uncommitted, so a change that IS documented
+// must not demand a `docs: none` acknowledgment.
+// proved by: looked only at the passed change set — the second commit on a
+// branch whose first commit updated the doc is then blocked, which is the
+// bug this fixes.
+func TestADocChangedEarlierOnTheBranchAnswersTheObligation(t *testing.T) {
+	root := gitFixture(t)
+	gitRun(t, root, "checkout", "-qb", "feature")
+	write(t, root, "docs/guide.md", "# guide\n\nExisting is the entry point, and Added joins it.\n")
+	gitRun(t, root, "add", "-A")
+	gitRun(t, root, "commit", "-qm", "docs first")
+
+	// the code half, still uncommitted, exporting something new
+	changed := write(t, root, "lib.go", "package widget\n\nfunc Existing() {}\n\nfunc Added() {}\n")
+	if msgs := messages(t, root, []string{changed}, "", true); strings.Contains(msgs, "documentation obligation") {
+		t.Errorf("the doc changed earlier in this branch's work: %s", msgs)
+	}
+}
+
+// The branch scope widens where the question was answered; it does not stop
+// asking. A branch that touched no document still owes one.
+// proved by: cleared the obligation whenever a branch existed at all.
+func TestABranchWithNoDocChangeStillOwesTheAnswer(t *testing.T) {
+	root := gitFixture(t)
+	gitRun(t, root, "checkout", "-qb", "feature")
+	changed := write(t, root, "lib.go", "package widget\n\nfunc Existing() {}\n\nfunc Added() {}\n")
+	msgs := messages(t, root, []string{changed}, "", true)
+	if !strings.Contains(msgs, "documentation obligation") || !strings.Contains(msgs, "[BLOCK]") {
+		t.Errorf("an undocumented public-surface change must still block: %s", msgs)
+	}
+}
+
+// The public surface is compared like with like: the previous revision read
+// by the same parser as the current one. The index calls every capitalised
+// tag exported — Go's rule and nobody else's — so a JavaScript file with a
+// capitalised local constant reported that constant removed on every run, a
+// phantom trigger dragging a blocking obligation behind it.
+// proved by: compared the file's exports against capitalised index tags —
+// the untouched ROOT then reads as an exported symbol removed.
+func TestACapitalisedLocalIsNotAnExportedSymbol(t *testing.T) {
+	root := gitFixture(t)
+	gitRun(t, root, "checkout", "-qb", "feature")
+	write(t, root, "plugin.js", "const ROOT = \"/tmp\";\n\nexport const Plugin = async () => ({});\n")
+	gitRun(t, root, "add", "-A")
+	gitRun(t, root, "commit", "-qm", "add the plugin")
+
+	// the body changes; the exported surface does not
+	changed := write(t, root, "plugin.js", "const ROOT = \"/var\";\nconst SELF = 1;\n\nexport const Plugin = async () => ({ a: SELF });\n")
+	if msgs := messages(t, root, []string{changed}, "", true); strings.Contains(msgs, "exported symbol") {
+		t.Errorf("no export changed here: %s", msgs)
+	}
+
+	// and a real export still triggers
+	changed = write(t, root, "plugin.js", "const ROOT = \"/var\";\n\nexport const Plugin = async () => ({});\nexport function Extra() {}\n")
+	if msgs := messages(t, root, []string{changed}, "", true); !strings.Contains(msgs, "exported symbol Extra added") {
+		t.Errorf("a real new export must trigger: %s", msgs)
+	}
+}


### PR DESCRIPTION
## What

Two documentation-gate false positives, both from the branch in #62.

## Why

**The obligation was asked of the wrong thing.** It looked only at the uncommitted slice, so writing the doc in one commit and the code in the next blocked the second commit — demanding a `docs: none` acknowledgment for work that *was* documented, one commit earlier, in the very file the trigger named. That is the tool contradicting itself, and it punishes the ordinary habit of committing docs separately.

**The public surface was diffed between two different definitions of "exported".** The index calls every capitalised tag exported — Go's rule and nobody else's — while the file itself is read by a parser that wants an `export` keyword. So a JavaScript `const ROOT` reported `exported symbol ROOT removed or renamed` on *every run*, forever, and dragged a blocking obligation behind it. Any JS/TS file with a capitalised local hits this.

## How

- The obligation now also clears when a documentation file changed in the commits this branch carries that the default branch does not (`<default>...HEAD`). On the default branch there is no such range and only the pending diff counts, exactly as before. Any git failure means no evidence of an answer, never a claim of one.
- "Before" now comes from git, read by the same parser as "now" — `exportedSymbols` split into a path half and a content half so both sides go through one reader. The index answers only where there is no history to compare against, which keeps the no-index honesty note where it belongs.

## Testing

`go test ./...`, `go vet ./...`, `procoder check` clean.

Three new tests: a doc committed earlier on the branch clears the obligation; a branch with no doc change still blocks; a capitalised local produces no trigger while a real new export still does. Both mutation-checked — reverting either fix fails its test specifically.

**Verified against the branch in the report.** Cloned it at the reported commit with the same pending change:

```
v1.0.1:  BLOCKING documentation obligation: docs/portability.md names changed file
         .opencode/plugins/procoder.mjs — no documentation file changed in this diff
fixed:   procoder gate: 1 clean, 0 unformatted, 0 unchecked, 1 hygiene finding(s) (0 blocking)
```

## Notes for the reviewer

The second fix quietly removes the index from this path where git can answer, which also makes the check immune to a stale index — the report's phantom `ROOT`/`SELF` findings were partly that. `docs/quality-chain.md` now states what the obligation asks and of what, which is the first prose anywhere on its scope.
