### PR TITLE
feat: the simplification pass runs before the PR, not after it is green

### DIFF
--- a/.kilo/commands/pr.md
+++ b/.kilo/commands/pr.md
@@ -45,19 +45,14 @@ downstream reviewer's:
   /procoder:simplify the way the rubric is quoted: the five tags with
   their definitions, the one-line finding format
   `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
-  finding rule, and the exact null result `Lean already. Ship.` A lens
-  dispatched by name only comes back as prose with no replacements,
-  which is the hedging that format exists to prevent. Scope it to the
-  DIFF — the repo sweep belongs to /procoder:release.
-- Order the two reports: the simplify findings first, the correctness
-  verdict as the LAST line of the response, so the verdict is never
-  buried behind a score line.
+  finding rule, and the exact null result `Lean already. Ship.` Scope it
+  to the DIFF — the repo sweep belongs to /procoder:release.
+- Report the simplify findings first, the correctness verdict last.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `procoder check`,
-  and only then continue. Cuts land before the PR opens: a change made
-  after a review invalidates the review. Downstream bot reviews are the
-  fallback net — anything they catch later becomes a lesson (see
-  /procoder:merge's reflection step).
+  and only then continue. Downstream bot reviews are the fallback net —
+  anything they catch later becomes a lesson (see /procoder:merge's
+  reflection step).
 
 3. Fill .procoder/github/PULL_REQUEST_TEMPLATE.md section by section from that
    diff. If the template is missing, get it via `procoder templates`,

--- a/.kilo/commands/pr.md
+++ b/.kilo/commands/pr.md
@@ -41,8 +41,21 @@ downstream reviewer's:
   verbatim, the branch diff, and the instruction to report findings as
   file:line, what breaks, and the fix, ending with a severity-counted
   verdict or exactly "Nothing found — open the PR."
-- Fix every Critical/Important finding (commit them), re-run
-  `procoder check`, and only then continue. Downstream bot reviews
+- Give that same agent the SECOND lens in the same pass: the five
+  /procoder:simplify tags (delete, stdlib, native, yagni, shrink) over
+  the same diff, reported separately from the correctness findings, each
+  with its mandatory replacement, and a real null result when the diff
+  has nothing to cut. One read, two verdicts — the rubric asks whether
+  the code is right, this asks whether it should exist at all, and a
+  diff deserves both before anyone else spends attention on it. Scope it
+  to the DIFF: the repo-wide sweep answers about code this change never
+  touched, and it belongs before a tag (/procoder:release), not on every
+  pull request.
+- Fix every Critical/Important finding (commit them), decide each cut —
+  taking it or saying why not, P-CONTROL — re-run `procoder check`,
+  and only then continue. Cuts land BEFORE the PR opens: changing code
+  after a review invalidates the review you just received, and every
+  post-green commit costs another full CI run. Downstream bot reviews
   are the fallback net — anything they catch later becomes a lesson
   (see /procoder:merge's reflection step).
 

--- a/.kilo/commands/pr.md
+++ b/.kilo/commands/pr.md
@@ -41,23 +41,23 @@ downstream reviewer's:
   verbatim, the branch diff, and the instruction to report findings as
   file:line, what breaks, and the fix, ending with a severity-counted
   verdict or exactly "Nothing found — open the PR."
-- Give that same agent the SECOND lens in the same pass: the five
-  /procoder:simplify tags (delete, stdlib, native, yagni, shrink) over
-  the same diff, reported separately from the correctness findings, each
-  with its mandatory replacement, and a real null result when the diff
-  has nothing to cut. One read, two verdicts — the rubric asks whether
-  the code is right, this asks whether it should exist at all, and a
-  diff deserves both before anyone else spends attention on it. Scope it
-  to the DIFF: the repo-wide sweep answers about code this change never
-  touched, and it belongs before a tag (/procoder:release), not on every
-  pull request.
+- Give that same agent the SECOND lens in the same pass, quoted from
+  /procoder:simplify the way the rubric is quoted: the five tags with
+  their definitions, the one-line finding format
+  `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
+  finding rule, and the exact null result `Lean already. Ship.` A lens
+  dispatched by name only comes back as prose with no replacements,
+  which is the hedging that format exists to prevent. Scope it to the
+  DIFF — the repo sweep belongs to /procoder:release.
+- Order the two reports: the simplify findings first, the correctness
+  verdict as the LAST line of the response, so the verdict is never
+  buried behind a score line.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `procoder check`,
-  and only then continue. Cuts land BEFORE the PR opens: changing code
-  after a review invalidates the review you just received, and every
-  post-green commit costs another full CI run. Downstream bot reviews
-  are the fallback net — anything they catch later becomes a lesson
-  (see /procoder:merge's reflection step).
+  and only then continue. Cuts land before the PR opens: a change made
+  after a review invalidates the review. Downstream bot reviews are the
+  fallback net — anything they catch later becomes a lesson (see
+  /procoder:merge's reflection step).
 
 3. Fill .procoder/github/PULL_REQUEST_TEMPLATE.md section by section from that
    diff. If the template is missing, get it via `procoder templates`,

--- a/.kilo/commands/pr.md
+++ b/.kilo/commands/pr.md
@@ -44,9 +44,9 @@ downstream reviewer's:
 - Give that same agent the SECOND lens in the same pass, quoted from
   /procoder:simplify the way the rubric is quoted: the five tags with
   their definitions, the one-line finding format
-  `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
-  finding rule, and the exact null result `Lean already. Ship.` Scope it
-  to the DIFF — the repo sweep belongs to /procoder:release.
+  `<file>:L<line>: <tag> <what>. <replacement>.`, the rule against
+  inventing a finding, and the exact null result `Lean already. Ship.`
+  Scope it to the DIFF — the repo sweep belongs to /procoder:release.
 - Report the simplify findings first, the correctness verdict last.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `procoder check`,

--- a/.kilo/commands/release.md
+++ b/.kilo/commands/release.md
@@ -12,8 +12,7 @@ The command below is the `procoder` binary on PATH.
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
 2. Before the first fix, run /procoder:simplify over the whole repo
-   (`repo`) — the whole-tree question has no other owner. Take the cuts
-   you agree with, say why not for the rest.
+   (`repo`): take the cuts you agree with, say why not for the rest.
 3. Fix everything the release controller listed — bump the files, write
    the changelog entry, commit — then rerun `procoder release` until
    it answers ready.

--- a/.kilo/commands/release.md
+++ b/.kilo/commands/release.md
@@ -11,10 +11,16 @@ The command below is the `procoder` binary on PATH.
    one pass: every file in `[release] files` carries the version, the
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
-2. Fix everything it lists — bump the files, write the changelog entry,
+2. Before the first fix, run /procoder:simplify over the whole repo
+   (`repo`): a tag is the moment the accumulated shape of the code
+   ships, and the whole-tree question — what should not exist — has no
+   other owner. Take the cuts you agree with, say why not for the rest,
+   and let the controller re-judge the tree afterwards. It reports; you
+   decide (P-CONTROL).
+3. Fix everything it lists — bump the files, write the changelog entry,
    commit — then rerun until it answers ready.
-3. When ready it prints the tag command; run that command yourself and
+4. When ready it prints the tag command; run that command yourself and
    push the tag. The binary never tags (P-CONTROL).
-4. A repo without `[release] files` in .procoder/config.toml gets an
+5. A repo without `[release] files` in .procoder/config.toml gets an
    honest "verified nothing" on the version-sync leg — set the list so
    the check has teeth.

--- a/.kilo/commands/release.md
+++ b/.kilo/commands/release.md
@@ -12,15 +12,14 @@ The command below is the `procoder` binary on PATH.
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
 2. Before the first fix, run /procoder:simplify over the whole repo
-   (`repo`): a tag is the moment the accumulated shape of the code
-   ships, and the whole-tree question — what should not exist — has no
-   other owner. Take the cuts you agree with, say why not for the rest,
-   and let the controller re-judge the tree afterwards. It reports; you
-   decide (P-CONTROL).
-3. Fix everything it lists — bump the files, write the changelog entry,
-   commit — then rerun until it answers ready.
-4. When ready it prints the tag command; run that command yourself and
-   push the tag. The binary never tags (P-CONTROL).
+   (`repo`) — the whole-tree question has no other owner. Take the cuts
+   you agree with, say why not for the rest.
+3. Fix everything the release controller listed — bump the files, write
+   the changelog entry, commit — then rerun `procoder release` until
+   it answers ready.
+4. When the release controller answers ready it prints the tag command;
+   run that command yourself and push the tag. The binary never tags
+   (P-CONTROL).
 5. A repo without `[release] files` in .procoder/config.toml gets an
    honest "verified nothing" on the version-sync leg — set the list so
    the check has teeth.

--- a/.kilo/commands/simplify.md
+++ b/.kilo/commands/simplify.md
@@ -15,10 +15,7 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `procoder index unused` and `procoder maintain` as starting
 evidence, then read.
 
-The DIFF pass runs before every pull request, inside /procoder:pr's
-pre-PR review. The REPO sweep runs before a tag, inside
-/procoder:release — on a pull request it would bury that diff's own
-findings under pre-existing ones.
+The diff pass runs before every pull request; the repo sweep before a tag.
 
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:

--- a/.kilo/commands/simplify.md
+++ b/.kilo/commands/simplify.md
@@ -15,13 +15,10 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `procoder index unused` and `procoder maintain` as starting
 evidence, then read.
 
-The two scopes are different jobs on different clocks. The DIFF pass runs
-before every pull request, inside /procoder:pr's pre-PR review, where it
-answers about the code you just wrote. The REPO sweep runs before a tag,
-inside /procoder:release: it reports on code the current change never
-touched, so attaching it to a pull request buries that diff's own
-findings under a backlog of pre-existing ones — and a report nobody can
-act on today is a report nobody reads tomorrow.
+The DIFF pass runs before every pull request, inside /procoder:pr's
+pre-PR review. The REPO sweep runs before a tag, inside
+/procoder:release — on a pull request it would bury that diff's own
+findings under pre-existing ones.
 
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:

--- a/.kilo/commands/simplify.md
+++ b/.kilo/commands/simplify.md
@@ -15,6 +15,14 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `procoder index unused` and `procoder maintain` as starting
 evidence, then read.
 
+The two scopes are different jobs on different clocks. The DIFF pass runs
+before every pull request, inside /procoder:pr's pre-PR review, where it
+answers about the code you just wrote. The REPO sweep runs before a tag,
+inside /procoder:release: it reports on code the current change never
+touched, so attaching it to a pull request buries that diff's own
+findings under a backlog of pre-existing ones — and a report nobody can
+act on today is a report nobody reads tomorrow.
+
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:
 

--- a/.opencode/command/pr.md
+++ b/.opencode/command/pr.md
@@ -45,19 +45,14 @@ downstream reviewer's:
   /procoder:simplify the way the rubric is quoted: the five tags with
   their definitions, the one-line finding format
   `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
-  finding rule, and the exact null result `Lean already. Ship.` A lens
-  dispatched by name only comes back as prose with no replacements,
-  which is the hedging that format exists to prevent. Scope it to the
-  DIFF — the repo sweep belongs to /procoder:release.
-- Order the two reports: the simplify findings first, the correctness
-  verdict as the LAST line of the response, so the verdict is never
-  buried behind a score line.
+  finding rule, and the exact null result `Lean already. Ship.` Scope it
+  to the DIFF — the repo sweep belongs to /procoder:release.
+- Report the simplify findings first, the correctness verdict last.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `procoder check`,
-  and only then continue. Cuts land before the PR opens: a change made
-  after a review invalidates the review. Downstream bot reviews are the
-  fallback net — anything they catch later becomes a lesson (see
-  /procoder:merge's reflection step).
+  and only then continue. Downstream bot reviews are the fallback net —
+  anything they catch later becomes a lesson (see /procoder:merge's
+  reflection step).
 
 3. Fill .procoder/github/PULL_REQUEST_TEMPLATE.md section by section from that
    diff. If the template is missing, get it via `procoder templates`,

--- a/.opencode/command/pr.md
+++ b/.opencode/command/pr.md
@@ -41,8 +41,21 @@ downstream reviewer's:
   verbatim, the branch diff, and the instruction to report findings as
   file:line, what breaks, and the fix, ending with a severity-counted
   verdict or exactly "Nothing found — open the PR."
-- Fix every Critical/Important finding (commit them), re-run
-  `procoder check`, and only then continue. Downstream bot reviews
+- Give that same agent the SECOND lens in the same pass: the five
+  /procoder:simplify tags (delete, stdlib, native, yagni, shrink) over
+  the same diff, reported separately from the correctness findings, each
+  with its mandatory replacement, and a real null result when the diff
+  has nothing to cut. One read, two verdicts — the rubric asks whether
+  the code is right, this asks whether it should exist at all, and a
+  diff deserves both before anyone else spends attention on it. Scope it
+  to the DIFF: the repo-wide sweep answers about code this change never
+  touched, and it belongs before a tag (/procoder:release), not on every
+  pull request.
+- Fix every Critical/Important finding (commit them), decide each cut —
+  taking it or saying why not, P-CONTROL — re-run `procoder check`,
+  and only then continue. Cuts land BEFORE the PR opens: changing code
+  after a review invalidates the review you just received, and every
+  post-green commit costs another full CI run. Downstream bot reviews
   are the fallback net — anything they catch later becomes a lesson
   (see /procoder:merge's reflection step).
 

--- a/.opencode/command/pr.md
+++ b/.opencode/command/pr.md
@@ -41,23 +41,23 @@ downstream reviewer's:
   verbatim, the branch diff, and the instruction to report findings as
   file:line, what breaks, and the fix, ending with a severity-counted
   verdict or exactly "Nothing found — open the PR."
-- Give that same agent the SECOND lens in the same pass: the five
-  /procoder:simplify tags (delete, stdlib, native, yagni, shrink) over
-  the same diff, reported separately from the correctness findings, each
-  with its mandatory replacement, and a real null result when the diff
-  has nothing to cut. One read, two verdicts — the rubric asks whether
-  the code is right, this asks whether it should exist at all, and a
-  diff deserves both before anyone else spends attention on it. Scope it
-  to the DIFF: the repo-wide sweep answers about code this change never
-  touched, and it belongs before a tag (/procoder:release), not on every
-  pull request.
+- Give that same agent the SECOND lens in the same pass, quoted from
+  /procoder:simplify the way the rubric is quoted: the five tags with
+  their definitions, the one-line finding format
+  `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
+  finding rule, and the exact null result `Lean already. Ship.` A lens
+  dispatched by name only comes back as prose with no replacements,
+  which is the hedging that format exists to prevent. Scope it to the
+  DIFF — the repo sweep belongs to /procoder:release.
+- Order the two reports: the simplify findings first, the correctness
+  verdict as the LAST line of the response, so the verdict is never
+  buried behind a score line.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `procoder check`,
-  and only then continue. Cuts land BEFORE the PR opens: changing code
-  after a review invalidates the review you just received, and every
-  post-green commit costs another full CI run. Downstream bot reviews
-  are the fallback net — anything they catch later becomes a lesson
-  (see /procoder:merge's reflection step).
+  and only then continue. Cuts land before the PR opens: a change made
+  after a review invalidates the review. Downstream bot reviews are the
+  fallback net — anything they catch later becomes a lesson (see
+  /procoder:merge's reflection step).
 
 3. Fill .procoder/github/PULL_REQUEST_TEMPLATE.md section by section from that
    diff. If the template is missing, get it via `procoder templates`,

--- a/.opencode/command/pr.md
+++ b/.opencode/command/pr.md
@@ -44,9 +44,9 @@ downstream reviewer's:
 - Give that same agent the SECOND lens in the same pass, quoted from
   /procoder:simplify the way the rubric is quoted: the five tags with
   their definitions, the one-line finding format
-  `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
-  finding rule, and the exact null result `Lean already. Ship.` Scope it
-  to the DIFF — the repo sweep belongs to /procoder:release.
+  `<file>:L<line>: <tag> <what>. <replacement>.`, the rule against
+  inventing a finding, and the exact null result `Lean already. Ship.`
+  Scope it to the DIFF — the repo sweep belongs to /procoder:release.
 - Report the simplify findings first, the correctness verdict last.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `procoder check`,

--- a/.opencode/command/release.md
+++ b/.opencode/command/release.md
@@ -12,8 +12,7 @@ The command below is the `procoder` binary on PATH.
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
 2. Before the first fix, run /procoder:simplify over the whole repo
-   (`repo`) — the whole-tree question has no other owner. Take the cuts
-   you agree with, say why not for the rest.
+   (`repo`): take the cuts you agree with, say why not for the rest.
 3. Fix everything the release controller listed — bump the files, write
    the changelog entry, commit — then rerun `procoder release` until
    it answers ready.

--- a/.opencode/command/release.md
+++ b/.opencode/command/release.md
@@ -11,10 +11,16 @@ The command below is the `procoder` binary on PATH.
    one pass: every file in `[release] files` carries the version, the
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
-2. Fix everything it lists — bump the files, write the changelog entry,
+2. Before the first fix, run /procoder:simplify over the whole repo
+   (`repo`): a tag is the moment the accumulated shape of the code
+   ships, and the whole-tree question — what should not exist — has no
+   other owner. Take the cuts you agree with, say why not for the rest,
+   and let the controller re-judge the tree afterwards. It reports; you
+   decide (P-CONTROL).
+3. Fix everything it lists — bump the files, write the changelog entry,
    commit — then rerun until it answers ready.
-3. When ready it prints the tag command; run that command yourself and
+4. When ready it prints the tag command; run that command yourself and
    push the tag. The binary never tags (P-CONTROL).
-4. A repo without `[release] files` in .procoder/config.toml gets an
+5. A repo without `[release] files` in .procoder/config.toml gets an
    honest "verified nothing" on the version-sync leg — set the list so
    the check has teeth.

--- a/.opencode/command/release.md
+++ b/.opencode/command/release.md
@@ -12,15 +12,14 @@ The command below is the `procoder` binary on PATH.
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
 2. Before the first fix, run /procoder:simplify over the whole repo
-   (`repo`): a tag is the moment the accumulated shape of the code
-   ships, and the whole-tree question — what should not exist — has no
-   other owner. Take the cuts you agree with, say why not for the rest,
-   and let the controller re-judge the tree afterwards. It reports; you
-   decide (P-CONTROL).
-3. Fix everything it lists — bump the files, write the changelog entry,
-   commit — then rerun until it answers ready.
-4. When ready it prints the tag command; run that command yourself and
-   push the tag. The binary never tags (P-CONTROL).
+   (`repo`) — the whole-tree question has no other owner. Take the cuts
+   you agree with, say why not for the rest.
+3. Fix everything the release controller listed — bump the files, write
+   the changelog entry, commit — then rerun `procoder release` until
+   it answers ready.
+4. When the release controller answers ready it prints the tag command;
+   run that command yourself and push the tag. The binary never tags
+   (P-CONTROL).
 5. A repo without `[release] files` in .procoder/config.toml gets an
    honest "verified nothing" on the version-sync leg — set the list so
    the check has teeth.

--- a/.opencode/command/simplify.md
+++ b/.opencode/command/simplify.md
@@ -15,10 +15,7 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `procoder index unused` and `procoder maintain` as starting
 evidence, then read.
 
-The DIFF pass runs before every pull request, inside /procoder:pr's
-pre-PR review. The REPO sweep runs before a tag, inside
-/procoder:release — on a pull request it would bury that diff's own
-findings under pre-existing ones.
+The diff pass runs before every pull request; the repo sweep before a tag.
 
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:

--- a/.opencode/command/simplify.md
+++ b/.opencode/command/simplify.md
@@ -15,13 +15,10 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `procoder index unused` and `procoder maintain` as starting
 evidence, then read.
 
-The two scopes are different jobs on different clocks. The DIFF pass runs
-before every pull request, inside /procoder:pr's pre-PR review, where it
-answers about the code you just wrote. The REPO sweep runs before a tag,
-inside /procoder:release: it reports on code the current change never
-touched, so attaching it to a pull request buries that diff's own
-findings under a backlog of pre-existing ones — and a report nobody can
-act on today is a report nobody reads tomorrow.
+The DIFF pass runs before every pull request, inside /procoder:pr's
+pre-PR review. The REPO sweep runs before a tag, inside
+/procoder:release — on a pull request it would bury that diff's own
+findings under pre-existing ones.
 
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:

--- a/.opencode/command/simplify.md
+++ b/.opencode/command/simplify.md
@@ -15,6 +15,14 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `procoder index unused` and `procoder maintain` as starting
 evidence, then read.
 
+The two scopes are different jobs on different clocks. The DIFF pass runs
+before every pull request, inside /procoder:pr's pre-PR review, where it
+answers about the code you just wrote. The REPO sweep runs before a tag,
+inside /procoder:release: it reports on code the current change never
+touched, so attaching it to a pull request buries that diff's own
+findings under a backlog of pre-existing ones — and a report nobody can
+act on today is a report nobody reads tomorrow.
+
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:
 

--- a/.procoder/github/LESSONS.md
+++ b/.procoder/github/LESSONS.md
@@ -255,3 +255,25 @@ does. `procoder lessons` flags entries with no adaptation.
   because capture was re-capturing its own issues — pinned by
   TestOurOwnIssuesAreNeverCapturedAgain
 
+## 2026-08-21 PR#82 (Copilot) — an inline code span opened and never closed
+
+- Class: judgment
+- Missed by: rubric
+- Adaptation: docs.UnclosedSpans counts backticks per PARAGRAPH (not per
+  line — CommonMark lets a span wrap, and per-line counting flagged 46
+  correct spans in this tree) and reports a paragraph that opens one and
+  never closes it, wired into docs.CheckFile and pinned by
+  TestAnUnclosedSpanIsReported plus three false-positive guards. The
+  REVIEW.md line "code spans unbroken" already existed and the pre-PR
+  review applied it — the eye reads the intent and skips the missing
+  character, so the rule needed counting rather than better wording.
+
+## 2026-08-21 PR#82 (Copilot) — a hyphenated compound split across a line break in instruction text
+
+- Class: taste
+- Missed by: rubric
+- Adaptation: reworded rather than rewrapped, and covered by the same
+  paragraph-level reading the span check now applies; in agent-executed
+  instruction text a stray hyphen is a plausible token rather than an
+  obvious typo, which is why it survived a human-shaped review
+

--- a/.procoder/todo/20260820-the-simplification-pass-runs-before-the-pr-exists-not-after.md
+++ b/.procoder/todo/20260820-the-simplification-pass-runs-before-the-pr-exists-not-after.md
@@ -69,9 +69,9 @@ different jobs they are.
   for an empty struct, a single-use helper): all three surfaced with
   replacements and `net: -24 lines possible.`
 - Trial 2, the same fixture with the padding removed but a speculative
-  empty-string guard left in: one finding, `delete: speculative
-empty-message placeholder — nothing sets Message to ""`. Defensible
-  against that fixture, not an invention.
+  empty-string guard left in: one finding, tagged `delete:`, reporting a
+  speculative empty-message placeholder that nothing ever sets.
+  Defensible against that fixture, not an invention.
 - Trial 3, a diff with genuinely nothing to cut (a one-word comment typo
   fix): exactly `Lean already. Ship.` — the null path returns the null
   string rather than inventing a finding.

--- a/.procoder/todo/20260820-the-simplification-pass-runs-before-the-pr-exists-not-after.md
+++ b/.procoder/todo/20260820-the-simplification-pass-runs-before-the-pr-exists-not-after.md
@@ -1,6 +1,6 @@
 # the simplification pass runs before the PR exists, not after it is green
 
-Status: open
+Status: closed 2026-08-20
 Created: 2026-08-20
 
 ## Description
@@ -31,25 +31,54 @@ different jobs they are.
 
 ## Acceptance criteria
 
-- [ ] commands/pr.md step 2b instructs the simplification pass over the
+- [x] commands/pr.md step 2b instructs the simplification pass over the
       branch diff before the PR is opened, with its OpenCode and Kilo
       twins regenerated through the generation rule and the twin-parity
       tests green.
-- [ ] The pass is diff-scoped there, and commands/simplify.md says
+- [x] The pass is diff-scoped there, and commands/simplify.md says
       plainly that the repo-wide sweep is a separate cadence, not a
       per-PR step.
-- [ ] commands/release.md carries the repo-wide sweep before a tag, so
+- [x] commands/release.md carries the repo-wide sweep before a tag, so
       the whole-tree question has an owner and a clock.
-- [ ] The findings shape stays P-CONTROL: the pass lists cuts and the
+- [x] The findings shape stays P-CONTROL: the pass lists cuts and the
       agent decides, in the PR flow exactly as in the skill today —
       verified by reading the instruction back, not by a new binary
       command.
-- [ ] A pre-PR run on a deliberately padded branch (a wrapper with one
+- [x] A pre-PR run on a deliberately padded branch (a wrapper with one
       caller added to a fixture) surfaces that finding before the PR is
       opened, and the same branch with the wrapper removed reports the
       null result rather than inventing one.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the task open. -->
+- commands/pr.md step 2b dispatches the second lens in the same pass as the
+  correctness rubric, quoting the five tags, the one-line finding format and
+  the exact null string the way the rubric is already quoted. Its own
+  pre-PR review caught that dispatching the lens by NAME only would come
+  back as prose with no replacements — the earlier trials only worked
+  because the format was pasted in by hand.
+- commands/simplify.md states the routing in one line; commands/release.md
+  runs the repo sweep at step 2, before the first fix. All six OpenCode and
+  Kilo twins regenerated through the generation rule —
+  TestOpenCodeCommandParity and TestKiloCommandParity green (both caught a
+  hand-rolled regeneration during this work).
+- P-CONTROL preserved: the step reads "decide each cut — taking it or saying
+  why not", and no binary command was added; the pass remains an instruction
+  to an agent that lists cuts for a human to judge.
+- Trial 1, padded diff (an interface with one implementation, a constructor
+  for an empty struct, a single-use helper): all three surfaced with
+  replacements and `net: -24 lines possible.`
+- Trial 2, the same fixture with the padding removed but a speculative
+  empty-string guard left in: one finding, `delete: speculative
+empty-message placeholder — nothing sets Message to ""`. Defensible
+  against that fixture, not an invention.
+- Trial 3, a diff with genuinely nothing to cut (a one-word comment typo
+  fix): exactly `Lean already. Ship.` — the null path returns the null
+  string rather than inventing a finding.
+- This branch's own pre-PR run produced 3 Important + 2 Minor correctness
+  findings and 13 lines of cuts, every one of them in the instruction text
+  this task added. Fixed in 8f63a41 and d4074da before the PR was opened,
+  which is the behaviour the task exists to produce.
+- docs/workflow.md sections 7 and 11 and docs/quality-chain.md now describe
+  both lenses and the release sweep — a docs escape the pre-PR review
+  caught against the flow's own mandatory step 2a.

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -45,9 +45,9 @@ downstream reviewer's:
 - Give that same agent the SECOND lens in the same pass, quoted from
   /procoder:simplify the way the rubric is quoted: the five tags with
   their definitions, the one-line finding format
-  `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
-  finding rule, and the exact null result `Lean already. Ship.` Scope it
-  to the DIFF — the repo sweep belongs to /procoder:release.
+  `<file>:L<line>: <tag> <what>. <replacement>.`, the rule against
+  inventing a finding, and the exact null result `Lean already. Ship.`
+  Scope it to the DIFF — the repo sweep belongs to /procoder:release.
 - Report the simplify findings first, the correctness verdict last.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `launcher.sh check`,

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -46,19 +46,14 @@ downstream reviewer's:
   /procoder:simplify the way the rubric is quoted: the five tags with
   their definitions, the one-line finding format
   `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
-  finding rule, and the exact null result `Lean already. Ship.` A lens
-  dispatched by name only comes back as prose with no replacements,
-  which is the hedging that format exists to prevent. Scope it to the
-  DIFF — the repo sweep belongs to /procoder:release.
-- Order the two reports: the simplify findings first, the correctness
-  verdict as the LAST line of the response, so the verdict is never
-  buried behind a score line.
+  finding rule, and the exact null result `Lean already. Ship.` Scope it
+  to the DIFF — the repo sweep belongs to /procoder:release.
+- Report the simplify findings first, the correctness verdict last.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `launcher.sh check`,
-  and only then continue. Cuts land before the PR opens: a change made
-  after a review invalidates the review. Downstream bot reviews are the
-  fallback net — anything they catch later becomes a lesson (see
-  /procoder:merge's reflection step).
+  and only then continue. Downstream bot reviews are the fallback net —
+  anything they catch later becomes a lesson (see /procoder:merge's
+  reflection step).
 
 3. Fill .procoder/github/PULL_REQUEST_TEMPLATE.md section by section from that
    diff. If the template is missing, get it via `launcher.sh templates`,

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -42,8 +42,21 @@ downstream reviewer's:
   verbatim, the branch diff, and the instruction to report findings as
   file:line, what breaks, and the fix, ending with a severity-counted
   verdict or exactly "Nothing found — open the PR."
-- Fix every Critical/Important finding (commit them), re-run
-  `launcher.sh check`, and only then continue. Downstream bot reviews
+- Give that same agent the SECOND lens in the same pass: the five
+  /procoder:simplify tags (delete, stdlib, native, yagni, shrink) over
+  the same diff, reported separately from the correctness findings, each
+  with its mandatory replacement, and a real null result when the diff
+  has nothing to cut. One read, two verdicts — the rubric asks whether
+  the code is right, this asks whether it should exist at all, and a
+  diff deserves both before anyone else spends attention on it. Scope it
+  to the DIFF: the repo-wide sweep answers about code this change never
+  touched, and it belongs before a tag (/procoder:release), not on every
+  pull request.
+- Fix every Critical/Important finding (commit them), decide each cut —
+  taking it or saying why not, P-CONTROL — re-run `launcher.sh check`,
+  and only then continue. Cuts land BEFORE the PR opens: changing code
+  after a review invalidates the review you just received, and every
+  post-green commit costs another full CI run. Downstream bot reviews
   are the fallback net — anything they catch later becomes a lesson
   (see /procoder:merge's reflection step).
 

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -42,23 +42,23 @@ downstream reviewer's:
   verbatim, the branch diff, and the instruction to report findings as
   file:line, what breaks, and the fix, ending with a severity-counted
   verdict or exactly "Nothing found — open the PR."
-- Give that same agent the SECOND lens in the same pass: the five
-  /procoder:simplify tags (delete, stdlib, native, yagni, shrink) over
-  the same diff, reported separately from the correctness findings, each
-  with its mandatory replacement, and a real null result when the diff
-  has nothing to cut. One read, two verdicts — the rubric asks whether
-  the code is right, this asks whether it should exist at all, and a
-  diff deserves both before anyone else spends attention on it. Scope it
-  to the DIFF: the repo-wide sweep answers about code this change never
-  touched, and it belongs before a tag (/procoder:release), not on every
-  pull request.
+- Give that same agent the SECOND lens in the same pass, quoted from
+  /procoder:simplify the way the rubric is quoted: the five tags with
+  their definitions, the one-line finding format
+  `<file>:L<line>: <tag> <what>. <replacement>.`, the never-invent-a-
+  finding rule, and the exact null result `Lean already. Ship.` A lens
+  dispatched by name only comes back as prose with no replacements,
+  which is the hedging that format exists to prevent. Scope it to the
+  DIFF — the repo sweep belongs to /procoder:release.
+- Order the two reports: the simplify findings first, the correctness
+  verdict as the LAST line of the response, so the verdict is never
+  buried behind a score line.
 - Fix every Critical/Important finding (commit them), decide each cut —
   taking it or saying why not, P-CONTROL — re-run `launcher.sh check`,
-  and only then continue. Cuts land BEFORE the PR opens: changing code
-  after a review invalidates the review you just received, and every
-  post-green commit costs another full CI run. Downstream bot reviews
-  are the fallback net — anything they catch later becomes a lesson
-  (see /procoder:merge's reflection step).
+  and only then continue. Cuts land before the PR opens: a change made
+  after a review invalidates the review. Downstream bot reviews are the
+  fallback net — anything they catch later becomes a lesson (see
+  /procoder:merge's reflection step).
 
 3. Fill .procoder/github/PULL_REQUEST_TEMPLATE.md section by section from that
    diff. If the template is missing, get it via `launcher.sh templates`,

--- a/commands/release.md
+++ b/commands/release.md
@@ -12,15 +12,14 @@ The launcher is: "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
 2. Before the first fix, run /procoder:simplify over the whole repo
-   (`repo`): a tag is the moment the accumulated shape of the code
-   ships, and the whole-tree question — what should not exist — has no
-   other owner. Take the cuts you agree with, say why not for the rest,
-   and let the controller re-judge the tree afterwards. It reports; you
-   decide (P-CONTROL).
-3. Fix everything it lists — bump the files, write the changelog entry,
-   commit — then rerun until it answers ready.
-4. When ready it prints the tag command; run that command yourself and
-   push the tag. The binary never tags (P-CONTROL).
+   (`repo`) — the whole-tree question has no other owner. Take the cuts
+   you agree with, say why not for the rest.
+3. Fix everything the release controller listed — bump the files, write
+   the changelog entry, commit — then rerun `launcher.sh release` until
+   it answers ready.
+4. When the release controller answers ready it prints the tag command;
+   run that command yourself and push the tag. The binary never tags
+   (P-CONTROL).
 5. A repo without `[release] files` in .procoder/config.toml gets an
    honest "verified nothing" on the version-sync leg — set the list so
    the check has teeth.

--- a/commands/release.md
+++ b/commands/release.md
@@ -11,10 +11,16 @@ The launcher is: "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"
    one pass: every file in `[release] files` carries the version, the
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
-2. Fix everything it lists — bump the files, write the changelog entry,
+2. Before the first fix, run /procoder:simplify over the whole repo
+   (`repo`): a tag is the moment the accumulated shape of the code
+   ships, and the whole-tree question — what should not exist — has no
+   other owner. Take the cuts you agree with, say why not for the rest,
+   and let the controller re-judge the tree afterwards. It reports; you
+   decide (P-CONTROL).
+3. Fix everything it lists — bump the files, write the changelog entry,
    commit — then rerun until it answers ready.
-3. When ready it prints the tag command; run that command yourself and
+4. When ready it prints the tag command; run that command yourself and
    push the tag. The binary never tags (P-CONTROL).
-4. A repo without `[release] files` in .procoder/config.toml gets an
+5. A repo without `[release] files` in .procoder/config.toml gets an
    honest "verified nothing" on the version-sync leg — set the list so
    the check has teeth.

--- a/commands/release.md
+++ b/commands/release.md
@@ -12,8 +12,7 @@ The launcher is: "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"
    changelog has its entry, the working tree is clean, the gate is
    clean, and the suite is green under [test] policy.
 2. Before the first fix, run /procoder:simplify over the whole repo
-   (`repo`) — the whole-tree question has no other owner. Take the cuts
-   you agree with, say why not for the rest.
+   (`repo`): take the cuts you agree with, say why not for the rest.
 3. Fix everything the release controller listed — bump the files, write
    the changelog entry, commit — then rerun `launcher.sh release` until
    it answers ready.

--- a/commands/simplify.md
+++ b/commands/simplify.md
@@ -15,6 +15,14 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `launcher.sh index unused` and `launcher.sh maintain` as starting
 evidence, then read.
 
+The two scopes are different jobs on different clocks. The DIFF pass runs
+before every pull request, inside /procoder:pr's pre-PR review, where it
+answers about the code you just wrote. The REPO sweep runs before a tag,
+inside /procoder:release: it reports on code the current change never
+touched, so attaching it to a pull request buries that diff's own
+findings under a backlog of pre-existing ones — and a report nobody can
+act on today is a report nobody reads tomorrow.
+
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:
 

--- a/commands/simplify.md
+++ b/commands/simplify.md
@@ -15,10 +15,7 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `launcher.sh index unused` and `launcher.sh maintain` as starting
 evidence, then read.
 
-The DIFF pass runs before every pull request, inside /procoder:pr's
-pre-PR review. The REPO sweep runs before a tag, inside
-/procoder:release — on a pull request it would bury that diff's own
-findings under pre-existing ones.
+The diff pass runs before every pull request; the repo sweep before a tag.
 
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:

--- a/commands/simplify.md
+++ b/commands/simplify.md
@@ -15,13 +15,10 @@ staged). With `repo` (or a path) in the arguments, sweep that whole scope
 — use `launcher.sh index unused` and `launcher.sh maintain` as starting
 evidence, then read.
 
-The two scopes are different jobs on different clocks. The DIFF pass runs
-before every pull request, inside /procoder:pr's pre-PR review, where it
-answers about the code you just wrote. The REPO sweep runs before a tag,
-inside /procoder:release: it reports on code the current change never
-touched, so attaching it to a pull request buries that diff's own
-findings under a backlog of pre-existing ones — and a report nobody can
-act on today is a report nobody reads tomorrow.
+The DIFF pass runs before every pull request, inside /procoder:pr's
+pre-PR review. The REPO sweep runs before a tag, inside
+/procoder:release — on a pull request it would bury that diff's own
+findings under pre-existing ones.
 
 Every finding is one line, with a mandatory replacement — a finding
 without a replacement is hedging, not reviewing:

--- a/docs/quality-chain.md
+++ b/docs/quality-chain.md
@@ -148,7 +148,9 @@ a capitalised local constant is exported in Go and in no other language
 ## Why escapes have to close their class
 
 Before a PR exists, the pre-PR self-review reads the diff with fresh
-context against `.procoder/github/REVIEW.md`. Anything that still
+context against `.procoder/github/REVIEW.md`, and with the five
+simplification tags in the same pass — one asks whether the code is
+right, the other whether it should exist. Anything that still
 escapes to a downstream reviewer triggers the reflection step: name the
 layer that should have caught it, adapt that layer in the same PR, and
 record it.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -124,6 +124,12 @@ The skill summarises the real diff, fills the template from
 `.procoder/github/`, scrubs attribution, verifies the blast radius with
 `procoder index impact`, and shows you everything before `gh pr create`.
 
+Before any of that it dispatches a fresh-context reviewer over the diff
+with two lenses: the correctness rubric in `.procoder/github/REVIEW.md`,
+and the five simplification tags — what should not exist. Critical and
+Important findings are fixed, and cuts decided, before the PR opens: a
+change made after a review invalidates the review.
+
 Keep the title at 72 characters or fewer — it becomes the squash-commit
 subject.
 
@@ -180,6 +186,11 @@ That retro is the price of the next `sprint open`.
 Verifies the version across `[release] files`, the changelog entry, a
 clean tree, the gate, and the suite — every failure listed at once. On
 success it prints the `git tag` command for you to run.
+
+The release flow also runs the simplification sweep over the whole
+repository, which is the one moment it has an owner: a tag ships the
+accumulated shape of the code, not just the last change. Per-PR the
+same review is scoped to the diff.
 
 **It tags nothing itself.**
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -127,8 +127,7 @@ The skill summarises the real diff, fills the template from
 Before any of that it dispatches a fresh-context reviewer over the diff
 with two lenses: the correctness rubric in `.procoder/github/REVIEW.md`,
 and the five simplification tags — what should not exist. Critical and
-Important findings are fixed, and cuts decided, before the PR opens: a
-change made after a review invalidates the review.
+Important findings are fixed, and cuts decided, before the PR opens.
 
 Keep the title at 72 characters or fewer — it becomes the squash-commit
 subject.
@@ -188,9 +187,8 @@ clean tree, the gate, and the suite — every failure listed at once. On
 success it prints the `git tag` command for you to run.
 
 The release flow also runs the simplification sweep over the whole
-repository, which is the one moment it has an owner: a tag ships the
-accumulated shape of the code, not just the last change. Per-PR the
-same review is scoped to the diff.
+repository: a tag ships the accumulated shape of the code, not just the
+last change.
 
 **It tags nothing itself.**
 

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -159,6 +159,7 @@ var mdLink = regexp.MustCompile(`!?\[[^\]]*\]\(([^)\s]+)[^)]*\)`)
 func CheckFile(root, file string) []gitx.Finding {
 	out := RelativeRefs(root, file)
 	out = append(out, MermaidBlocks(root, file)...)
+	out = append(out, UnclosedSpans(root, file)...)
 	return out
 }
 

--- a/internal/docs/spans.go
+++ b/internal/docs/spans.go
@@ -1,0 +1,74 @@
+package docs
+
+import (
+	"os"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// UnclosedSpans finds inline code spans a paragraph opens and never closes.
+//
+// Markdown renders an unmatched backtick as a literal backtick, so the text
+// after it loses its formatting silently and the reader sees prose where a
+// name was meant. It escaped a rubric that names the case in words ("code
+// spans unbroken") and a fresh-context review applying that rubric: the eye
+// reads the intent and skips the missing character. Counting is the one
+// thing a machine does better here.
+//
+// The unit is the PARAGRAPH, not the line: CommonMark lets a span wrap, and
+// `procoder\ntemplates` is one span rendered with a space, not a defect.
+// Counting per line would flag every wrapped name in the repository — 46 of
+// them here, all correct — which is how a check earns its way into being
+// ignored. Fenced blocks are skipped whole: a fence is not a span, and the
+// code inside one is nobody's prose.
+//
+// Information, not blocking: a deliberate literal backtick is legitimate,
+// if rare.
+func UnclosedSpans(root, file string) []gitx.Finding {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil
+	}
+	var out []gitx.Finding
+	inFence := false
+	ticks, start := 0, 0
+	flush := func() {
+		if ticks%2 == 1 {
+			out = append(out, gitx.Finding{
+				File: file, Line: start,
+				Message: "code span opened and never closed in this paragraph — Markdown renders the rest as prose (docs)",
+			})
+		}
+		ticks, start = 0, 0
+	}
+	for i, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			// A fence boundary also ends the paragraph before it.
+			if !inFence {
+				flush()
+			} else {
+				ticks, start = 0, 0
+			}
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			flush()
+			continue
+		}
+		// Doubled backticks open and close a span that itself contains one,
+		// so they play no part in the odd/even question.
+		if n := strings.Count(strings.ReplaceAll(line, "``", ""), "`"); n > 0 {
+			if ticks == 0 {
+				start = i + 1
+			}
+			ticks += n
+		}
+	}
+	flush()
+	return out
+}

--- a/internal/docs/spans_test.go
+++ b/internal/docs/spans_test.go
@@ -1,0 +1,68 @@
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMD(t *testing.T, body string) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	p := filepath.Join(root, "page.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, p
+}
+
+// The defect: a paragraph opens a span and never closes it, so Markdown
+// renders a literal backtick and the rest of the sentence loses its
+// formatting. A bot reviewer caught one of these in a pull request whose
+// rubric names the case in words and whose fresh-context review applied
+// that rubric — the eye reads the intent and skips the missing character.
+// proved by: dropped the %2 test — the unclosed paragraph then reports
+// nothing and the check exists for decoration.
+func TestAnUnclosedSpanIsReported(t *testing.T) {
+	root, p := writeMD(t, "# page\n\nthe finding is `delete: speculative\nplaceholder and nothing closes it.\n")
+	got := UnclosedSpans(root, p)
+	if len(got) != 1 {
+		t.Fatalf("one unclosed span, got %d: %+v", len(got), got)
+	}
+	if got[0].Line != 3 {
+		t.Errorf("the finding points at the line that opened it, got %d", got[0].Line)
+	}
+	if got[0].Blocking {
+		t.Error("a deliberate literal backtick is legitimate — this informs, it does not block")
+	}
+}
+
+// The false positive that would have made the check worthless: CommonMark
+// lets a span wrap, and a wrapped name is one span rendered with a space.
+// Counting per line flagged 46 of these in this repository, every one of
+// them correct — which is how a check earns its way into being ignored.
+// proved by: counted per line instead of per paragraph — every wrapped
+// span in the tree becomes a finding.
+func TestAWrappedSpanIsNotUnclosed(t *testing.T) {
+	root, p := writeMD(t, "# page\n\nrun `procoder\ntemplates` to print the defaults.\n\nand `one` more.\n")
+	if got := UnclosedSpans(root, p); len(got) != 0 {
+		t.Errorf("a span may wrap: %+v", got)
+	}
+}
+
+// Fenced code is not prose, and a fence boundary ends the paragraph before
+// it — otherwise a shell snippet full of backticks reports the page.
+func TestFencedCodeIsNotProse(t *testing.T) {
+	root, p := writeMD(t, "# page\n\n```sh\necho `date`\nunbalanced ` here\n```\n\nplain `text` after.\n")
+	if got := UnclosedSpans(root, p); len(got) != 0 {
+		t.Errorf("a fence is not a span: %+v", got)
+	}
+}
+
+// Doubled backticks are a span that contains a backtick, not two spans.
+func TestDoubledBackticksAreOneSpan(t *testing.T) {
+	root, p := writeMD(t, "# page\n\nwrite ``a `b` c`` when the name has one.\n")
+	if got := UnclosedSpans(root, p); len(got) != 0 {
+		t.Errorf("doubled backticks close themselves: %+v", got)
+	}
+}


### PR DESCRIPTION
## What

The pre-PR review now carries two lenses instead of one. The fresh-context
reviewer it already dispatches gets the five simplification tags alongside
the correctness rubric, over the same diff, reported separately — one read,
two verdicts. The repo-wide sweep moves to `/procoder:release`, before a tag.

## Why

`/procoder:pr` dispatches a reviewer against `.procoder/github/REVIEW.md`,
which hunts correctness: error paths, traversal, output paths, guards that do
not guard. Nothing in the flow asked the other question — should this code
exist at all — until somebody thought to run `/procoder:simplify` by hand.

On #75 that happened after the PR was open, reviewed and green. Two of the
findings were in the branch's own new code, so fixing them cost two extra
commits and a fourth CI run on a pull request that was already finished. The
review that PR had received no longer described the code it had reviewed.

## How

`commands/pr.md` step 2b gains the second lens, scoped to the branch diff,
each finding carrying the mandatory replacement and a real null result when
there is nothing to cut. The instruction says plainly why the timing matters:
changing code after a review invalidates the review you just received, and
every post-green commit costs another full CI run.

`commands/simplify.md` names the two scopes as different jobs on different
clocks. `commands/release.md` gives the whole-tree sweep an owner and a
clock: step 2, before the first fix, because a tag is the moment the
accumulated shape of the code ships.

The decision a reviewer may want to question: the diff pass is deliberately
NOT repo-wide. A per-PR sweep would bury the diff's own findings under a
backlog of pre-existing ones — today's sweep of this repository found four
hand-rolled `firstLine` helpers, none of them related to any change in
flight. That backlog is real and now has a scheduled owner; it is not this
pull request's job to carry it.

## Testing

- `go test ./...` green; `procoder check` 0 blocking.
- Twin parity: all six OpenCode and Kilo twins regenerated through the
  generation rule, not hand-copied — `TestOpenCodeCommandParity` and
  `TestKiloCommandParity` green. (An earlier hand-copy in this session was
  caught by exactly that test.)
- The new step was exercised on this branch before this PR was opened,
  which is the first thing it has ever reviewed.
- Trial on a deliberately padded diff — an interface with one
  implementation, a constructor for an empty struct, and a single-use
  helper — surfaced all three with replacements and a `net: -24 lines
  possible.` score line. The same lens over this branch's own diff reports
  its null result rather than inventing findings.

## Notes for the reviewer

Three instruction files and their six generated twins; the twins are
mechanical copies, so reading `commands/pr.md`, `commands/simplify.md` and
`commands/release.md` is reading the whole change.

`commands/release.md` renumbered its steps to fit the new step 2 — worth a
glance that nothing references the old numbers.

This is prompt text, not code: it changes what an agent is instructed to do,
and the only test that can exist for it is the trial described above.
