### PR TITLE
backlog: the marketplace-strategy and interactive-qa work joins the repository

### DIFF
--- a/.procoder/backlog/epics/interactive-qa.md
+++ b/.procoder/backlog/epics/interactive-qa.md
@@ -1,0 +1,10 @@
+# Interactive Q&A
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Milestone: interactive-qa
+Spec: interactive-qa
+
+## Description
+
+This epic introduces `procoder ask` — a structured Q&A flow where procoder collects questions from all question-generating domains (spec, docs, security, lint), presents them to the human user, and re-injects the answers as ground truth. It adds an `internal/ask/ask` package with question collection, interactive prompting, and file-based Q&A. It updates the PostToolUse hook to inject Q&A sections into the AI coder's context, updates the principles hook with Q&A behavior instructions, and updates AGENTS.md and skills to instruct AI coders to stop and ask rather than guess.

--- a/.procoder/backlog/epics/marketplace-strategy.md
+++ b/.procoder/backlog/epics/marketplace-strategy.md
@@ -1,0 +1,10 @@
+# Procoder Marketplace Strategy
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Milestone: marketplace-strategy
+Spec: marketplace-strategy
+
+## Description
+
+This epic delivers the entire marketplace strategy: converting Procoder's scattered hand-rolled integrations into a unified Agent Plugins v1.0.0 compliant plugin architecture, creating formal plugin manifests for every AI coding tool marketplace, establishing an MCP server, improving hooks across platforms, and creating a VS Code extension. All 13 existing integrations (Claude Code, Cursor, Copilot, Windsurf, Roo Code, Cline, Qoder, OpenCode, Kilo, Codex, Kiro, Devin, Gemini) are restructured under a single portable core with client-specific extension overlays.

--- a/.procoder/backlog/epics/self-update.md
+++ b/.procoder/backlog/epics/self-update.md
@@ -1,0 +1,10 @@
+# Self-Update: Version Check & Upgrade
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Milestone: self-update
+Spec: self-update
+
+## Description
+
+This epic adds version detection, upgrade, and self-update to procoder. It introduces the `releases` package (stdlib-only, no external dependencies) that queries GitHub releases API, compares semver versions, downloads the correct binary for the platform, and installs it atomically. The `version --check` flag warns when a newer version exists and offers upgrade. The `self-upgrade` command downloads and installs directly. The SessionStart hook runs a background version check and prints warnings to stderr. Downgrade protection is enforced.

--- a/.procoder/backlog/milestones/interactive-qa.md
+++ b/.procoder/backlog/milestones/interactive-qa.md
@@ -1,0 +1,8 @@
+# Interactive Q&A — procoder asks the human
+
+Status: open 2026-08-20
+Created: 2026-08-20
+
+## Goal
+
+When procoder finds something that needs a human decision (spec OPEN: questions, docs obligations, security flags, lint judgments), it actually asks the user instead of letting the AI coder guess. Questions are collected, presented interactively, written to `.procoder/ask/`, and re-injected as ground truth into the AI coder's context.

--- a/.procoder/backlog/milestones/marketplace-strategy.md
+++ b/.procoder/backlog/milestones/marketplace-strategy.md
@@ -1,0 +1,8 @@
+# Procoder Marketplace Strategy
+
+Status: open 2026-08-20
+Created: 2026-08-20
+
+## Goal
+
+Procoder becomes a first-class citizen on every AI coding marketplace that has one, with a unified plugin architecture based on the Agent Plugins specification, formal MCP server, hooks, skills, and submissions to Claude Code, Kiro, VS Code, Cline, Roo Code, and GitHub Marketplaces.

--- a/.procoder/backlog/milestones/self-update.md
+++ b/.procoder/backlog/milestones/self-update.md
@@ -1,0 +1,8 @@
+# Procoder self-update — version check, warning, and upgrade
+
+Status: open 2026-08-20
+Created: 2026-08-20
+
+## Goal
+
+When procoder detects a newer version is available on GitHub releases, it warns the user and offers to upgrade. Users can upgrade via `procoder self-upgrade` or directly from the version-check prompt. The version check has a hard 1-second timeout, never blocks the AI coder, and refuses downgrades.

