### PR TITLE
fix: pin the Go toolchain so the same commit builds the same way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 gitleaks:allow
+      # v6 is the first major that reads go.mod's toolchain directive; v5
+      # matched only the `go` line and installed the newest patch of it, so
+      # the pin in go.mod would have been ignored here. v6+ also exports
+      # GOTOOLCHAIN=local, so no `go` command in the job can quietly fetch
+      # a different compiler than the one this step installed.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7 gitleaks:allow
         with:
           go-version-file: go.mod
       - name: gofmt is clean
@@ -52,10 +57,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 gitleaks:allow
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7 gitleaks:allow
         with:
           go-version-file: go.mod
       - name: install the tools the gate needs
+        env:
+          # setup-go exports GOTOOLCHAIN=local so nothing drifts off the pin,
+          # but these are other people's modules: gopls@latest already
+          # declares go 1.26, and `local` makes that a hard install failure
+          # instead of a toolchain fetch. The pin governs what compiles
+          # procoder; it has no business governing the linters.
+          GOTOOLCHAIN: auto
         run: |
           go build -o /usr/local/bin/procoder ./cmd/procoder
           # the runner's azure apt mirrors die for minutes at a time (two gate

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module procoder
 
 go 1.23
+
+// A bare `go 1.23` is a floor, not a version: setup-go reads go.mod and
+// installs whatever the newest 1.23.x is on the day the job runs, so the
+// same commit builds with different compilers weeks apart. Patch releases
+// change codegen and vet, and Go stamps the toolchain into the binary, so
+// a rebuilt dist/ binary stops matching the committed one for no reason
+// the source can explain. Bumping this is a commit, not a Tuesday.
+toolchain go1.23.12


### PR DESCRIPTION
## What

`go.mod` gains `toolchain go1.23.12`, and both `setup-go` steps read it through `go-version-file: go.mod`.

## Why

A bare `go 1.23` is a floor, not a version: setup-go installs whatever the newest 1.23.x is on the day the job runs, so the same commit builds with different compilers weeks apart. Patch releases change codegen and vet, and Go stamps the toolchain into the binary — for a repository that commits its own binaries, that is a difference users execute.

## How

The pin lives in one place and both consumers derive from it, which also governs a developer's machine where a workflow says nothing at all. An explicit `go-version:` in the workflow would drift the moment someone edits one of the two steps and not the other.

**The obvious version of this fix does not work.** The repository pinned setup-go at v5.6.0, whose `parseGoVersionFile` matches only the `go` line — the `toolchain` directive is invisible to it, so adding the directive alone would have left CI drifting exactly as before, silently. v6 is the first major that reads it; this pins v7.0.0 (`b7ad1dad…`, verified against the tag). v6+ also exports `GOTOOLCHAIN=local`, so no `go` command in the job can quietly fetch another compiler.

One consequence needed handling: `GOTOOLCHAIN=local` would break the gate job, which installs third-party tools at `@latest` and `gopls` now declares `go 1.26`. That step alone sets `GOTOOLCHAIN: auto` — the pin governs what compiles procoder, not what compiles the linters.

## Testing

`go version` locally is go1.26.3; `go build ./...` and `go test ./...` pass against the pin. `procoder ci` reports 0 findings before and after. `actionlint` passes on the modified workflow. The pinned SHA was checked against `actions/setup-go`'s v7.0.0 tag rather than trusted.

## Notes for the reviewer

Two files. The judgement worth questioning is the v5→v7 bump: it is a major version jump made to obtain behaviour the fix depends on, and it is what makes the `GOTOOLCHAIN` exception in the gate job necessary.