### PR TITLE
fix: launcher resolves the windows binary under git bash, msys and cygwin

### DIFF
--- a/hooks/launcher.sh
+++ b/hooks/launcher.sh
@@ -6,12 +6,14 @@
 # architecture and execs it with everything passed through — argv, stdin,
 # stdout — so hooks.json and the skills only ever name this one path.
 set -u
+ext=""
 
 dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 
 case "$(uname -s)" in
 Darwin) os=darwin ;;
 Linux) os=linux ;;
+MINGW* | MSYS* | CYGWIN*) os=windows ext=".exe" ;;
 *)
 	echo "procoder: unsupported OS $(uname -s)" >&2
 	exit 1
@@ -27,7 +29,7 @@ x86_64 | amd64) arch=amd64 ;;
 	;;
 esac
 
-bin="$dir/dist/$os-$arch/procoder"
+bin="$dir/dist/$os-$arch/procoder$ext"
 if [ ! -x "$bin" ]; then
 	echo "procoder: no binary for $os/$arch at $bin — reinstall the plugin" >&2
 	exit 1


### PR DESCRIPTION
## What

`hooks/launcher.sh` learns the MSYS/MinGW/Cygwin `uname -s` values and the
`.exe` suffix, so the `dist/windows-amd64/procoder.exe` that already ships
is reachable. Three lines added, one changed; no manifest touched.

## Why

Fixes #78. Claude Code runs hook commands through Git Bash on Windows, so
`launcher.sh` is what executes — and its OS switch mapped only `Darwin` and
`Linux`. Under Git Bash `uname -s` is `MINGW64_NT-10.0-26200`, which fell to
the catch-all and exited 1. On a fresh Windows install that means hook-error
noise on every SessionStart, Stop, PreCompact, PreToolUse and PostToolUse
event, and not a single working command.

`hooks/launcher.cmd` is correct and ships, but nothing references it — all
five hooks in `hooks/claude-hooks.json` and every file under `commands/`
name `launcher.sh`.

## How

The fix issue #78 proposes, unchanged:

```sh
ext=""
case "$(uname -s)" in
Darwin) os=darwin ;;
Linux) os=linux ;;
MINGW* | MSYS* | CYGWIN*) os=windows ext=".exe" ;;
...
bin="$dir/dist/$os-$arch/procoder$ext"
```

Teaching the launcher rather than re-pointing the manifests keeps the single
path the design contract asks for — `launcher.cmd` stays for hosts that
invoke cmd directly.

## Testing

Verified on real Windows 11 (Git Bash, `uname -s` = `MINGW64_NT-10.0-26200`),
against the plugin as installed from the marketplace.

Before — every hook path:

```
$ hooks/launcher.sh principles --hook
procoder: unsupported OS MINGW64_NT-10.0-26200
exit=1
```

After:

```
$ hooks/launcher.sh principles --hook
# Engineering principles (Procoder)
exit=0
```

Also round-tripped the change as a patch — `git checkout` to restore the
failure, `git apply` to restore the pass — to confirm nothing else in the
script depends on it.

**I did not run `go test ./...` or `go run ./cmd/procoder check`: there is no
Go toolchain on this machine.** The change is shell-only and touches no Go
code, so nothing in the suite should move, but I would rather say that
plainly than claim a green run I did not see.

## Notes for the reviewer

**No test ships with this, and CONTRIBUTING asks for one.** I wrote one and
then pulled it, because I could not compile it and did not want to hand you
an unrun test. What it did: read `dist/` in `internal/portability`, and
assert every `<os>-<arch>` target it finds is reachable from the launcher's
`uname` switch — so a future `dist/` target cannot ship unreachable, which is
the general form of this bug. Happy to push it if you want it; it belongs in
`internal/portability` alongside the other shipped-file invariants, and CI
would be its first real run either way.

Two things from #78 this deliberately leaves alone:

- `dist/windows-arm64/` still does not exist while `launcher.cmd` selects it
  on ARM64. With this patch `launcher.sh` reaches the same dead end via the
  "no binary" error rather than "unsupported OS" — a better message, but the
  ship-it-or-drop-the-branch call is yours.
- The `launcher.cmd` / `launcher.sh` split stays as is.

The branch is LF-only and matches the file's existing endings; the diff is
genuinely 3 insertions and 1 deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
