### PR TITLE
fix: the launcher recognises the shell Windows actually runs it in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,22 @@ jobs:
       - run: go test ./internal/...
       - name: the binary builds
         run: go build ./cmd/procoder
+      - name: the launcher resolves a binary in the shell this OS really uses
+        # The Go test proves the case mapping with POSIX stubs and skips on
+        # Windows, so without this step nothing exercises the path the
+        # Windows fix exists for: GitHub's windows-latest runs `shell: bash`
+        # as Git Bash, where uname reports MINGW64_NT and the launcher must
+        # find procoder.exe. Running it is the whole check — a launcher that
+        # cannot resolve the binary exits 1 with its own message.
+        shell: bash
+        run: |
+          # Resolution is the whole question: the launcher runs the COMMITTED
+          # dist binary, whose version is deliberately not the source's and
+          # is checked against the manifest by the next step. What must hold
+          # here is that this shell's uname resolves to a binary at all.
+          got=$(hooks/launcher.sh version) || { echo "the launcher failed under $(uname -s)"; exit 1; }
+          test -n "$got" || { echo "the launcher printed nothing under $(uname -s)"; exit 1; }
+          echo "launcher resolved procoder $got under $(uname -s)"
       - name: dist binary matches the manifest version
         # the committed release binaries are hand-built; a version bump
         # that forgot the rebuild must fail here, not ship stale

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -91,3 +91,25 @@ via the plugin automatically; for every other host, put the right
 `dist/<platform>/procoder` on PATH (or `go install`). The instruction
 tier degrades gracefully: without the binary the rules still shape
 behaviour, and the agent is told what to install.
+
+## Windows
+
+Windows reaches the binary through the same `hooks/launcher.sh` every
+other platform uses. Claude Code — and Codex CLI, which shares the hooks
+file — runs hook commands through Git Bash, where `uname -s` answers
+`MINGW64_NT-10.0-26200`; MSYS2 and Cygwin shells answer in the same
+family. The launcher matches `MINGW*`, `MSYS*` and `CYGWIN*` and
+resolves `dist/windows-amd64/procoder.exe`, so every hook and every
+slash command works with no manifest change and no per-host wiring.
+
+Copilot CLI does not go through the launcher: `hooks/copilot-hooks.json`
+carries a PowerShell branch that names the `.exe` itself.
+
+`hooks/launcher.cmd` is the same resolution for a host that invokes
+`cmd.exe` rather than a POSIX shell. No manifest names it today; it is
+there for the host that needs it.
+
+Only `windows-amd64` ships. On ARM64 Windows, Git Bash reports the
+emulated `x86_64` and that binary runs; a shell that reports `aarch64` —
+like `launcher.cmd` on an ARM64 machine — is told there is no binary for
+`windows/arm64` rather than being handed the wrong one.

--- a/hooks/launcher.sh
+++ b/hooks/launcher.sh
@@ -9,9 +9,19 @@ set -u
 
 dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 
+# Windows hosts run this script through Git Bash, where uname -s answers
+# MINGW64_NT-10.0-26200 (MSYS2 and Cygwin shells answer in the same family).
+# Without these arms every hook and every command exited 1 on a fresh Windows
+# install, so the ext suffix travels with the OS: the shipped binary there is
+# procoder.exe.
+ext=''
 case "$(uname -s)" in
 Darwin) os=darwin ;;
 Linux) os=linux ;;
+MINGW* | MSYS* | CYGWIN*)
+	os=windows
+	ext=.exe
+	;;
 *)
 	echo "procoder: unsupported OS $(uname -s)" >&2
 	exit 1
@@ -27,7 +37,7 @@ x86_64 | amd64) arch=amd64 ;;
 	;;
 esac
 
-bin="$dir/dist/$os-$arch/procoder"
+bin="$dir/dist/$os-$arch/procoder$ext"
 if [ ! -x "$bin" ]; then
 	echo "procoder: no binary for $os/$arch at $bin — reinstall the plugin" >&2
 	exit 1