--- a/.procoder/backlog/stories/20260820-ask-command.md
+++ b/.procoder/backlog/stories/20260820-ask-command.md
@@ -1,0 +1,24 @@
+# Implement `ask` command at top level
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Add the `procoder ask` command to the top-level CLI dispatcher with `--file <path>` flag support.
+
+## Acceptance criteria
+
+- [ ] `procoder ask` command registered in `cmd/procoder/main.go` switch statement
+- [ ] `askCmd` function calls `ask.Collect(root)` to get questions
+- [ ] If no questions: prints "no questions to ask" and exits 0
+- [ ] If TTY: runs interactive prompt, collects answers, exits 0
+- [ ] If no TTY: writes `.procoder/ask/QA.md`, exits 1 with instruction
+- [ ] `--file <path>` flag: loads existing answers from file, writes to `answers.md`, exits 0
+- [ ] Usage text includes `ask [--file <path>]`
+- [ ] Command resolves root correctly from working directory
+- [ ] Exit codes: 0 = questions answered or no questions; 1 = questions unanswered (no TTY)
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-ask-tests.md
+++ b/.procoder/backlog/stories/20260820-ask-tests.md
@@ -1,0 +1,25 @@
+# Add tests for internal/ask package
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Create tests for the `internal/ask/ask` package covering all major functions: Collection, TTY detection, file write/read, and the `--file` flag flow.
+
+## Acceptance criteria
+
+- [ ] `internal/ask/ask_test.go` created
+- [ ] Test: `Collect` on repo with known OPEN: questions returns correct count
+- [ ] Test: `Collect` on clean repo (no questions) returns 0 questions
+- [ ] Test: `Collect` on repo with no specs dir returns 0 spec questions (no panic)
+- [ ] Test: TTY() returns different paths for terminal vs non-terminal
+- [ ] Test: Write/read round-trip — questions written to QA.md are read back correctly
+- [ ] Test: Write/read round-trip — answers written to answers.md are read back correctly
+- [ ] Test: `parseQA` on missing file returns empty map (not error)
+- [ ] Test: `--file` flag path works correctly (answer loaded from file)
+- [ ] `go test ./internal/ask/...` — all tests pass
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-create-ask-package.md
+++ b/.procoder/backlog/stories/20260820-create-ask-package.md
@@ -1,0 +1,24 @@
+# Create internal/ask/ask.go — Question struct and collect framework
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Create the `internal/ask/ask` package that defines the Question struct and the Collect framework. This is the foundation that all other ask features build on.
+
+## Acceptance criteria
+
+- [ ] `internal/ask/ask.go` created with Question struct: Source, ID, SpecName, Text, Default, Answered
+- [ ] Questions type defined as []Question
+- [ ] Collect(root string) Questions function calls each domain's collector
+- [ ] TTY() bool function checks stdin using syscall.IsTerminal (or existing copilot.Prompt pattern)
+- [ ] WriteFile(qs Questions, root string) error writes questions to `.procoder/ask/QA.md`
+- [ ] Question.Source distinguishes: spec, docs, security, lint
+- [ ] Question.ID is unique (e.g., "spec:my-spec:1")
+- [ ] When a domain has no questions, its collector returns zero Questions (no panics)
+- [ ] Package compiles and all tests pass
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-create-cline-roo-manifests.md
+++ b/.procoder/backlog/stories/20260820-create-cline-roo-manifests.md
@@ -1,0 +1,23 @@
+# Create Cline and Roo Code plugin manifests
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Create formal plugin manifests for Cline and Roo Code under `cline/` and `roo/` directories. Both use the Agent Plugins specification with the same portable core format. Each manifest defines the plugin name, version, description, MCP server config, and skills path.
+
+## Acceptance criteria
+
+- [ ] `cline/plugin.json` created with Agent Plugins format
+- [ ] `roo/plugin.json` created with Agent Plugins format
+- [ ] Both have: name, version, description, author, license, keywords
+- [ ] Both include MCP server config with stdio transport
+- [ ] Both reference skills path (`skills/procoder/SKILL.md`)
+- [ ] Both parse as valid JSON
+- [ ] JSON files have consistent metadata (matching other manifests)
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-create-extension-directories.md
+++ b/.procoder/backlog/stories/20260820-create-extension-directories.md
@@ -1,0 +1,23 @@
+# Create client-specific extension directories with hooks
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Create the formal extension directory structure under reverse-domain namespaces. Each AI coding tool gets its own hook configuration with proper lifecycle events (SessionStart, PreToolUse, PostToolUse, PreCompact, Stop). This moves hooks from ad-hoc locations into the spec-compliant structure.
+
+## Acceptance criteria
+
+- [ ] `com.anthropic.claude-code/hooks/claude-hooks.json` created with lifecycle hooks
+- [ ] Claude hooks include: SessionStart, PreToolUse (Bash gate), PostToolUse (Write/Edit format), PreCompact, Stop
+- [ ] `com.kiro/hooks/kiro-hooks.json` created with Kiro-specific lifecycle events
+- [ ] Kiro hooks include: PreToolUse (gate before edits), PostToolUse (format check)
+- [ ] All hook files define proper matcher regex, timeouts, and statusMessages
+- [ ] Commands use `${CLAUDE_PLUGIN_ROOT}` or `${PLUGIN_ROOT}` variables
+- [ ] All JSON files parse without errors
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-create-github-app-action.md
+++ b/.procoder/backlog/stories/20260820-create-github-app-action.md
@@ -1,0 +1,26 @@
+# Create GitHub App + Action for GitHub Marketplace
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Create a GitHub App manifest and a GitHub Action workflow that enables Procoder to run quality checks on PRs and commits. The App is submitted to GitHub Marketplace with categories `code-quality`, `agent-apps`, and `code-review`. The Action runs the procoder gate CI pipeline on PR events.
+
+## Acceptance criteria
+
+- [ ] `.github/workflows/procoder-gate.yml` created with PR trigger
+- [ ] Workflow triggers on: `pull_request`, `push`, `check_run`
+- [ ] Job runs: `procoder check`, `procoder lint`, `procoder security`
+- [ ] Post findings as PR comments where possible
+- [ ] Sets CI status on the PR
+- [ ] `github-app/MANIFEST.json` created with App registration template
+- [ ] Manifest has: name, description, url, webhook_url, public
+- [ ] Manifest subscribes to events: pull_request, push, check_run
+- [ ] Manifest has redirect_url and setup_url
+- [ ] README documents the GitHub App workflow
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-create-mcp-json.md
+++ b/.procoder/backlog/stories/20260820-create-mcp-json.md
@@ -1,0 +1,24 @@
+# Create mcp.json portable MCP server config
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Create a portable MCP server configuration file (`mcp.json`) at the plugin root. This file defines how AI coding tools connect to Procoder as an MCP server. It must use the Agent Plugins MCP schema with stdio transport pointing to the procoder binary.
+
+## Acceptance criteria
+
+- [ ] `mcp.json` exists at repo root
+- [ ] `$schema` points to the MCP server schema URL
+- [ ] `mcpServers` key exists with at least one server definition
+- [ ] Server uses `type: "stdio"` transport
+- [ ] `command` uses `./` relative path to procoder binary
+- [ ] `--mode mcp` is included as first arg
+- [ ] `cwd` reference uses `${PLUGIN_ROOT}` variable
+- [ ] JSON parses without errors
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-create-submission-docs.md
+++ b/.procoder/backlog/stories/20260820-create-submission-docs.md
@@ -1,0 +1,25 @@
+# Create marketplace submission documentation
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Create a documentation file tracking all marketplace submissions made and their status. This serves as the submission ledger so anyone can see what has been submitted, where evidence lives, and what blockers exist for each marketplace.
+
+## Acceptance criteria
+
+- [ ] `docs/marketplace-submissions.md` created (or `.procoder/release/submissions.md`)
+- [ ] Each marketplace has an entry with: name, URL, submission status (pending/submitted/accepted/rejected)
+- [ ] Claude Code community marketplace listed with submission URL
+- [ ] Kiro Powers marketplace listed
+- [ ] VS Code Marketplace listed
+- [ ] GitHub Marketplace listed
+- [ ] Cline/Roo listed (self-distributed via GitHub)
+- [ ] Any blockers or requirements are documented per marketplace
+- [ ] Evidence links present for accepted submissions
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-create-vscode-extension.md
+++ b/.procoder/backlog/stories/20260820-create-vscode-extension.md
@@ -1,0 +1,32 @@
+# Create VS Code extension scaffold
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Create a VS Code extension scaffold under `vscode/` that enables Procoder to be listed on the VS Code Marketplace. The extension will work natively in Cursor, Windsurf, Cline, and any other VS Code-based coding tool. It declares procoder commands, MCP server, configuration options, and uses the VS Code AI extensibility API.
+
+## Acceptance criteria
+
+- [ ] `vscode/package.json` created with all required VS Code fields
+- [ ] Has `name`, `displayName`, `version`, `publisher`, `description`
+- [ ] Has `engines.vscode` with minimum version
+- [ ] Has `main` pointing to compiled output
+- [ ] Has `categories` (at least `["Other"]` or `["Extension Packs"]`)
+- [ ] Has `keywords` array
+- [ ] Has `contributes.commands` with procoder subcommands
+- [ ] Has `contributes.mcp.servers` declaring procoder MCP server
+- [ ] Has `contributes.configuration` with settings
+- [ ] Has `activationEvents` with `onStartupFinished`
+- [ ] Has `galleryBanner`, badges, icon reference
+- [ ] Has `sponsor` link to GitHub Sponsors
+- [ ] `vscode/src/extension.ts` has stub `activate`/`deactivate` exports
+- [ ] `vscode/tsconfig.json` present
+- [ ] `vscode/README.md` present with marketplace description
+- [ ] All JSON files parse without errors
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-download-upgrade.md
+++ b/.procoder/backlog/stories/20260820-download-upgrade.md
@@ -1,0 +1,28 @@
+# Create internal/releases/upgrade.go — Download & install
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Implement the download-and-install flow that fetches the latest procoder binary from GitHub releases and replaces the running binary.
+
+## Acceptance criteria
+
+- [ ] `internal/releases/upgrade.go` created
+- [ ] `DownloadAndInstall(latest string, out func(string)) int` downloads and installs
+- [ ] Platform detection: use `GOOS/GOARCH` or `uname -s/-m` to determine dist directory (matches launcher.sh logic)
+- [ ] Asset URL constructed from release: find matching `procoder-<os>-<arch>` in release assets
+- [ ] Download to temp file via `os.CreateTemp`
+- [ ] Temp file is made executable: `os.Chmod +x`
+- [ ] Binary resolution: find the procoder binary from `os.Args[0]` or from the current working directory
+- [ ] Atomic replace: rename temp file over the original binary (or copy then rename)
+- [ ] Refuse to downgrade: compare current version before installing
+- [ ] If download fails: leave current binary untouched, clean up temp file
+- [ ] Interactive prompt: "Update procoder X.Y.Z → A.B.C? (y/N)"
+- [ ] No TTY: print warning, do not hang
+- [ ] Tests: mock HTTP server serves fake binary; download succeeds; temp file is cleaned up on failure
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-hook-qa-section.md
+++ b/.procoder/backlog/stories/20260820-hook-qa-section.md
@@ -1,0 +1,24 @@
+# Update PostToolUse hook to inject Q&A section
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Modify the PostToolUse hook (`internal/hook/hook.go`) to inject a Q&A section into `additionalContext` when there are pending questions from the just-written file.
+
+## Acceptance criteria
+
+- [ ] Hook calls `ask.Collect(root)` alongside existing format/docs/lint/security checks
+- [ ] If questions exist, appends a `== q&a` section to the hook output
+- [ ] Q&A section text uses clear instructions: "Do NOT guess — stop and ask the user"
+- [ ] Q&A section lists each question with source and ID
+- [ ] Q&A section includes instruction: "Answer via: \`procoder ask --file .procoder/ask/answers.md\`"
+- [ ] When no TTY, Q&A section mentions `.procoder/ask/QA.md` and instructs to answer there
+- [ ] When no questions, no Q&A section is added (keeps output clean)
+- [ ] Q&A section is under the maxInlineBytes threshold (48KB)
+- [ ] Hook still handles errors gracefully (failed Q&A collection does not break the hook)
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-hook-version-check.md
+++ b/.procoder/backlog/stories/20260820-hook-version-check.md
@@ -1,0 +1,22 @@
+# Add version check to SessionStart hook (non-blocking)
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Extend the principles SessionStart hook to check for version updates in the background. Warnings are printed to stderr (not captured by the hook's stdout), so they appear in the AI coder's output without corrupting the `additionalContext` JSON.
+
+## Acceptance criteria
+
+- [ ] `internal/principles/principles.go` `RunHook` spawns a goroutine for version check
+- [ ] The goroutine has a 1-second timeout via `releases.Latest(root, 1*time.Second)`
+- [ ] If newer version found, prints to stderr: `== procoder: newer version X.Y.Z is available (current: A.B.C) — run \`procoder self-upgrade\` to update`
+- [ ] Goroutine does not block stdout or `RunHook`'s return
+- [ ] If version check fails (network error, timeout): silently ignored (no stderr output — keep logs clean)
+- [ ] `RunHook` still returns within the 3-second budget (goroutine runs independently)
+- [ ] No race conditions: goroutine only writes to stderr (thread-safe)
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-interactive-prompt.md
+++ b/.procoder/backlog/stories/20260820-interactive-prompt.md
@@ -1,0 +1,24 @@
+# Implement interactive prompt flow
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Implement the interactive terminal prompt flow that presents each question one at a time and collects the human's answer using free-text input.
+
+## Acceptance criteria
+
+- [ ] `promptQuestion(q Question) string` prints the question and reads from stdin
+- [ ] `runInteractive(qs Questions, out func(string)) int` iterates all questions, collects answers
+- [ ] Terminal check uses syscall.IsTerminal(int(os.Stdin.Fd())) (same pattern as copilot.Prompt)
+- [ ] Empty input is recorded as "skip" (not as a valid answer)
+- [ ] "skip" answers are recorded but marked as skipped, not resolved
+- [ ] Questions with free-text answers accept user typing
+- [ ] After all questions, prints summary: "answered: N / N questions (M skipped)"
+- [ ] Function returns exit 0 always (never breaks the host)
+- [ ] Interactive path only triggers when TTY() is true
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-principles-qa-section.md
+++ b/.procoder/backlog/stories/20260820-principles-qa-section.md
@@ -1,0 +1,24 @@
+# Update principles hook with Q&A behavior instructions
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Add a new "Asking the user" section to the principles text that instructs AI coders on how to behave when presented with procoder questions.
+
+## Acceptance criteria
+
+- [ ] `principles.go` Default text gains a new "## Asking the user" section
+- [ ] Section is placed after "Communicating: ADHD/ASD-friendly formatting" and before "Output preferences"
+- [ ] Section instructs: do NOT guess when asked by procoder
+- [ ] Section instructs: stop processing and ask the human the exact question text
+- [ ] Section instructs: use `procoder ask --file` or write answers to `.procoder/ask/answers.md`
+- [ ] Section instructs: re-run `procoder check` after answering
+- [ ] Section is under 15 lines (principles are injected at every session start)
+- [ ] Both `Run` and `RunHook` include the new section
+- [ ] Section text uses the same tone and formatting as the existing principles
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-qa-file-formats.md
+++ b/.procoder/backlog/stories/20260820-qa-file-formats.md
@@ -1,0 +1,24 @@
+# Write QA.md and answers.md file formats
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Define and implement the `.procoder/ask/QA.md` and `.procoder/ask/answers.md` file formats. These files persist between procoder runs so the AI coder can forward questions to the human and the human can submit answers.
+
+## Acceptance criteria
+
+- [ ] `.procoder/ask/QA.md` format: numbered questions with Source, Text, and HTML comment for Answer
+- [ ] `.procoder/ask/answers.md` format: numbered sections with Question text and Answer text
+- [ ] `parseQA(root string) map[string]string` reads answers.md, returns ID -> answer mapping
+- [ ] `writeQA(qs Questions, root string) error` creates directory and writes QA.md
+- [ ] `writeAnswers(answers map[string]string, root string) error` creates directory and writes answers.md
+- [ ] File formats are human-readable and parseable by AI coders
+- [ ] `parseQA` handles missing file (returns empty map, not error)
+- [ ] `parseQA` handles malformed file (returns partial map for valid sections, logs error for bad ones)
+- [ ] All write/read operations create `.procoder/ask/` directory if missing
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-quest-collectors.md
+++ b/.procoder/backlog/stories/20260820-quest-collectors.md
@@ -1,0 +1,23 @@
+# Implement question collectors for spec, docs, security, lint
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Implement the per-domain question collectors in `internal/ask/ask.go`. Each collector reads its domain's state and returns Questions that need human answers.
+
+## Acceptance criteria
+
+- [ ] Spec collector: reads `.procoder/specs/*.md`, parses for `OPEN:` lines, returns one Question per OPEN: marker
+- [ ] Spec collector reuses the existing `openRe` regex from `internal/spec/spec.go`
+- [ ] Docs obligation collector: calls `docs.Obligation()` with block=false, returns one Question per finding not cleared by edit
+- [ ] Security collector: calls `security.SecretsChangedFiles()` with block=false, returns one Question per flagged secret (real or test?)
+- [ ] Lint collector: calls `lint.Files()` with block=false, returns one Question per non-trivial blocker
+- [ ] Each collector respects the "conservative" policy: only collect truly ambiguous questions
+- [ ] Collectors handle empty input and missing files gracefully
+- [ ] Collectors are in `internal/ask/ask.go` as separate functions called by Collect()
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-releases-package.md
+++ b/.procoder/backlog/stories/20260820-releases-package.md
@@ -1,0 +1,24 @@
+# Create internal/releases/releases.go — GitHub release query
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Create the `internal/releases/releases` package that queries GitHub's releases API and returns the latest tagged release.
+
+## Acceptance criteria
+
+- [ ] `internal/releases/releases.go` created
+- [ ] `Release` struct with `TagName` and `Assets []ReleaseAsset`
+- [ ] `ReleaseAsset` struct with `URL` and `Name`
+- [ ] `Latest(root string, timeout time.Duration) (string, error)` fetches from `api.github.com/repos/azrtydxb/procoder/releases`
+- [ ] Uses `http.Client{Timeout: timeout}` — hard deadline enforced
+- [ ] Returns the first (most recent) release's `tag_name`
+- [ ] Handles errors gracefully: network failure → error (not panic), non-200 → error, no tag → error
+- [ ] Package compiles with stdlib only (no external deps)
+- [ ] Tests: mock HTTP server returns correct tag; timeout is enforced; 404 handled
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-restructure-plugin-manifests.md
+++ b/.procoder/backlog/stories/20260820-restructure-plugin-manifests.md
@@ -1,0 +1,24 @@
+# Restructure existing plugin manifests
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Update all existing plugin manifest files (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.devin-plugin/plugin.json`, `gemini-extension.json`, `package.json`) to follow the Agent Plugins specification. Move hooks to extension namespaces, add missing metadata (`$schema`, version, author, description), and ensure consistency across all manifests.
+
+## Acceptance criteria
+
+- [ ] `.claude-plugin/plugin.json` has hooks under `extensions.com.anthropic.claude-code.hooks`
+- [ ] `.claude-plugin/plugin.json` has `$schema` and full metadata
+- [ ] `.codex-plugin/plugin.json` has hooks under extension namespace with `$schema`
+- [ ] `.devin-plugin/plugin.json` has version and description
+- [ ] `gemini-extension.json` has version, description, repository, license
+- [ ] `package.json` has `$schema`, author, homepage, repository, keywords
+- [ ] All manifests have consistent name, version, description, author, license
+- [ ] All JSON files parse without errors
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-root-plugin-json-agent-plugins-v1.md
+++ b/.procoder/backlog/stories/20260820-root-plugin-json-agent-plugins-v1.md
@@ -1,0 +1,22 @@
+# Update root plugin.json to Agent Plugins v1.0.0
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+The current root `plugin.json` has only `{"name": "procoder"}`. It must be rewritten to follow the Agent Plugins v1.0.0 specification with all required fields, the canonical `$schema` URL, author metadata, and hooks moved to the client-specific extension namespace.
+
+## Acceptance criteria
+
+- [ ] `plugin.json` at repo root has `$schema` pointing to `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`
+- [ ] All required fields present: `name`, `description`, `author` (object with `name`, optional `email`/`url`), `version`
+- [ ] Optional metadata present: `license`, `homepage`, `repository`, `keywords`
+- [ ] Hook config moved to `extensions.com.anthropic.claude-code.hooks` per spec
+- [ ] JSON parses without errors
+- [ ] `procoder release` includes this file in sync verification
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-self-upgrade-command.md
+++ b/.procoder/backlog/stories/20260820-self-upgrade-command.md
@@ -1,0 +1,21 @@
+# Add `self-upgrade` command
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Add a standalone `procoder self-upgrade` command that directly downloads and installs the latest version without prompting for a version check first.
+
+## Acceptance criteria
+
+- [ ] `"self-upgrade"` case added to the command switch in `cmd/procoder/main.go`
+- [ ] `selfUpgradeCmd` calls `releases.Latest()` then `upgrade.DownloadAndInstall()`
+- [ ] Prints progress: "Checking for updates..." → "Downloading..." → "Installing..." → "Updated to X.Y.Z"
+- [ ] On failure: prints error and exits 0 (upgrade failure should not crash the binary)
+- [ ] Usage text includes: `self-upgrade        download and install the latest procoder version`
+- [ ] Placement: after the `version` command in the usage text block
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-semver-compare.md
+++ b/.procoder/backlog/stories/20260820-semver-compare.md
@@ -1,0 +1,25 @@
+# Create internal/releases/compare.go — Semver comparison
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Implement semver comparison for procoder's version strings. Prodetector uses N.N.N format (e.g., 0.28.1) with an optional `v` prefix.
+
+## Acceptance criteria
+
+- [ ] `internal/releases/compare.go` created
+- [ ] `Semver` struct: Major, Minor, Patch int
+- [ ] `Parse(ver string) Semver` — strips `v` prefix, parses N.N.N, returns empty for invalid strings
+- [ ] `Compare(current, latest string) int` returns -1/0/1 (current/newer, equal, latest/newer)
+- [ ] `ShouldWarn(current, latest string) bool` — true only if current is a release version and latest > current
+- [ ] `dev` string is treated as equal (no version known yet)
+- [ ] Empty/invalid strings are treated as equal
+- [ ] Comparison order: Major → Minor → Patch
+- [ ] Tests cover: identical, patch bump, minor bump, major bump, dev prefix, invalid, empty
+- [ ] `go test ./internal/releases/...` passes
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-update-docs-qa.md
+++ b/.procoder/backlog/stories/20260820-update-docs-qa.md
@@ -1,0 +1,23 @@
+# Update AGENTS.md and SKILL.md with Q&A workflow
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Update the AI coder-facing documentation (AGENTS.md and skills/procoder/SKILL.md) to document the Q&A workflow — when to stop and ask, how to submit answers, and where answers live.
+
+## Acceptance criteria
+
+- [ ] `AGENTS.md` gains a reference to the Q&A workflow (either new section or integration into existing sections)
+- [ ] `skills/procoder/SKILL.md` gains documentation about `procoder ask` behavior
+- [ ] Both files reference `.procoder/ask/` directory as the canonical Q&A location
+- [ ] Both files instruct AI coders: "When you see a question from procoder, do NOT guess — stop and ask the user"
+- [ ] Both files reference `procoder ask --file` as the submission mechanism
+- [ ] AGENTS.md references the skill file as source of truth
+- [ ] No duplication between AGENTS.md and SKILL.md (they should cross-reference)
+- [ ] Changes are minimal — no rewrite of existing content
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-update-docs-upgrade.md
+++ b/.procoder/backlog/stories/20260820-update-docs-upgrade.md
@@ -1,0 +1,21 @@
+# Update AGENTS.md & skill with upgrade instruction
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Add documentation to AGENTS.md and SKILL.md about the upgrade workflow. AI coders should notice when procoder reports a newer version and ask the user to upgrade.
+
+## Acceptance criteria
+
+- [ ] `AGENTS.md` gains a new "Upgrading procoder" subsection (or integrates into existing sections)
+- [ ] AGENTS.md instructs: if procoder prints a version warning, ask the user if they want to upgrade
+- [ ] AGENTS.md documents `procoder self-upgrade` as the upgrade command
+- [ ] `skills/procoder/SKILL.md` references the self-upgrade workflow
+- [ ] Changes are minimal — no rewrite of existing content
+- [ ] Cross-reference with the principles "Asking the user" section (from the ask feature) if applicable
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-update-release-config.md
+++ b/.procoder/backlog/stories/20260820-update-release-config.md
@@ -1,0 +1,21 @@
+# Update procoder release config with new version-bearing files
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Update `.procoder/config.toml` `[release] files` list to include all new version-bearing files created by this plan: `plugin.json`, `mcp.json`, `skills/procoder/SKILL.md`, `com.anthropic.claude-code/hooks/claude-hooks.json`, `vscode/package.json`, `cline/plugin.json`, `roo/plugin.json`, `gemini-extension.json`. This ensures `procoder release` syncs all versions across the new files.
+
+## Acceptance criteria
+
+- [ ] `[release] files` in config.toml updated with all new files
+- [ ] List includes: `plugin.json`, `mcp.json`, `skills/procoder/SKILL.md`, all new plugin manifests
+- [ ] Old files removed from list only if no longer version-bearing
+- [ ] `procoder release --dry-run` (or equivalent) validates the file list
+- [ ] No existing version-bearing files are removed from sync
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-update-rules-directories.md
+++ b/.procoder/backlog/stories/20260820-update-rules-directories.md
@@ -1,0 +1,21 @@
+# Update existing rules directories
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+All existing rules directories (`.cursor/rules/`, `.windsurf/rules/`, `.roo/rules/`, `.clinerules/`, `.kiro/steering/`, `.agents/rules/`) must be verified for consistency. They should all reference the same canonical content and not have conflicting instructions. Add version references so rules auto-update when the skill core is updated.
+
+## Acceptance criteria
+
+- [ ] All rule files (`.cursor/rules/procoder.mdc`, `.windsurf/rules/procoder.md`, `.roo/rules/procoder.md`, `.clinerules/procoder.md`, `.kiro/steering/procoder.md`, `.agents/rules/procoder.md`) exist
+- [ ] All rule files contain identical content (or reference same source)
+- [ ] No conflicting instructions across rule files
+- [ ] Version references present so rules sync with skill updates
+- [ ] No orphaned rule files from removed integrations
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-update-skill-frontmatter.md
+++ b/.procoder/backlog/stories/20260820-update-skill-frontmatter.md
@@ -1,0 +1,24 @@
+# Update skills/procoder/SKILL.md with proper frontmatter
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+The skills/procoder/SKILL.md file currently has YAML frontmatter but needs to be fully compliant with the Agent Skills specification. Update the frontmatter fields (name, description, license, metadata) to meet all spec requirements: name 1-64 chars with lowercase alphanumerics, description 1-1024 chars describing both WHAT and WHEN, proper metadata category and version.
+
+## Acceptance criteria
+
+- [ ] Frontmatter YAML parses without errors
+- [ ] `name` is 1-64 chars, lowercase alphanumerics + hyphens, no leading/trailing hyphen
+- [ ] `description` is 1-1024 chars and describes both WHAT the skill does AND WHEN to use it
+- [ ] `license` field present (Apache-2.0)
+- [ ] `metadata.category` present (development)
+- [ ] `metadata.version` present (1.0.1)
+- [ ] Body is under 500 lines (progressive disclosure)
+- [ ] `allowed-tools` added to frontmatter
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-upgrade-tests.md
+++ b/.procoder/backlog/stories/20260820-upgrade-tests.md
@@ -1,0 +1,35 @@
+# Add tests for releases package
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Create comprehensive tests for the `internal/releases` package covering release fetching, semver comparison, and upgrade flow.
+
+## Acceptance criteria
+
+- [ ] `internal/releases/releases_test.go` tests:
+  - `Latest()` returns the first release's tag from a mock server
+  - `Latest()` panics/retires when network is down (returns error, not panic)
+  - `Latest()` returns empty string on 404 (no releases)
+  - Timeout is enforced (request does not hang)
+- [ ] `internal/releases/compare_test.go` tests:
+  - Same versions → Compare returns 0
+  - Patch bump → Compare returns 1
+  - Minor bump → Compare returns 1
+  - Major bump → Compare returns 1
+  - Current newer → Compare returns -1
+  - Dev version → Compare returns 0
+  - Invalid strings → Compare returns 0
+  - `ShouldWarn` returns false for dev, equal, or older
+  - `ShouldWarn` returns true only for strictly newer release
+- [ ] `internal/releases/upgrade_test.go` tests:
+  - Download succeeds → temp file deleted, binary updated
+  - Download fails → temp file cleaned up, binary unchanged
+  - Current version > latest → refuses download (downgrade protection)
+- [ ] `go test ./internal/releases/...` — all tests pass
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-validate-ask-feature.md
+++ b/.procoder/backlog/stories/20260820-validate-ask-feature.md
@@ -1,0 +1,25 @@
+# Final validation of ask feature
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: interactive-qa
+Sprint: -
+
+## Description
+
+Run the full validation suite end-to-end on procoder's own repo and a test scenario to ensure the ask feature works correctly.
+
+## Acceptance criteria
+
+- [ ] `procoder ask` runs on procoder's own repo without error
+- [ ] `procoder ask` on a fixture repo with unresolved questions collects them correctly
+- [ ] `procoder check` after `procoder ask` with answers passes (questions accepted)
+- [ ] `procoder ask` without TTY writes `.procoder/ask/QA.md` and exits 1
+- [ ] `procoder ask --file ans.md` reads answers and exits 0
+- [ ] Hook output on a write event includes `== q&a` section when questions exist
+- [ ] `procoder format` on new files passes
+- [ ] `procoder lint` — no blocking findings
+- [ ] `procoder check` — gate must pass after all changes
+- [ ] `procoder test` — all tests in the repo pass
+
+## Evidence

--- a/.procoder/backlog/stories/20260820-validate-changes.md
+++ b/.procoder/backlog/stories/20260820-validate-changes.md
@@ -1,0 +1,24 @@
+# Validate all changes with procoder gate and tests
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: marketplace-strategy
+Sprint: -
+
+## Description
+
+Run the full procoder gate and test suite to validate all changes from tasks 1-10. This is the final validation step before considering the epic complete. The gate (`procoder check`) must pass, the test suite must pass, and no linting/blocking findings should remain.
+
+## Acceptance criteria
+
+- [ ] `procoder check` passes — no blocking findings
+- [ ] `procoder test` passes — suite verifiable and green
+- [ ] `procoder format` — all new/modified files are formatted
+- [ ] `procoder lint` — no blocking findings
+- [ ] All JSON files in the repo parse without syntax errors
+- [ ] YAML frontmatter in SKILL.md parses without errors
+- [ ] `procoder check` on any modified integration file passes
+- [ ] No new conflicts with existing `.procoder/` state
+
+## Evidence
+

--- a/.procoder/backlog/stories/20260820-version-check-flag.md
+++ b/.procoder/backlog/stories/20260820-version-check-flag.md
@@ -1,0 +1,26 @@
+# Add `--check` flag to `version` command
+
+Status: open 2026-08-20
+Created: 2026-08-20
+Epic: self-update
+Sprint: -
+
+## Description
+
+Modify the `procoder version` command to accept a `--check` flag that queries GitHub for the latest version, compares, and optionally upgrades.
+
+## Acceptance criteria
+
+- [ ] `cmd/procoder/main.go` modified: the `"version"` case parses `--check` flag
+- [ ] Without `--check`: prints version string and exits 0 (existing behavior unchanged)
+- [ ] With `--check`: queries GitHub via `releases.Latest()` with 1-second timeout
+- [ ] If newer version found: prints warning `== procoder: newer version X.Y.Z is available (current: A.B.C)`
+- [ ] If TTY: prompts user with yes/no question (using existing `copilot.Prompt` pattern)
+- [ ] If user says yes: calls `upgrade.DownloadAndInstall(latest, out)`
+- [ ] If user says no / no TTY: exits 0 silently
+- [ ] If no newer version: prints "up to date" (or silent)
+- [ ] On network error: prints brief message to stderr, exits 0 (never fails)
+- [ ] Exit code 0 always (version check failure does not fail the gate)
+- [ ] Usage text updated: `version [--check]`
+
+## Evidence

--- a/.procoder/plans/interactive-qa.md
+++ b/.procoder/plans/interactive-qa.md
@@ -1,0 +1,228 @@
+# Plan: Interactive Q&A — `ask` Feature
+
+## Context
+
+Procoder's hooks inject plain text findings into the AI coder's context. When those findings contain questions (spec `OPEN:` markers, docs obligations, security flags, lint judgments), the AI coder guesses rather than asking the human. This feature introduces `procoder ask` — a structured Q&A flow that actually collects human answers and re-injects them as ground truth.
+
+## Architecture Decision
+
+Create a new `internal/ask/ask` package that:
+
+- Provides a `Collect(root string)` function returning questions from all domains
+- Normalises heterogeneous question sources into a uniform `Question` struct
+- Handles TTY detection (uses existing `copilot.Prompt` pattern)
+- Writes questions to `.procoder/ask/QA.md` and answers to `.procoder/ask/answers.md`
+
+The `ask` command lives at the top level (matching `check`, `lint`, etc.). It is NOT behind any config policy — when there are questions, they must be asked.
+
+## Tasks
+
+### 1. Create `internal/ask/ask.go` — Question struct and collect framework
+
+**File:** `internal/ask/ask.go` (new)
+**Steps:**
+1.1 Define `Question` struct: `Source` (spec/docs/security/lint), `ID` (unique per question), `SpecName` (for spec questions), `Text` (the question), `Default` (suggested answer), `Answered` (bool)
+1.2 Define `Questions []Question` as the collection type
+1.3 Implement `Collect(root string) Questions` that calls each domain's question collector
+1.4 Implement `TTY() bool` that checks `os.Stdin` via `syscall.IsTerminal` (or fallback to existing `copilot.Prompt` terminal check)
+1.5 Implement `WriteFile(qs Questions, root string) error` that writes questions to `.procoder/ask/QA.md`
+1.6 Implement the read-write pattern: TTY -> interactive prompt; no TTY -> write file
+
+**Evidence:** Package compiles. `Collect` returns at least one Question per domain. `TTY()` correctly detects terminal.
+
+### 2. Implement question collectors per domain
+
+**File:** `internal/ask/ask.go` (edit, add collector functions)
+**Steps:**
+2.1 Spec collector: read each `.procoder/specs/*.md` file, parse for `OPEN:` lines in the "Open questions" section, return one Question per `OPEN:` line
+2.2 Docs obligation collector: call `docs.Obligation(root, changed, "", false)` (with block=false since we want findings to surface questions, not block), return one Question per finding
+2.3 Security collector: call `security.SecretsChangedFiles(root, changed)` with block=false, filter for flagged secrets that have uncertain classification, return one Question per flag
+2.4 Lint collector: call `lint.Files(root, changed, false)` with block=false, filter for findings in non-obvious files, return one Question per finding (or skip if trivial)
+2.5 Each collector returns `[]Question` with proper Source, ID, and Text fields
+
+**Evidence:** Each collector returns zero or more Questions. No panics on missing domains. All collectors handle empty input gracefully.
+
+### 3. Implement interactive prompt flow
+
+**File:** `internal/ask/ask.go` (edit, add interactive section)
+**Steps:**
+3.1 Implement `promptQuestion(q Question) string` — prints the question text with source label, waits for stdin input
+3.2 Implement `runInteractive(qs Questions, out func(string)) int` — iterates questions, prints each one, reads answer, returns exit code
+3.3 Use the existing `copilot.Prompt` interaction pattern for consistency (terminal check, yes/no parsing) but extend to free-text input
+3.4 For each question: print source + ID + text, read answer line, write to answers map
+3.5 If answer == "skip" or empty, record as "skip" (not auto-answered)
+3.6 After all questions, print summary line: "answered: N / N questions"
+
+**Evidence:** Interactive run collects answers for all questions. Empty input is recorded as skip, not accepted as answer.
+
+### 4. Implement `ask` command at top level
+
+**File:** `cmd/procoder/main.go` (edit, add `ask` subcommand)
+**Steps:**
+4.1 Add `"ask"` to the command switch in `run()`
+4.2 `askCmd` function:
+
+- Parse flags: `--file` (path to answers file)
+- Call `ask.Collect(root)` to get all questions
+- If no questions, print "no questions to ask" and exit 0
+- If `--file` flag, load answers from file, write to `answers.md`, exit 0
+- If TTY, call `runInteractive` to prompt user
+- If no TTY, call `WriteFile` to write `QA.md`, exit 1
+- Print final summary
+  4.3 Add `ask [--file <path>]` to the usage text (around line 280, near `test` or `principles`)
+  4.4 Wire root resolution from the command context
+
+**Evidence:** `procoder ask` runs without error on any repo. `procoder ask` with questions prints them. `procoder ask` without questions exits cleanly. `procoder ask --file ans.md` reads answers from file.
+
+### 5. Write `QA.md` and `answers.md` formats
+
+**File:** `internal/ask/file.go` (new)
+**Steps:**
+5.1 Define `.procoder/ask/QA.md` format:
+
+```markdown
+# Procoder — Questions to Answer
+
+Status: open
+Date: 2026-08-20
+
+## Q-1: [Source] spec-name — Short label
+
+**Source:** spec | docs | security | lint
+**Text:** Full question text here?
+
+<!-- Answer with your decision, e.g.:
+Answer: We will use PostgreSQL because ...
+Answer: skip (not a secret — it's a test key)
+Answer: skip (intentional lint)
+-->
+```
+
+5.2 Define `.procoder/ask/answers.md` format:
+
+```markdown
+# Procoder — Answers
+
+Status: open
+Date: 2026-08-20
+
+## Q-1: [Source] spec-name — Short label
+
+Answer: Full human answer text here.
+```
+
+5.3 Implement `parseQA(root string) map[string]string` — reads answers.md, returns id -> answer mapping
+5.4 Implement `writeQA(qs Questions, root string) error` — writes QA.md with all questions
+5.5 Implement `writeAnswers(answers map[string]string, root string) error` — writes answers.md
+
+**Evidence:** Both files parse correctly. `parseQA` returns correct mapping. File writing survives directory creation (`.procoder/ask/` may not exist).
+
+### 6. Update PostToolUse hook to inject Q&A section
+
+**File:** `internal/hook/hook.go` (edit)
+**Steps:**
+6.1 After the existing checks (format, docs, drift, secrets, lint), call `askCollect(root, file)` to get questions related to the just-written file
+6.2 If there are questions, add a section:
+
+```
+== q&a
+
+The following question(s) need human input. Do NOT guess — stop and ask the user:
+
+[list questions here]
+
+Answer them via: `procoder ask --file .procoder/ask/answers.md`
+Then run `procoder check` again.
+```
+
+6.3 If there is NO TTY, write questions to `QA.md` and add:
+
+```
+== q&a
+
+Procoder found questions that need human input. These are in `.procoder/ask/QA.md` — read them and answer them in `.procoder/ask/answers.md`, then re-run `procoder check` without `--no-verify`.
+```
+
+**Evidence:** When questions exist, output contains `== q&a` section with human instruction. When no questions, no Q&A section is added.
+
+### 7. Update principles hook with Q&A behavior instructions
+
+**File:** `internal/principles/principles.go` (edit)
+**Steps:**
+7.1 Add a new section to the principles Default text called "Asking the user":
+
+```
+## Asking the user
+
+When procoder sends a question — whether via a `@HUMAN:` marker in `additionalContext`,
+a `== q&a` section, or a question file (`.procoder/ask/QA.md`) — it means the answer
+requires a human decision you cannot make.
+
+- Do NOT guess. Do NOT invent answers. Do NOT proceed without the answer.
+- Stop processing and ask the human the exact question text as written.
+- Get the human's answer, then either:
+  a) Run `procoder ask --file .procoder/ask/answers.md` to submit it, OR
+  b) Write the answer directly into `.procoder/ask/answers.md` following the format
+- After the answer is recorded, re-run `procoder check` to verify.
+```
+
+**Evidence:** Principles output includes "Asking the user" section. The section is present in both `Run` and `RunHook` output.
+
+### 8. Update AGENTS.md and skills/procoder/SKILL.md
+
+**File:** `AGENTS.md` (edit), `skills/procoder/SKILL.md` (edit)
+**Steps:**
+8.1 In AGENTS.md's "Communicating" section, add a note about asking questions (or better: add a dedicated "Asking the user" subsection)
+8.2 In SKILL.md, add the `ask` workflow: when the AI coder encounters a procoder question, it must stop and ask
+8.3 Reference the `.procoder/ask/` directory as the canonical Q&A location
+8.4 Document that answers in `answers.md` override domain judgment during `procoder check`
+
+**Evidence:** Both files contain the Q&A workflow. AI coders reading these files know to stop and ask.
+
+### 9. Update `procoder release` config and tests
+
+**File:** `.procoder/config.toml` (edit), `cmd/procoder/main.go` tests
+**Steps:**
+9.1 Add `.procoder/ask/` directory files to `[release] files` if they exist (they won't by default, but the config should not break if they do)
+9.2 Create tests for `internal/ask/ask.go`:
+
+- Test `Collect` on repo with known questions
+- Test `Collect` on clean repo (zero questions)
+- Test `TTY()` returns true/false appropriately
+- Test file write/read round-trip
+- Test `--file` flag loading
+  9.3 Run `go test ./internal/ask/...` — all tests pass
+
+**Evidence:** Tests cover all `ask` package functions. `procoder release` validates the repo with `ask` files present.
+
+### 10. Final validation
+
+**Steps:**
+10.1 Run `procoder ask` on procoder's own repo — verify it collects questions (or zero if clean)
+10.2 Run `procoder ask` on a fixture repo with unresolved spec questions — verify they are collected
+10.3 Run `procoder check` after `procoder ask` with answers — verify questions are accepted
+10.4 Run `procoder ask` without TTY — verify file is written and exit code is 1
+10.5 Run `procoder format` on new files
+10.6 Run `procoder lint` — no blocking findings
+10.7 Run `procoder check` — gate must pass
+
+**Evidence:** `procoder check`, `procoder test`, `procoder lint` all pass.
+
+## Dependencies
+
+- Task 1 creates the foundation that Task 2 builds on
+- Task 3 depends on Task 1 (needs Question struct and TTY check)
+- Task 4 depends on Task 1 (needs Collect function)
+- Task 5 can be parallel with Task 1 (file format definition)
+- Task 6, 7, 8 are independent once the ask package exists
+- Task 9 and 10 are last (validation)
+
+## Risk Assessment
+
+| Risk                                                               | Impact                                                 | Mitigation                                                                                                                           |
+| ------------------------------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Questions become too noisy (every lint finding creates a question) | Blocks Task 2 — users will ignore the feature          | Start conservative: only collect questions that truly need human judgment (spec, docs obligation, security flags); skip trivial lint |
+| Interactive prompt blocks the AI coder's session                   | Blocks Task 3 — the coder hangs waiting for user input | Design the TTY check carefully: only prompt when a terminal is truly available; otherwise fall back to file                          |
+| Adding Q&A to every hook output bloats the context                 | Blocks Task 6 — context window pressure                | Only add Q&A section when there are ACTUAL questions (not every hook run); keep it brief                                             |
+| Answers file becomes stale across sessions                         | Blocks Task 4 — stale answers lead to wrong decisions  | Clear answers on each `procoder ask` run; the file is ephemeral per session                                                          |
+| Spec OPEN: parsing is fragile                                      | Blocks Task 2 — wrong questions collected              | Use the existing `openRe` regex from `internal/spec/spec.go`; reuse the same parser                                                  |

--- a/.procoder/plans/marketplace-strategy.md
+++ b/.procoder/plans/marketplace-strategy.md
@@ -1,0 +1,240 @@
+# Plan: Multi-Marketplace Strategy
+
+## Context
+
+Procoder currently has 13+ hand-rolled integrations across AI coding tools. Each integration is scattered across directories (`.cursor/rules/`, `.windsurf/rules/`, etc.) with minimal manifest files. No integration follows the Agent Plugins specification. No marketplace submissions exist.
+
+The plan converts all integrations into a unified plugin architecture based on the Agent Plugins v1.0.0 specification, creates formal marketplace submissions, and improves hooks/MCP/skills for every platform.
+
+## Architecture Decision
+
+Adopt a single portable core (`plugin.json`, `mcp.json`, `skills/`) with client-specific extension overlays under reverse-domain namespaces. One procoder binary serves CLI (`procoder <cmd>`), MCP stdio server (`procoder --mode mcp`), and hook launcher (`launcher.sh procoder ...`).
+
+```
+.
+├── plugin.json              ← Agent Plugins v1.0.0 manifest (new, replaces root plugin.json)
+├── mcp.json                 ← MCP server config (new)
+├── skills/
+│   └── procoder/
+│       └── SKILL.md         ← Updated with Agent Skills frontmatter
+├── com.anthropic.claude-code/  ← Claude Code hooks + config
+│   ├── hooks/
+│   │   └── claude-hooks.json
+│   └── mcp.json
+├── com.kiro/                    ← Kiro hooks + steering
+│   └── hooks/
+│       └── kiro-hooks.json
+├── com.cursor/                  ← Cursor hooks
+│   └── hooks/
+│       └── cursor-hooks.json
+├── vscode/                      ← VS Code extension (new directory)
+│   ├── package.json             ← VS Code manifest
+│   └── src/                     ← Extension source (stub)
+├── cline/                       ← Cline plugin manifest (new)
+│   └── plugin.json
+├── roo/                         ← Roo Code plugin manifest (new)
+│   └── plugin.json
+├── .claude-plugin/              ← Legacy, restructured under extension namespace
+├── .codex-plugin/               ← Updated manifest
+├── .devin-plugin/               ← Updated manifest
+├── .qoder/                      ← Updated plugin.json and rules structure
+├── hooks/                       ← Shared: launcher.sh + launcher.cmd
+├── .cursor/rules/               ← Kept as rules-only (no marketplace)
+├── .windsurf/rules/             ← Kept as rules-only (no marketplace)
+├── .roo/rules/                  ← Kept as rules-only (no marketplace)
+├── .clinerules/                 ← Kept as rules-only (no marketplace)
+├── .kiro/                       ← Kept steering dir
+├── .opencode/                   ← Kept as-is (fork of Kilo)
+├── .kilo/                       ← Kept as-is
+├── gemini-extension.json        ← Updated with marketplace fields
+├── package.json                 ← Updated with Agent Plugins metadata
+├── plugin.yaml                  ← Updated with version sync
+└── README.md                    ← Updated with marketplace links
+```
+
+## Tasks
+
+### 1. Update root `plugin.json` to Agent Plugins v1.0.0
+
+**File:** `plugin.json` (rewrite)
+**Steps:**
+1.1 Add `$schema` pointing to `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`
+1.2 Add all required fields: `name`, `description`, `author` (name + email + url), `version`, `license`, `keywords`
+1.3 Add `homepage`, `repository`
+1.4 Move existing hook config to `extensions.com.anthropic.claude-code.hooks`
+1.5 Move existing plugin metadata to appropriate extension namespaces
+1.6 Update `procoder release` config to include the new file
+
+**Evidence:** File validates as JSON with all required fields. Schema URL matches v1.0.0.
+
+### 2. Create `mcp.json` portable MCP server config
+
+**File:** `mcp.json` (new)
+**Steps:**
+2.1 Define `$schema` for MCP config
+2.2 Create `mcpServers.procorder` with stdio transport pointing to `./dist/procoder` binary
+2.3 Include `--mode mcp` as first arg
+2.4 Set `cwd` to `${PLUGIN_ROOT}` and env to `${PLUGIN_DATA}/procoder`
+2.5 Ensure command path uses `./` relative notation
+
+**Evidence:** File exists with valid JSON schema. `mcpServers` key present with at least one server.
+
+### 3. Restructure existing plugin manifests
+
+**Files:** `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.devin-plugin/plugin.json`, `gemini-extension.json`, `package.json`
+**Steps:**
+3.1 `.claude-plugin/plugin.json` — Move hooks from root level to `extensions.com.anthropic.claude-code.hooks` per spec. Add `$schema` and full metadata. Create new top-level directory structure per spec.
+3.2 `.codex-plugin/plugin.json` — Update to Agent Plugins format. Move hooks under extension namespace. Add `$schema`, `author`, `version`.
+3.3 `.devin-plugin/plugin.json` — Add version, description, hooks config if supported.
+3.4 `gemini-extension.json` — Add all marketplace-required fields: version, description, repository, license.
+3.5 `package.json` — Add `$schema` for Agent Plugins, author, homepage, repository, keywords. Rename `pi` key to follow spec.
+
+**Evidence:** All manifests have consistent metadata (name, version, description, author, license).
+
+### 4. Create client-specific extension directories
+
+**Directories:** `com.anthropic.claude-code/`, `com.kiro/`, `com.cursor/`
+**Steps:**
+4.1 Create `com.anthropic.claude-code/hooks/claude-hooks.json` with lifecycle hooks (SessionStart, PreToolUse, PostToolUse, PreCompact, Stop)
+4.2 Create `com.kiro/hooks/kiro-hooks.json` with Kiro-specific lifecycle events (PreToolUse for gate, PostToolUse for format)
+4.3 Create `com.cursor/hooks/cursor-hooks.json` with Cursor-specific hooks if applicable
+
+**Evidence:** Each directory has valid JSON hooks files with proper matcher regex and timeouts.
+
+### 5. Update skills/procoder/SKILL.md with proper frontmatter
+
+**File:** `skills/procoder/SKILL.md` (edit)
+**Steps:**
+5.1 Ensure YAML frontmatter has: `name`, `description` (1-1024 chars, describes WHAT and WHEN), `license`, `metadata.category`, `metadata.version`
+5.2 Ensure name follows spec: 1-64 chars, lowercase alphanumerics + hyphens
+5.3 Check body is under 500 lines (progressive disclosure)
+5.4 Add `allowed-tools` to frontmatter listing the procoder commands
+
+**Evidence:** YAML frontmatter parses correctly. Description covers both what and when.
+
+### 6. Create VS Code extension scaffold
+
+**Directory:** `vscode/` (new)
+**Files:** `vscode/package.json`, `vscode/src/extension.ts` (stub), `vscode/tsconfig.json`, `vscode/README.md`
+**Steps:**
+6.1 Create `package.json` with all required VS Code fields: `name`, `displayName`, `version`, `publisher`, `description`, `engines.vscode`, `license`, `categories` (at least `["Other"]` or `["Extension Packs"]`), `keywords`
+6.2 Add `main` field pointing to compiled output
+6.3 Add `contributes` block with:
+
+- `commands`: One command per procoder subcommand (check, format, lint, security, status, spec, plan, todo, test, index, git, release)
+- `mcp.servers`: Procorder MCP server declaration
+- `configuration`: Settings for procoder binary path, check policy
+- `menus`: Context menu items for key operations
+  6.4 Add `activationEvents` with `onStartupFinished`
+  6.5 Add gallery banner, badges, icon reference
+  6.6 Add sponsor link (`github.com/sponsors`)
+  6.7 Create minimal `tsconfig.json`
+  6.8 Create stub `src/extension.ts` with `activate`/`deactivate` exports
+  6.9 Create `README.md` with marketplace description
+
+**Evidence:** `package.json` has all required VS Code fields. `contributes.mcp` declares procoder server.
+
+### 7. Create Cline and Roo Code plugin manifests
+
+**Files:** `cline/plugin.json` (new), `roo/plugin.json` (new)
+**Steps:**
+7.1 `cline/plugin.json` — Agent Plugins format with name, version, description, author, MCP config pointing to stdio server, skills path
+7.2 `roo/plugin.json` — Identical structure to Cline (Roo uses same Agent Plugins spec)
+7.3 Both must use `mcp.json`-compatible MCP server definitions
+
+**Evidence:** Both files parse as valid JSON with required fields and MCP config.
+
+### 8. Create GitHub App + Action for GitHub Marketplace
+
+**Files:** `.github/workflows/procoder-gate.yml` (new), `github-app/` directory (new)
+**Steps:**
+8.1 Create GitHub Action workflow at `.github/workflows/procoder-gate.yml`:
+
+- Triggers: `pull_request`, `push`, `check_run`
+- Job runs: `procoder check`, `procoder lint`, `procoder security`
+- Posts findings as PR comments
+- Sets CI status
+  8.2 Create a GitHub App manifest in `github-app/MANIFEST.json`:
+- `name`: "procoder"
+- `url`: "https://procoder.azrty.com/"
+- `hook_attributes`: { `url`, `events`: ["pull_request", "push", "check_run"] }
+- `callback_urls`, `redirect_url`
+- `public`, `request_oauth_on_install`: true
+- `setup_url`
+  8.3 Submit the GitHub App on GitHub Marketplace with categories: `code-quality`, `agent-apps`, `code-review`
+
+**Evidence:** Workflow file runs `procoder check` on PRs. GitHub App manifest has all required fields.
+
+### 9. Create formal Cline CLI plugin and Roo plugin
+
+**Files:** `cline/README.md`, `roo/README.md` (new)
+**Steps:**
+9.1 Create `cline/README.md` with install instructions: `cline install procoder` (hypothetical — verify Cline's actual CLI install pattern)
+9.2 Create `roo/README.md` with install instructions: `roo install procoder` (hypothetical — verify Roo's actual install pattern)
+9.3 Both READMEs must include: one-line install command, description, use case, and links to docs
+
+**Evidence:** READMEs exist with clear install commands and descriptions.
+
+### 10. Update existing rules directories to be consistent
+
+**Files:** `.cursor/rules/procoder.mdc`, `.windsurf/rules/procoder.md`, `.roo/rules/procoder.md`, `.clinerules/procoder.md`, `.kiro/steering/procoder.md`, `.agents/rules/procoder.md`
+**Steps:**
+10.1 Verify all rule files point to the same canonical content (AGENTS.md or skills/procoder/SKILL.md)
+10.2 Add version references so rules auto-update with skill updates
+10.3 Ensure no conflicting instructions across rule files
+
+**Evidence:** All rule files contain identical content (or reference the same source).
+
+### 11. Update `procoder release` config with new files
+
+**File:** `.procoder/config.toml` (edit)
+**Steps:**
+11.1 Add new version-bearing files to `[release] files`: `plugin.json`, `mcp.json`, `skills/procoder/SKILL.md`, `com.anthropic.claude-code/hooks/claude-hooks.json`, `vscode/package.json`, `cline/plugin.json`, `roo/plugin.json`, `gemini-extension.json`
+11.2 Remove or keep old files as appropriate
+
+**Evidence:** Config.toml includes all version-bearing files. `procoder release` validates them.
+
+### 12. Create marketplace submission documentation
+
+**File:** `docs/marketplace-submissions.md` (new) or `.procoder/release/` (subdirectory)
+**Steps:**
+12.1 Document each marketplace with: URL, submission process, status (pending/submitted/accepted/rejected), evidence link
+12.2 Track Claude Code community marketplace submission
+12.3 Track Kiro Powers marketplace submission
+12.4 Track VS Code Marketplace submission
+12.5 Track GitHub Marketplace submission
+12.6 Document any blockers or requirements for each
+
+**Evidence:** Submission tracking document exists with status for each marketplace.
+
+### 13. Validate and test all changes
+
+**Steps:**
+13.1 Run `procoder check` — gate must pass (no conflicts from new files)
+13.2 Run `procoder test` — suite must pass
+13.3 Run `procoder format` on all new/modified files
+13.4 Run `procoder lint` — no blocking findings
+13.5 Verify all JSON files parse correctly (no syntax errors)
+13.6 Verify YAML frontmatter in SKILL.md parses correctly
+
+**Evidence:** `procoder check`, `procoder test`, `procoder lint` all pass.
+
+## Dependencies
+
+- Task 1 must complete before Task 3 (restructured manifest is the source of truth)
+- Task 1 must complete before Task 4 (extension namespaces depend on schema URL)
+- Task 5 and Task 3 are independent (frontmatter vs manifest metadata)
+- Task 6 is independent (VS Code is a separate ecosystem)
+- Task 7 is independent (Cline/Roo use same Portable spec as task 1)
+- Task 8 is independent (GitHub is a separate ecosystem with its own model)
+- Task 13 last (validation after all changes)
+
+## Risk Assessment
+
+| Risk                                                        | Impact                  | Mitigation                                                       |
+| ----------------------------------------------------------- | ----------------------- | ---------------------------------------------------------------- |
+| Claude Code marketplace review is slow or rejected          | Blocks Task 3c evidence | Self-distribute via GitHub; submission is one way                |
+| VS Code extension requirements are stricter than documented | Blocks Task 6           | Start with minimal extension that only declares MCP server       |
+| Cline/Roo install patterns differ from assumptions          | Blocks Task 9           | Document what we know, update after testing                      |
+| Restructuring breaks existing users' integrations           | Blocks Task 3, 10       | Keep old directory structure alongside new one; deprecate slowly |
+| `procoder release` config update breaks release process     | Blocks Task 11          | Test on a branch first; keep original files in sync              |

--- a/.procoder/plans/self-update.md
+++ b/.procoder/plans/self-update.md
@@ -1,0 +1,151 @@
+# Plan: Self-Update — Version Check & Upgrade
+
+## Context
+
+Procoder's binary version is stamped by release builds via `-ldflags`. There is no mechanism to check for updates, warn users, or install newer versions. The `procoder version` command just prints the version string.
+
+This plan introduces `procoder version --check` (version check + upgrade prompt) and `procoder self-upgrade` (upgrade command), both using only Go stdlib.
+
+## Architecture Decision
+
+- Use `net/http` (stdlib-only) to query GitHub's releases API: `https://api.github.com/repos/azrtydxb/procoder/releases`
+- Parse the first (most recent) release tag and compare semver
+- Download the correct binary for the current OS/arch from the release assets
+- Use a temp file + atomic rename for the upgrade (same pattern as launcher.sh resolver)
+- Run the version check in a goroutine with a hard 1-second timeout — never blocks the caller
+- The version check output goes to stderr when in a session hook (does not mix with hook output)
+
+## Tasks
+
+### 1. Create `internal/releases/releases.go` — GitHub release query
+
+**File:** `internal/releases/releases.go` (new)
+**Steps:**
+1.1 Define `Release struct { TagName string; Assets []ReleaseAsset }` and `ReleaseAsset struct { URL string; Name string }`
+1.2 Define `Latest(root string) (string, error)` — fetches `api.github.com/repos/azrtydxb/procoder/releases`, returns the first release's tag name
+1.3 Use `fmt.Sprintf("https://api.github.com/repos/%s/releases", repoPath)` (repoPath="azrtydxb/procoder")
+1.4 The function must accept a timeout parameter — callers pass a `time.Duration`
+1.5 Returns error if network fails, if the API returns non-200, or if no tag found (e.g., private repo or rate limit)
+1.6 Use `http.Client{Timeout: timeout}` to enforce hard deadline
+
+**Evidence:** `Latest(ctx, 1*time.Second)` fetches the latest tag. Timeout is enforced.
+
+### 2. Create `internal/releases/compare.go` — Semver comparison
+
+**File:** `internal/releases/compare.go` (new)
+**Steps:**
+2.1 Define `Compare(current, latest string) int` — returns -1 (current newer), 0 (equal), 1 (latest newer)
+2.2 Parse version strings as `Semver{Major, Minor, Patch int}` using `regexp.MustCompile` or manual parse
+2.3 Compare major → minor → patch in order (semver precedence)
+2.4 Handle edge cases: `dev` tag (unknown version → return 0), `v` prefix (strip it), empty strings (treat as equal)
+2.5 Define `ShouldWarn(current, latest string) bool` — returns true only if latest is strictly newer AND the version is a release (not dev)
+2.6 Tests for: identical versions, patch bump, minor bump, major bump, invalid strings, dev version
+
+**Evidence:** `Compare("0.28.0", "0.28.1") == 1`, `Compare("0.28.1", "0.28.1") == 0`, `Compare("0.29.0", "0.28.1") == -1`.
+
+### 3. Create `internal/releases/upgrade.go` — Download & install
+
+**File:** `internal/releases/upgrade.go` (new)
+**Steps:**
+3.1 Define `DownloadAndInstall(latest string, out func(string)) int`
+3.2 Determine the platform-specific asset name from the tag: construct from `github.com/azrtydxb/procoder/releases/latest` — use `uname -s` + `uname -m` to build asset name (e.g., `procoder-darwin-arm64`, `procoder-linux-amd64`)
+3.3 Find the matching asset URL from the release's assets list
+3.4 Download to a temp file in `/var/folders/` (or `os.TempDir()`)
+3.5 Make the temp file executable (`os.Chmod +x`)
+3.6 Prompt the user: "Update procoder %s → %s? (y/N)"
+3.7 If yes: replace the current binary with the temp file (atomic rename)
+3.8 If no / timeout / no TTY: delete temp file, exit 0
+3.9 Defend: `cmd/procoder/main.go` knows the binary path. If invoked via `$PATH`, find the containing directory and replace the binary in-place. If invoked as a path (e.g., `./dist/procoder`), replace that specific file.
+3.10 Defend: refuse to downgrade if already known (current version > latest)
+
+**Evidence:** After upgrade, running `procoder version` prints the new version. Downgrade is refused.
+
+### 4. Add `--check` flag to `version` command
+
+**File:** `cmd/procoder/main.go` (edit)
+**Steps:**
+4.1 Modify the `"version"` case to optionally accept `--check`
+4.2 `versionCmd` function:
+
+- If no flags: print version string and exit 0 (existing behavior unchanged)
+- If `--check`: call `releases.Latest(root, 1*time.Second)`
+- If `latest != ""`, compare with current version
+- If `latest` is newer: print warning to stderr, check TTY
+- If TTY: prompt for upgrade (yes/no)
+- If yes: call `upgrade.DownloadAndInstall(latest, out)`
+- If no TTY / upgrade skipped: exit 0
+- If no newer version: print "up to date" (or silent) and exit 0
+- On network error: print warning to stderr but do not block ("version check failed — network unavailable")
+- Must exit 0 always (version check failure is not a gate failure)
+  4.3 Update usage text: `version [--check] [flags]`
+
+**Evidence:** `procoder version` prints one line. `procoder version --check` may print warning + prompt.
+
+### 5. Add `self-upgrade` command
+
+**File:** `cmd/procoder/main.go` (edit)
+**Steps:**
+5.1 Add `"self-upgrade"` case to the command switch
+5.2 `selfUpgradeCmd` function:
+
+- Call `upgrade.DownloadAndInstall(latest, out)` directly (no version comparison needed — this command implies upgrade)
+- Add to usage text: `self-upgrade        download and install the latest procoder version`
+  5.3 Usage text location: after `version` in the existing usage block
+
+**Evidence:** `procoder self-upgrade` downloads and installs the latest version on the platform.
+
+### 6. Integrate version check into SessionStart hook
+
+**File:** `internal/principles/principles.go` (edit)
+**Steps:**
+6.1 In `RunHook`, after printing the principles + status, check for version updates in a non-blocking way
+6.2 The version check runs in a goroutine inside the hook: it prints to stderr (not stdout, so it does not corrupt the hook output)
+6.3 If a newer version is available, print a short note to stderr (visible in the AI coder's output logs)
+6.4 The note: `== procoder: version X.Y.Z is available (you have A.B.C)`
+6.5 Include upgrade instruction: `Run \`procoder self-upgrade\` to update.`
+
+**Evidence:** SessionStart hook still completes within the budget — version check runs in background and prints to stderr.
+
+### 7. Update AGENTS.md with upgrade instruction
+
+**File:** `AGENTS.md` (edit) — add to the principles or a new "Upgrading procoder" section
+**Steps:**
+7.1 When procoder says a newer version is available, the coder should not ignore it
+7.2 Document: "If procoder prints a version warning, ask the user if they want to upgrade. The user can answer 'yes' and you should run `procoder self-upgrade`."
+
+**Evidence:** The AGENTS.md (or skills) file documents the upgrade flow.
+
+### 8. Test and validate
+
+**Steps:**
+8.1 Test `releases.Latest()` with mock HTTP server — verify it returns correct tag, handles 404, handles timeout
+8.2 Test semver comparison — all edge cases covered
+8.3 Test `procoder version --check` path — verify correct output
+8.4 Test no-TTY path — verify no hang, warning still printed
+8.5 Test `procoder version` still works without `--check`
+8.6 Run `procoder check` — must pass
+8.7 Run `procoder test` — must pass
+8.8 Run `procoder lint` — must pass
+
+**Evidence:** `go test ./internal/releases/...` passes. All validation steps succeed.
+
+## Dependencies
+
+- Task 1 creates the GitHub release query that Task 2 and Task 3 depend on
+- Task 2 is independent (semver parsing)
+- Task 3 depends on Task 1 (needs Latest to find asset URL)
+- Task 4 depends on Task 1 and Task 2 (needs Latest and Compare)
+- Task 5 depends on Task 1 and Task 3 (needs Latest and Download)
+- Task 6 is independent (calls releases in goroutine)
+- Task 7 is independent
+- Task 8 is last (all pieces in place)
+
+## Risk Assessment
+
+| Risk                                                  | Impact                                           | Mitigation                                                                      |
+| ----------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| GitHub API rate limiting                              | Blocks version check for unauthenticated calls   | Accept graceful failure — don't block the hook if network fails                 |
+| Binary not found on PATH (hooks use launcher.sh path) | Blocks Task 3/5 — can't find the file to replace | Resolve the binary path from the launcher.sh location; fall back to PATH search |
+| Download fails mid-flight                             | Corrupts binary                                  | Use temp file + atomic rename; only replace on success                          |
+| Network timeout freezes the hook                      | Blocks Task 6 — session stalls                   | Hard timeout of 1s; run in background goroutine; never blocks stdout            |
+| Downgrade protection missed                           | Bad UX — installs older version                  | Compare before installing; refuse if current > latest                           |

--- a/.procoder/specs/interactive-qa.md
+++ b/.procoder/specs/interactive-qa.md
@@ -1,14 +1,25 @@
 # Spec: Interactive Q&A — `ask` Feature
 
-## Background
+Status: draft
+
+## Problem
 
 When procoder finds things that need human judgment, the answers are injected into the AI coder's context as plain text via hooks (PostToolUse `additionalContext`, SessionStart principles hook). The AI coder then tries to answer these itself — guessing about specs with `OPEN:` questions, about whether a linter finding is real, about documentation gaps, about security flags. The user never gets to answer; they just see text that looks like the problem was resolved when the coder made it up.
 
 We need a structured Q&A flow where procoder actually asks the human, collects answers, and makes those answers available to the AI coder as ground truth.
 
-## Requirements
+## Users
 
-### Functional
+- The human being asked. Today they never see the question: it goes into
+  the coder's context, the coder answers it, and the answer reads like a
+  resolution rather than a guess.
+- The AI coder, which currently has to invent an answer or stall. With
+  `ask` it has ground truth to work from, and an instruction to stop rather
+  than guess when it does not.
+- The reviewer of the resulting work, who can see which decisions a human
+  actually made.
+
+## In scope
 
 - [R-01] `procoder ask` collects questions from all question-generating domains:
   - Spec: every unresolved `OPEN:` question with its spec name and the question text
@@ -23,28 +34,82 @@ We need a structured Q&A flow where procoder actually asks the human, collects a
 - [R-07] `procoder ask` output includes the answers (from `answers.md` if present) so the AI coder sees the human's decisions
 - [R-08] The `principles` hook text includes a section about how the AI coder should behave when presented with questions
 
-### Non-functional
+## Out of scope
+
+- Procoder answering on the user's behalf, or inferring an answer from the
+  repository. The whole point is that a guess stops being indistinguishable
+  from a decision.
+- A graphical or web interface. The terminal and a Markdown file are the
+  two surfaces.
+- Question generation itself: each domain already knows what it cannot
+  decide; `ask` collects and normalises, it does not invent questions.
+- Answer persistence across runs — [O-2] asks whether that is even wanted,
+  and [N-04] currently says a re-run refreshes.
+
+## Constraints
 
 - [N-01] Each domain collects questions in its own format; `ask` normalises them into a uniform `Question{Source, ID, Text, Default}` struct
 - [N-02] The interaction is non-blocking for the AI coder: if the coder cannot interact (no terminal), questions are written to file with clear instructions
 - [N-03] The Q&A file format must be parseable by both humans and the AI coder (Markdown format with clear structure)
 - [N-04] Re-running `procoder ask` clears previous answers and refreshes questions
 
-## Open Questions
+## Interfaces
+
+- `procoder ask [--file <path>]` — collects, asks, and records ([R-01],
+  [R-05]).
+- `.procoder/ask/QA.md` — the questions, one numbered section each, written
+  when there is no terminal to ask ([R-03]).
+- `.procoder/ask/answers.md` — the answers, machine-readable ([R-04]).
+- The PostToolUse hook's `additionalContext`, which carries the pending
+  questions and the instruction not to guess ([R-06]).
+- The `principles` hook text, which tells the coder how to behave when it
+  is handed a question ([R-08]).
+- `Question{Source, ID, Text, Default}` — the normalised shape every
+  domain's questions are mapped into ([N-01]).
+
+## Data
+
+`.procoder/ask/QA.md` and `.procoder/ask/answers.md` hold questions and the
+human's answers. Both are repository state, not user code, and both are
+readable by a person as well as by the coder ([N-03]).
+
+The questions themselves quote what the domain found — a spec's `OPEN:`
+line, a lint finding, a flagged secret. A flagged secret's _value_ must
+never be written into either file: the question is whether the flag is
+real, and the answer does not need the credential to be legible.
+
+## Edge cases
+
+- No questions at all: `ask` must be a quiet no-op, not an empty prompt.
+- A terminal that goes away mid-run.
+- An answers file that answers questions which no longer exist, or misses
+  ones that do.
+- A question whose text is longer than a terminal line.
+- Two domains asking the same question about the same finding.
+- `--file` pointed at a file that is not answer-shaped.
+
+## Failure modes
+
+- `.procoder/ask/` is unwritable: the questions must still be shown, and
+  the run must say plainly that nothing was recorded.
+- The answers file is unreadable or malformed: the questions stay
+  unanswered rather than being treated as answered — unknown is never done.
+- The hook cannot reach the question set: it says so rather than injecting
+  an empty Q&A section that reads as "nothing to ask".
+
+## Acceptance criteria
+
+- [ ] C-01: `procoder ask` collects at least one question from each domain that generates them — verified by: Run on a repo with known questions per domain; verify output includes all
+- [ ] C-02: Interactive path reads from stdin only when a TTY is available — verified by: Run with `/dev/null` input; must write to file, not hang
+- [ ] C-03: File path is written to a stable location — verified by: Check `.procoder/ask/QA.md` and `.procoder/ask/answers.md` exist after run
+- [ ] C-04: `--file` flag reads answers from specified file — verified by: Write test answers file; run `ask --file`; verify questions are answered
+- [ ] C-05: Hook output contains a `[q-a]` section with explicit ask instructions — verified by: Run hook; verify output contains `== q&a` and "do NOT guess" text
+- [ ] C-06: Spec's `check` incorporates answers from `answers.md` when re-running — verified by: Write answer in `answers.md`; run check; verify OPEN: questions are accepted
+- [ ] C-07: Non-interactive execution exits 1 (questions unanswered) — verified by: Run without TTY; verify exit code is 1, exit 0 only when all answered
+- [ ] C-08: Prodigy gate passes with answered questions — verified by: Run `procoder check` after `procoder ask`; must pass when all answers provided
+
+## Open questions
 
 - [O-1] Should `procoder ask` be a subcommand of `ask` or a standalone command at the top level? (Top-level: simpler, matches existing commands like `check`, `lint`)
 - [O-2] Should answers persist across runs, or every run re-asks all questions?
 - [O-3] Should the AI coder be able to submit answers inline in its response, or must it use a separate command?
-
-## Criteria
-
-| #    | Criterion                                                                          | Verification                                                                   |
-| ---- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| C-01 | `procoder ask` collects at least one question from each domain that generates them | Run on a repo with known questions per domain; verify output includes all      |
-| C-02 | Interactive path reads from stdin only when a TTY is available                     | Run with `/dev/null` input; must write to file, not hang                       |
-| C-03 | File path is written to a stable location                                          | Check `.procoder/ask/QA.md` and `.procoder/ask/answers.md` exist after run     |
-| C-04 | `--file` flag reads answers from specified file                                    | Write test answers file; run `ask --file`; verify questions are answered       |
-| C-05 | Hook output contains a `[q-a]` section with explicit ask instructions              | Run hook; verify output contains `== q&a` and "do NOT guess" text              |
-| C-06 | Spec's `check` incorporates answers from `answers.md` when re-running              | Write answer in `answers.md`; run check; verify OPEN: questions are accepted   |
-| C-07 | Non-interactive execution exits 1 (questions unanswered)                           | Run without TTY; verify exit code is 1, exit 0 only when all answered          |
-| C-08 | Prodigy gate passes with answered questions                                        | Run `procoder check` after `procoder ask`; must pass when all answers provided |

--- a/.procoder/specs/interactive-qa.md
+++ b/.procoder/specs/interactive-qa.md
@@ -1,0 +1,50 @@
+# Spec: Interactive Q&A — `ask` Feature
+
+## Background
+
+When procoder finds things that need human judgment, the answers are injected into the AI coder's context as plain text via hooks (PostToolUse `additionalContext`, SessionStart principles hook). The AI coder then tries to answer these itself — guessing about specs with `OPEN:` questions, about whether a linter finding is real, about documentation gaps, about security flags. The user never gets to answer; they just see text that looks like the problem was resolved when the coder made it up.
+
+We need a structured Q&A flow where procoder actually asks the human, collects answers, and makes those answers available to the AI coder as ground truth.
+
+## Requirements
+
+### Functional
+
+- [R-01] `procoder ask` collects questions from all question-generating domains:
+  - Spec: every unresolved `OPEN:` question with its spec name and the question text
+  - Docs obligation: every documentation gap that was not cleared by an edit or commit message
+  - Security: every secret flag (real secret or test credential?)
+  - Lint: every blocking lint finding that needs judgment (true positive or false positive?)
+- [R-02] `procoder ask` presents questions one at a time in the terminal when a TTY is available, using the existing `copilot.Prompt` interaction pattern
+- [R-03] When no TTY is available, `procoder ask` writes all questions to `.procoder/ask/QA.md` (one question per section, numbered) and exits 1 with a clear instruction telling the AI coder to forward them
+- [R-04] `procoder ask` writes answers to `.procoder/ask/answers.md` in a machine-readable format
+- [R-05] `procoder ask --file <path>` accepts answers from a file instead of interactive input (enables the AI coder to submit human answers)
+- [R-06] PostToolUse hook injects a Q&A section into `additionalContext` whenever there are pending questions, with explicit instructions that the AI coder must stop and ask, not guess
+- [R-07] `procoder ask` output includes the answers (from `answers.md` if present) so the AI coder sees the human's decisions
+- [R-08] The `principles` hook text includes a section about how the AI coder should behave when presented with questions
+
+### Non-functional
+
+- [N-01] Each domain collects questions in its own format; `ask` normalises them into a uniform `Question{Source, ID, Text, Default}` struct
+- [N-02] The interaction is non-blocking for the AI coder: if the coder cannot interact (no terminal), questions are written to file with clear instructions
+- [N-03] The Q&A file format must be parseable by both humans and the AI coder (Markdown format with clear structure)
+- [N-04] Re-running `procoder ask` clears previous answers and refreshes questions
+
+## Open Questions
+
+- [O-1] Should `procoder ask` be a subcommand of `ask` or a standalone command at the top level? (Top-level: simpler, matches existing commands like `check`, `lint`)
+- [O-2] Should answers persist across runs, or every run re-asks all questions?
+- [O-3] Should the AI coder be able to submit answers inline in its response, or must it use a separate command?
+
+## Criteria
+
+| #    | Criterion                                                                          | Verification                                                                   |
+| ---- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| C-01 | `procoder ask` collects at least one question from each domain that generates them | Run on a repo with known questions per domain; verify output includes all      |
+| C-02 | Interactive path reads from stdin only when a TTY is available                     | Run with `/dev/null` input; must write to file, not hang                       |
+| C-03 | File path is written to a stable location                                          | Check `.procoder/ask/QA.md` and `.procoder/ask/answers.md` exist after run     |
+| C-04 | `--file` flag reads answers from specified file                                    | Write test answers file; run `ask --file`; verify questions are answered       |
+| C-05 | Hook output contains a `[q-a]` section with explicit ask instructions              | Run hook; verify output contains `== q&a` and "do NOT guess" text              |
+| C-06 | Spec's `check` incorporates answers from `answers.md` when re-running              | Write answer in `answers.md`; run check; verify OPEN: questions are accepted   |
+| C-07 | Non-interactive execution exits 1 (questions unanswered)                           | Run without TTY; verify exit code is 1, exit 0 only when all answered          |
+| C-08 | Prodigy gate passes with answered questions                                        | Run `procoder check` after `procoder ask`; must pass when all answers provided |

--- a/.procoder/specs/marketplace-strategy.md
+++ b/.procoder/specs/marketplace-strategy.md
@@ -1,0 +1,53 @@
+# Spec: Multi-Marketplace Strategy
+
+## Background
+
+Procoder is an AI coding governance harness that currently integrates with 13+ coding tools through hand-rolled directory conventions (`.cursor/rules/`, `.windsurf/rules/`, etc.). Each tool has different marketplace/extension/plugin systems. Procoder's root `plugin.json` is minimal and does not follow any marketplace schema. Most integrations are per-project rules only — they are not distributable as installable plugins on any marketplace.
+
+We need a unified plugin architecture that:
+
+1. Lists Procoder on the marketplaces that have one
+2. Follows the Agent Plugins specification (agent-plugins.org) as the portable core
+3. Is installable and discoverable per-platform
+4. Uses MCP, hooks, skills, and agents to provide the best experience on each platform
+
+## Requirements
+
+### Functional
+
+- [R-01] Procoder must follow the Agent Plugins specification v1.0.0 as its portable plugin core
+- [R-02] Procoder must publish a `plugin.json` manifest compliant with the Agent Plugins schema
+- [R-03] Procoder must publish an `mcp.json` defining an MCP stdio server exposing procoder tools
+- [R-04] Procoder must create client-specific extension directories under reverse-domain namespaces (e.g. `com.anthropic.claude-code/`, `com.kiro/`)
+- [R-05] Procoder must submit to every marketplace that exists and has a public submission process
+- [R-06] Procoder must submit to the VS Code Marketplace as a native extension (works in Cursor, Windsurf, Cline)
+- [R-07] Procoder must register a GitHub App + Action for the GitHub Marketplace
+- [R-08] Procoder must create formal plugin manifests for Cline and Roo Code
+- [R-09] Procoder must create a `SKILL.md` compliant with the Agent Skills specification with proper frontmatter
+- [R-10] Procoder must update all existing `.xxx-plugin/plugin.json` and `.xxx/rules/` files to the new structure
+
+### Non-functional
+
+- [N-01] Single binary architecture: one procoder binary serves CLI, MCP, and hooks
+- [N-02] Graceful degradation: individual component failures must not break the plugin
+- [N-03] Hooks must be lightweight with appropriate timeouts
+- [N-04] All paths in hooks and MCP must use `./` relative paths and `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` variables
+
+## Open Questions
+
+- [O-1] Which version of the Agent Plugins specification is current? (Research indicates v1.0.0 at agent-plugins.org)
+- [O-2] Does the Claude Code marketplace offer a "curated" tier beyond community that requires approval?
+- [O-3] What is the timeline for each marketplace review cycle?
+
+## Criteria
+
+| #    | Criterion                                                                           | Verification                                                                             |
+| ---- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| C-01 | `plugin.json` validates against the Agent Plugins v1.0.0 schema                     | Run: `claude plugin validate ./plugin.json` (or equivalent lint)                         |
+| C-02 | All existing plugin directories have updated manifests                              | Glob all `.*/plugin.json` files and verify `$schema`, `description`, `author`, `version` |
+| C-03 | `mcp.json` exists at plugin root with stdio server definition                       | Check file exists with `mcpServers` key                                                  |
+| C-04 | Client-specific hooks exist under `com.anthropic.claude-code/` namespace            | Check `.claude-plugin/` structure has extension namespace                                |
+| C-05 | `skills/procoder/SKILL.md` has proper YAML frontmatter (name, description, license) | Check YAML parsing of frontmatter                                                        |
+| C-06 | VS Code extension manifest exists with required fields                              | Verify `package.json` in `vscode/` has `engines.vscode`, `main`, `contributes`           |
+| C-07 | Procoder submissions have been made to all identified marketplaces                  | Evidence: submission confirmation URLs or PR merge links                                 |
+| C-08 | No marketplace integration is broken by the restructuring                           | Run existing `procoder check` and `procoder test` on the repo                            |

--- a/.procoder/specs/marketplace-strategy.md
+++ b/.procoder/specs/marketplace-strategy.md
@@ -1,6 +1,8 @@
 # Spec: Multi-Marketplace Strategy
 
-## Background
+Status: draft
+
+## Problem
 
 Procoder is an AI coding governance harness that currently integrates with 13+ coding tools through hand-rolled directory conventions (`.cursor/rules/`, `.windsurf/rules/`, etc.). Each tool has different marketplace/extension/plugin systems. Procoder's root `plugin.json` is minimal and does not follow any marketplace schema. Most integrations are per-project rules only — they are not distributable as installable plugins on any marketplace.
 
@@ -11,9 +13,18 @@ We need a unified plugin architecture that:
 3. Is installable and discoverable per-platform
 4. Uses MCP, hooks, skills, and agents to provide the best experience on each platform
 
-## Requirements
+## Users
 
-### Functional
+- A developer who finds procoder on the marketplace their editor already
+  has, installs it there, and expects it to work without cloning a
+  repository or placing a binary by hand.
+- The maintainer, who submits and re-submits to each marketplace and needs
+  one manifest set to keep in sync rather than thirteen hand-rolled ones.
+- The agent inside each client, which reads whatever that client reads —
+  rules, skills, hooks, or MCP tools — and should find the same contract
+  behind all four.
+
+## In scope
 
 - [R-01] Procoder must follow the Agent Plugins specification v1.0.0 as its portable plugin core
 - [R-02] Procoder must publish a `plugin.json` manifest compliant with the Agent Plugins schema
@@ -26,28 +37,89 @@ We need a unified plugin architecture that:
 - [R-09] Procoder must create a `SKILL.md` compliant with the Agent Skills specification with proper frontmatter
 - [R-10] Procoder must update all existing `.xxx-plugin/plugin.json` and `.xxx/rules/` files to the new structure
 
-### Non-functional
+## Out of scope
+
+- Marketplaces with no public submission process, and closed or
+  invite-only tiers — [O-2] asks whether the Claude Code marketplace has
+  one, and until it is answered nothing is promised there.
+- Building or hosting a marketplace of our own.
+- Changing what the harness does. This is distribution: the gate, the
+  chain, and the domains are untouched by it.
+- Private or enterprise marketplace instances behind an organisation's own
+  registry.
+
+## Constraints
 
 - [N-01] Single binary architecture: one procoder binary serves CLI, MCP, and hooks
 - [N-02] Graceful degradation: individual component failures must not break the plugin
 - [N-03] Hooks must be lightweight with appropriate timeouts
 - [N-04] All paths in hooks and MCP must use `./` relative paths and `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` variables
 
-## Open Questions
+## Interfaces
+
+- `plugin.json` at the repository root — the Agent Plugins v1.0.0 manifest
+  ([R-01], [R-02]).
+- `mcp.json` at the plugin root — an MCP stdio server exposing procoder's
+  tools ([R-03]).
+- Client extension directories under reverse-domain namespaces, e.g.
+  `com.anthropic.claude-code/`, `com.kiro/` ([R-04]).
+- `skills/procoder/SKILL.md` — the Agent Skills manifest ([R-09]).
+- A VS Code extension manifest (`package.json` with `engines.vscode`,
+  `main`, `contributes`) for the VS Code Marketplace ([R-06]).
+- A GitHub App and Action for the GitHub Marketplace ([R-07]).
+- The existing `.xxx-plugin/plugin.json` and `.xxx/rules/` files, migrated
+  rather than abandoned ([R-10]).
+
+## Data
+
+Every manifest above carries the plugin version, and they are already
+pinned to `.claude-plugin/plugin.json` by the gate — a release where one
+manifest is stale is a release where all of them are. The new manifests
+join that same list rather than starting a second source of truth.
+
+No user data, credentials, or repository content travels to any
+marketplace: what is submitted is the manifest set and the documentation
+in this repository.
+
+## Edge cases
+
+- A client reads none of the new structure and still expects its old
+  `.xxx/rules/` file — [R-10] migrates rather than deletes, so both paths
+  answer until the old one is provably unused.
+- A marketplace rejects or delists a submission; the other twelve
+  integrations must be unaffected.
+- Two marketplaces disagree about a manifest field with the same name.
+- A client ships its own procoder version through its marketplace while a
+  binary from another channel is already on PATH.
+
+## Failure modes
+
+- A component fails to load in one client: [N-02] requires the rest of the
+  plugin to keep working, never a broken session.
+- A hook exceeds its budget: [N-03] requires a timeout, and a gate that did
+  not finish is reported as NOT run rather than clean.
+- A manifest drifts from the schema after a marketplace updates it:
+  validation is [C-01]'s job, and it must fail loudly at release time
+  rather than silently at install time.
+- A submission stalls in review: the repository stays installable by hand,
+  which is how it works today.
+
+## Acceptance criteria
+
+- [ ] C-01: `plugin.json` validates against the Agent Plugins v1.0.0 schema — verified by: Run: `claude plugin validate ./plugin.json` (or equivalent lint)
+- [ ] C-02: All existing plugin directories have updated manifests — verified by: Glob all `.*/plugin.json` files and verify `$schema`, `description`, `author`, `version`
+- [ ] C-03: `mcp.json` exists at plugin root with stdio server definition — verified by: Check file exists with `mcpServers` key
+- [ ] C-04: Client-specific hooks exist under `com.anthropic.claude-code/` namespace — verified by: Check `.claude-plugin/` structure has extension namespace
+- [ ] C-05: `skills/procoder/SKILL.md` has proper YAML frontmatter (name, description, license) — verified by: Check YAML parsing of frontmatter
+- [ ] C-06: VS Code extension manifest exists with required fields — verified by: Verify `package.json` in `vscode/` has `engines.vscode`, `main`, `contributes`
+- [ ] C-07: Procoder submissions have been made to all identified marketplaces — verified by: Evidence: submission confirmation URLs or PR merge links
+- [ ] C-08: No marketplace integration is broken by the restructuring — verified by: Run existing `procoder check` and `procoder test` on the repo
+
+## Open questions
 
 - [O-1] Which version of the Agent Plugins specification is current? (Research indicates v1.0.0 at agent-plugins.org)
 - [O-2] Does the Claude Code marketplace offer a "curated" tier beyond community that requires approval?
 - [O-3] What is the timeline for each marketplace review cycle?
-
-## Criteria
-
-| #    | Criterion                                                                           | Verification                                                                             |
-| ---- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| C-01 | `plugin.json` validates against the Agent Plugins v1.0.0 schema                     | Run: `claude plugin validate ./plugin.json` (or equivalent lint)                         |
-| C-02 | All existing plugin directories have updated manifests                              | Glob all `.*/plugin.json` files and verify `$schema`, `description`, `author`, `version` |
-| C-03 | `mcp.json` exists at plugin root with stdio server definition                       | Check file exists with `mcpServers` key                                                  |
-| C-04 | Client-specific hooks exist under `com.anthropic.claude-code/` namespace            | Check `.claude-plugin/` structure has extension namespace                                |
-| C-05 | `skills/procoder/SKILL.md` has proper YAML frontmatter (name, description, license) | Check YAML parsing of frontmatter                                                        |
-| C-06 | VS Code extension manifest exists with required fields                              | Verify `package.json` in `vscode/` has `engines.vscode`, `main`, `contributes`           |
-| C-07 | Procoder submissions have been made to all identified marketplaces                  | Evidence: submission confirmation URLs or PR merge links                                 |
-| C-08 | No marketplace integration is broken by the restructuring                           | Run existing `procoder check` and `procoder test` on the repo                            |
+- [O-4] Which sections of this spec's Criteria table are release blockers
+  and which are follow-ups? [C-07] cannot be met on our own schedule —
+  it depends on other people's review queues.

--- a/.procoder/specs/self-update.md
+++ b/.procoder/specs/self-update.md
@@ -1,0 +1,53 @@
+# Spec: Self-Update — Version Check & Upgrade
+
+## Background
+
+Procoder's binary version is stamped at build time (`cmd/procoder/main.go` line 170: `var version = "dev"` → `-ldflags -X ...` sets it to the release version). The `procoder version` command prints this version. But nothing warns the user when a newer version exists, and there is no way to upgrade without manually downloading from GitHub or installing via a package manager.
+
+AI coders run procoder via hooks at every session start. If they are running an older version, they may not know about bug fixes, new features, or security patches. Users never see a "new version available" warning and have no path to upgrade.
+
+## Requirements
+
+### Functional
+
+- [R-01] `procoder version --check` queries GitHub releases API for `github.com/azrtydxb/procoder` and returns the latest tagged version
+- [R-02] `procoder version --check` compares the current version against the latest tagged version (semver comparison, only patches/minors)
+- [R-03] If a newer version exists, `--check` prints a warning: `== procoder: newer version X.Y.Z is available (current: A.B.C)`
+- [R-04] `--check` asks the user interactively (TTY) if they want to upgrade, using the existing `copilot.Prompt` interaction pattern
+- [R-05] If the user answers yes, `procoder self-upgrade` (or `--check --upgrade`) downloads and installs the new version
+- [R-06] `procoder self-upgrade` is also a top-level command: `procoder self-upgrade` without checking first
+- [R-07] The version check is integrated into the SessionStart hook output so the warning is visible at every session
+- [R-08] When no TTY, the warning is still printed (in hook output) but no upgrade prompt is sent
+
+### Non-functional
+
+- [N-01] Version check uses only stdlib (`net/http`) to query GitHub releases API — no new dependencies
+- [N-02] The version check has a hard timeout (1 second) — a slow network must not block the session
+- [N-03] The version check must not block the gate — it runs in a goroutine and the gate proceeds regardless
+- [N-04] Upgrade must be atomic: download to temp file, verify checksum if available, then rename
+- [N-05] `procoder version` should continue to just print the version (unchanged)
+
+### Security
+
+- [N-06] Downgrade protection: `procoder self-upgrade` refuses to install a version older than the current one
+- [N-07] The binary path for `procoder self-upgrade` resolves the binary from PATH (same way hooks resolve it)
+- [N-08] The downloaded binary is not executed until the user confirms (or the `--force` flag is set)
+
+## Open Questions
+
+- [O-1] Should the version check only warn for patches (A.B.C → A.B.D) or also for minors (A.B.C → A.(B+1).C)?
+- [O-2] Should `procoder self-upgrade` work offline? (No — requires network)
+- [O-3] Should the version check be configurable? (e.g., `[version] check = "warn"` / "off" / "upgrade")
+
+## Criteria
+
+| #    | Criterion                                                                     | Verification                                          |
+| ---- | ----------------------------------------------------------------------------- | ----------------------------------------------------- |
+| C-01 | `procoder version --check` on latest version prints nothing (or "up to date") | Run on a box with the latest installed                |
+| C-02 | `procoder version --check` on old version prints warning + asks to upgrade    | Run with an old dev binary                            |
+| C-03 | `procoder self-upgrade` downloads and installs the latest binary on the PATH  | Run on a clean env; verify version advances           |
+| C-04 | `procoder self-upgrade` refuses to downgrade                                  | Pin to old version, run self-upgrade; must fail       |
+| C-05 | TTY check path — warning prints but no hanging prompt when no terminal        | Run with `                                            | head`or`/dev/null` stdin; must not hang |
+| C-06 | Network timeout (1s) does not block hook output                               | Simulate slow/no network; verify hook still completes |
+| C-07 | `procoder version` without flags still just prints the version                | Run `procoder version`; must output one line          |
+| C-08 | Version check does not block the gate                                         | Hook pre-tool-use must not wait for version check     |

--- a/.procoder/specs/self-update.md
+++ b/.procoder/specs/self-update.md
@@ -1,14 +1,24 @@
 # Spec: Self-Update — Version Check & Upgrade
 
-## Background
+Status: draft
+
+## Problem
 
 Procoder's binary version is stamped at build time (`cmd/procoder/main.go` line 170: `var version = "dev"` → `-ldflags -X ...` sets it to the release version). The `procoder version` command prints this version. But nothing warns the user when a newer version exists, and there is no way to upgrade without manually downloading from GitHub or installing via a package manager.
 
 AI coders run procoder via hooks at every session start. If they are running an older version, they may not know about bug fixes, new features, or security patches. Users never see a "new version available" warning and have no path to upgrade.
 
-## Requirements
+## Users
 
-### Functional
+- The developer running an old binary without knowing it, who finds out
+  when a bug that was fixed weeks ago bites them again.
+- The AI coder, which runs procoder through hooks at every session start
+  and cannot tell whether the verdicts it is acting on come from a current
+  binary.
+- The maintainer, whose bug fix is only real once it is on other people's
+  machines — a release nobody installs has changed nothing.
+
+## In scope
 
 - [R-01] `procoder version --check` queries GitHub releases API for `github.com/azrtydxb/procoder` and returns the latest tagged version
 - [R-02] `procoder version --check` compares the current version against the latest tagged version (semver comparison, only patches/minors)
@@ -19,7 +29,19 @@ AI coders run procoder via hooks at every session start. If they are running an 
 - [R-07] The version check is integrated into the SessionStart hook output so the warning is visible at every session
 - [R-08] When no TTY, the warning is still printed (in hook output) but no upgrade prompt is sent
 
-### Non-functional
+## Out of scope
+
+- Package-manager installs. Where a binary came from Homebrew or a
+  distribution package, that manager owns the upgrade and this command must
+  not fight it — [O-4] asks how that is detected.
+- Downgrading, and installing a chosen version: [N-06] refuses to move
+  backwards at all.
+- Automatic upgrades without consent. Every path here ends in a question,
+  and [N-08] keeps the downloaded binary unexecuted until it is answered.
+- Updating anything other than the binary — plugin manifests, rules files
+  and skills travel with the repository, not with this command.
+
+## Constraints
 
 - [N-01] Version check uses only stdlib (`net/http`) to query GitHub releases API — no new dependencies
 - [N-02] The version check has a hard timeout (1 second) — a slow network must not block the session
@@ -33,21 +55,71 @@ AI coders run procoder via hooks at every session start. If they are running an 
 - [N-07] The binary path for `procoder self-upgrade` resolves the binary from PATH (same way hooks resolve it)
 - [N-08] The downloaded binary is not executed until the user confirms (or the `--force` flag is set)
 
-## Open Questions
+## Interfaces
+
+- `procoder version --check` — queries, compares, warns, and offers
+  ([R-01] to [R-04]).
+- `procoder self-upgrade` — the same install path without checking first
+  ([R-05], [R-06]).
+- `procoder version` with no flags, unchanged: one line, the version
+  ([N-05]).
+- The SessionStart hook's output, which carries the warning where the coder
+  and the user both see it ([R-07], [R-08]).
+- GitHub's releases API for `github.com/azrtydxb/procoder`, over stdlib
+  `net/http` only ([N-01]).
+
+## Data
+
+Nothing is stored: the check reads the current binary's stamped version and
+GitHub's latest tag, and keeps neither. No telemetry leaves the machine —
+the request asks GitHub what its newest release is and says nothing about
+who is asking.
+
+The upgrade writes one file: the new binary, downloaded to a temporary path
+and renamed over the old one only after it is complete ([N-04]).
+
+## Edge cases
+
+- The binary is not writable — a system-wide install, or one owned by a
+  package manager. The upgrade must say so rather than fail halfway.
+- The running binary is the one being replaced.
+- A build with no version stamped (`dev`), where there is nothing to
+  compare.
+- A release published with no asset for this platform.
+- Two procoder binaries on PATH, and the upgrade replaces the wrong one —
+  [N-07] resolves it the way hooks do, which is the only definition that
+  matches what actually runs.
+- The newest release is older than the running build, which happens to
+  anyone working on an unreleased branch.
+
+## Failure modes
+
+- The network is slow or absent: [N-02] caps the wait at one second and
+  [N-03] keeps it off the gate's path. A check that did not answer is
+  reported as not done, never as up to date.
+- GitHub answers with something unexpected: the check says it could not
+  determine the latest version, and no upgrade is offered on a guess.
+- The download is truncated or corrupt: [N-04] makes the rename the last
+  step, so a failed download leaves the working binary in place.
+- The upgrade succeeds and the new binary does not run: the user is left
+  with a broken tool, which is why [N-08] wants the confirmation and why a
+  verified checksum matters more than speed.
+
+## Acceptance criteria
+
+- [ ] C-01: `procoder version --check` on latest version prints nothing (or "up to date") — verified by: Run on a box with the latest installed
+- [ ] C-02: `procoder version --check` on old version prints warning + asks to upgrade — verified by: Run with an old dev binary
+- [ ] C-03: `procoder self-upgrade` downloads and installs the latest binary on the PATH — verified by: Run on a clean env; verify version advances
+- [ ] C-04: `procoder self-upgrade` refuses to downgrade — verified by: Pin to old version, run self-upgrade; must fail
+- [ ] C-05: TTY check path — warning prints but no hanging prompt when no terminal — verified by: Run with ` | head`or`/dev/null` stdin; must not hang
+- [ ] C-06: Network timeout (1s) does not block hook output — verified by: Simulate slow/no network; verify hook still completes
+- [ ] C-07: `procoder version` without flags still just prints the version — verified by: Run `procoder version`; must output one line
+- [ ] C-08: Version check does not block the gate — verified by: Hook pre-tool-use must not wait for version check
+
+## Open questions
 
 - [O-1] Should the version check only warn for patches (A.B.C → A.B.D) or also for minors (A.B.C → A.(B+1).C)?
 - [O-2] Should `procoder self-upgrade` work offline? (No — requires network)
 - [O-3] Should the version check be configurable? (e.g., `[version] check = "warn"` / "off" / "upgrade")
-
-## Criteria
-
-| #    | Criterion                                                                     | Verification                                          |
-| ---- | ----------------------------------------------------------------------------- | ----------------------------------------------------- |
-| C-01 | `procoder version --check` on latest version prints nothing (or "up to date") | Run on a box with the latest installed                |
-| C-02 | `procoder version --check` on old version prints warning + asks to upgrade    | Run with an old dev binary                            |
-| C-03 | `procoder self-upgrade` downloads and installs the latest binary on the PATH  | Run on a clean env; verify version advances           |
-| C-04 | `procoder self-upgrade` refuses to downgrade                                  | Pin to old version, run self-upgrade; must fail       |
-| C-05 | TTY check path — warning prints but no hanging prompt when no terminal        | Run with `                                            | head`or`/dev/null` stdin; must not hang |
-| C-06 | Network timeout (1s) does not block hook output                               | Simulate slow/no network; verify hook still completes |
-| C-07 | `procoder version` without flags still just prints the version                | Run `procoder version`; must output one line          |
-| C-08 | Version check does not block the gate                                         | Hook pre-tool-use must not wait for version check     |
+- [O-4] How is a package-manager install detected, so the command can step
+  aside instead of overwriting a file Homebrew or apt believes it owns?

--- a/internal/backlog/board_test.go
+++ b/internal/backlog/board_test.go
@@ -118,6 +118,26 @@ func TestListOrdersOpenBeforeDone(t *testing.T) {
 	}
 }
 
+// A Spec: line with no fingerprint at all is the same fact as one carrying a
+// value no fingerprint could produce, and it used to be worse: the header did
+// not parse, so the epic read as having no spec reference — no link on the
+// board and nothing to flag. Silence is the one answer a reader cannot act on.
+// proved by: required the `@ <print>` half to match — the epic then claims no
+// spec at all and the board says nothing about it.
+func TestAnEpicNamingASpecWithNoFingerprintIsNotSilent(t *testing.T) {
+	root := t.TempDir()
+	writeSpec(t, root, "auth", "# auth\n\nthe spec\n")
+	writeItem(t, root, KindEpic, "auth", "# Auth\n\nStatus: open 2026-08-20\nSpec: auth\n")
+
+	var lines []string
+	if code := Board(root, func(s string) { lines = append(lines, s) }); code != 0 {
+		t.Fatalf("board exit code = %d, want 0", code)
+	}
+	if joined := strings.Join(lines, "\n"); !strings.Contains(joined, "⚠ spec not seeded") {
+		t.Errorf("an epic that names a spec but records no seeding must say so: %s", joined)
+	}
+}
+
 // An epic whose Spec: line carries something no fingerprint could produce was
 // never seeded from that spec — the binary prints the epic and the agent
 // writes it, so a placeholder can land where the digest belongs. That is a

--- a/internal/backlog/items.go
+++ b/internal/backlog/items.go
@@ -39,7 +39,12 @@ var (
 	sprintRe    = regexp.MustCompile(`(?m)^Sprint:\s*(\S+)`)
 	typeRe      = regexp.MustCompile(`(?m)^Type:\s*(\S+)`)
 	severityRe  = regexp.MustCompile(`(?m)^Severity:\s*(\S+)`)
-	specRe      = regexp.MustCompile(`(?m)^Spec:\s*(\S+)\s*@\s*(\S+)`)
+	// The fingerprint half is optional to MATCH so that a Spec: line without
+	// one still registers as a spec reference. It is not optional to HAVE:
+	// an epic that names a spec but records no seeding is one the board must
+	// be able to say that about, and a line that simply failed to parse is
+	// invisible — the worst of the three states.
+	specRe      = regexp.MustCompile(`(?m)^Spec:\s*(\S+)(?:\s*@\s*(\S+))?`)
 	uncheckedRe = regexp.MustCompile(`(?m)^\s*- \[ \]`)
 	checkedRe   = regexp.MustCompile(`(?m)^\s*- \[[xX]\]`)
 	placeholder = regexp.MustCompile(`(?m)^\s*- \[.\]\s*\.\.\.`)


### PR DESCRIPTION
## What

The `marketplace-strategy`, `interactive-qa` and `self-update` work joins the repository — specs, plans, a milestone, an epic, and thirteen stories — and the two issues that reading it surfaced are fixed rather than noted.

## Why

The files existed in one working tree and nowhere else. A `git clean`, a fresh clone, or a machine change and they were gone.

Reading them then surfaced two real problems:

**Both specs read NOT ready for a vocabulary difference.** They said everything a spec should say, under their own headings — Background, Requirements, Criteria — so `procoder spec check` reported missing sections that were in fact present under other names. A controller that refuses good work for its shape teaches people to ignore the controller.

**The epic named a spec and the board said nothing.** Its header reads `Spec: marketplace-strategy` with no fingerprint, and the parser required the `@ <fingerprint>` half to match — so the line did not parse at all, and the epic read as naming *no* spec. Not flagged, not linked: invisible. That is the worst of the three states, and it is the same class as #64 wearing a different hat.

## How

**The specs are moved, not rewritten.** Background → Problem, Functional requirements → In scope, Non-functional → Constraints, Open Questions → Open questions, all verbatim. The criteria tables became `- [ ]` checkbox lines — the shape `backlog seed` actually reads, so these specs can now seed stories instead of being transcribed by hand.

Users, Out of scope, Interfaces, Data, Edge cases and Failure modes are written from what each spec already commits to — its requirements name its interfaces, its non-functional constraints name its failure modes. **Where a genuine decision was missing it became an open question, not an answer nobody made** — `[O-4]` on marketplace-strategy asks which criteria are release blockers, because `[C-07]` depends on other people's review queues and cannot be scheduled here.

Both specs now report **COMPLETE**.

**The header regex** makes the fingerprint half optional to *match* and still required to *have*. The epic now reads `⚠ spec not seeded`, which is what it is — re-seeding once the spec settles restores the link.

## Testing

`go test ./...`, `go vet ./...` clean. `procoder check`: 9 clean, 0 unformatted, 0 unchecked, 0 blocking.

New test: an epic naming a spec with no fingerprint says so rather than reading as spec-less. Mutation-checked — restoring the strict regex makes the board fall silent again, which is the bug.

## Notes for the reviewer

Committed as a snapshot while the authoring session was still live — files kept arriving mid-run (`plans/interactive-qa.md`, then `specs/self-update.md` and a `validate-ask-feature` story), and each was picked up and formatted. Later edits land on top.

The only content I touched is structural. If any section I wrote states a decision you did not make, it is wrong and should be cut — that is exactly the line I tried not to cross.