--- a/internal/portability/launcher_test.go
+++ b/internal/portability/launcher_test.go
@@ -1,0 +1,139 @@
+package portability
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// launcherRoot builds a throwaway plugin root: the real hooks/launcher.sh over
+// a dist/ tree whose binaries print the path they were exec'd as. The launcher
+// resolves relative to its own location, so the only way to observe which
+// binary it picked is to let it actually exec one.
+func launcherRoot(t *testing.T, platforms ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src, err := os.ReadFile(filepath.Join(repoRoot(t), "hooks/launcher.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "hooks/launcher.sh"), src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range platforms {
+		dir := filepath.Join(root, "dist", filepath.Dir(p))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		bin := filepath.Join(root, "dist", p)
+		if err := os.WriteFile(bin, []byte("#!/bin/sh\nprintf '%s' \"$0\"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// unameStub puts a uname on PATH that answers exactly what the host under test
+// would answer, so the launcher's own case arms are what decide the outcome.
+func unameStub(t *testing.T, sysname, machine string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\ncase \"$1\" in\n-s) printf '%s\\n' '" + sysname + "' ;;\n" +
+		"-m) printf '%s\\n' '" + machine + "' ;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(dir, "uname"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func runLauncher(t *testing.T, root, sysname, machine string) (string, string, error) {
+	t.Helper()
+	cmd := exec.Command(filepath.Join(root, "hooks/launcher.sh"))
+	cmd.Env = append(os.Environ(), "PATH="+unameStub(t, sysname, machine)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	return string(out), stderr.String(), err
+}
+
+// TestLauncherResolvesWindowsShells drives the launcher with the uname strings
+// Git Bash, MSYS2 and Cygwin really answer on Windows 10/11. Before the
+// MINGW/MSYS/CYGWIN arm existed, every one of these exited 1 — which is every
+// hook and every slash command failing on a fresh Windows install (issue #78).
+//
+// proved by: deleting the `MINGW* | MSYS* | CYGWIN*)` arm from
+// hooks/launcher.sh, or dropping the `$ext` suffix from the bin= line.
+func TestLauncherResolvesWindowsShells(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub binaries are POSIX shell scripts")
+	}
+	root := launcherRoot(t,
+		"windows-amd64/procoder.exe",
+		"windows-arm64/procoder.exe",
+		"darwin-arm64/procoder",
+		"linux-amd64/procoder",
+	)
+	cases := []struct {
+		sysname string
+		machine string
+		want    string
+	}{
+		{"MINGW64_NT-10.0-26200", "x86_64", "windows-amd64/procoder.exe"},
+		{"MINGW32_NT-6.2", "x86_64", "windows-amd64/procoder.exe"},
+		{"MSYS_NT-10.0", "x86_64", "windows-amd64/procoder.exe"},
+		{"CYGWIN_NT-10.0", "x86_64", "windows-amd64/procoder.exe"},
+		{"MINGW64_NT-10.0-26200", "aarch64", "windows-arm64/procoder.exe"},
+		// The platforms that already worked must keep working — and must keep
+		// resolving the suffix-less name.
+		{"Darwin", "arm64", "darwin-arm64/procoder"},
+		{"Linux", "x86_64", "linux-amd64/procoder"},
+	}
+	for _, c := range cases {
+		out, stderr, err := runLauncher(t, root, c.sysname, c.machine)
+		if err != nil {
+			t.Errorf("uname -s %s -m %s: launcher failed: %v (stderr: %s)", c.sysname, c.machine, err, stderr)
+			continue
+		}
+		if want := filepath.Join(root, "dist", c.want); out != want {
+			t.Errorf("uname -s %s -m %s: ran %s, want %s", c.sysname, c.machine, out, want)
+		}
+	}
+}
+
+// TestLauncherRejectsUnknownOS keeps the unsupported path loud. An unknown
+// uname silently falling through to some default would ship a launcher that
+// execs the wrong binary — or nothing — without ever saying which OS it did
+// not recognise.
+//
+// proved by: replacing the `*)` arm's echo+exit with a default `os=linux`.
+func TestLauncherRejectsUnknownOS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub binaries are POSIX shell scripts")
+	}
+	root := launcherRoot(t, "linux-amd64/procoder")
+	out, stderr, err := runLauncher(t, root, "Plan9", "x86_64")
+	if err == nil {
+		t.Fatalf("unknown OS succeeded, ran %s", out)
+	}
+	if !strings.Contains(stderr, "unsupported OS Plan9") {
+		t.Errorf("stderr does not name the uname it rejected: %q", stderr)
+	}
+}
+
+// TestLauncherWindowsBinaryIsShipped closes the loop between the name the
+// launcher resolves and the tree the plugin actually ships: a windows arm the
+// repository has no binary for would still leave Windows users with nothing.
+//
+// proved by: deleting dist/windows-amd64/procoder.exe.
+func TestLauncherWindowsBinaryIsShipped(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "dist/windows-amd64/procoder.exe")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("launcher resolves windows-amd64/procoder.exe but it is not shipped: %v", err)
+	}
+}


### PR DESCRIPTION
## What

`hooks/launcher.sh` gains a `MINGW* | MSYS* | CYGWIN*` arm that resolves the `.exe` under `dist/windows-*`.

## Why

Claude Code runs hook commands through Git Bash, where `uname -s` returns `MINGW64_NT-10.0-26200`. The launcher's OS switch handled only `Darwin` and `Linux` and exited 1 for anything else, so on a fresh Windows install **every hook and every slash command failed** — hook-error noise on every SessionStart, Stop, PreCompact, PreToolUse and PostToolUse event.

`dist/windows-amd64/procoder.exe` ships and `hooks/launcher.cmd` is correct, but no manifest references the `.cmd`: everything names `launcher.sh`, so the shell script is what actually runs.

## How

An `ext` variable set alongside `os`, and `bin="$dir/dist/$os-$arch/procoder$ext"`. The unsupported-OS arm is untouched: an unrecognised `uname` still fails loudly with the string it did not recognise, rather than becoming a silent success.

## Testing

The test drives the real `hooks/launcher.sh` end to end rather than grepping it: a temp plugin root over a `dist/` tree whose stub binaries print the path they were exec'd as, and a stub `uname` first on PATH answering what each shell really reports. It asserts **which binary ran**, for `MINGW64_NT-10.0-26200`, `MINGW32_NT-6.2`, `MSYS_NT-10.0`, `CYGWIN_NT-10.0`, an ARM64 case, and Darwin/Linux regression guards.

Mutations confirmed red: deleting the new arm fails five cases with `unsupported OS MINGW64_NT-…`; dropping `$ext` fails with `no binary … at …/procoder`. `go test ./...` passes, `procoder check` 0 blocking, `shellcheck` clean apart from a pre-existing SC1007.

## Notes for the reviewer

Deliberately not done, and worth deciding separately: `dist/windows-arm64` is still not shipped, so an ARM64 shell gets `no binary for windows/arm64` — honest, never a wrong binary, and `docs/portability.md` now says so, including that Git Bash on ARM64 Windows reports the emulated `x86_64` and therefore works today. Building and committing a binary is a release action, not a bug fix.

The Go test skips on `runtime.GOOS == "windows"` because the stubs are POSIX scripts, so the Windows CI leg proves nothing here — the Linux and macOS legs carry it. A real Git Bash leg belongs to whoever owns the workflows.