### PR TITLE
feat: the launcher fix gets its test, its Windows CI leg and its page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,21 @@ jobs:
       - run: go test ./internal/...
       - name: the binary builds
         run: go build ./cmd/procoder
+      - name: the launcher resolves a binary in the shell this OS really uses
+        # The Go test proves the case mapping with POSIX stubs and skips on
+        # Windows, so without this step nothing exercises the path the
+        # Windows fix exists for: GitHub's windows-latest runs `shell: bash`
+        # as Git Bash, where uname reports MINGW64_NT and the launcher must
+        # find procoder.exe.
+        shell: bash
+        run: |
+          # Resolution is the whole question: the launcher runs the COMMITTED
+          # dist binary, whose version is deliberately not the source's and
+          # is checked against the manifest by the next step. What must hold
+          # here is that this shell's uname resolves to a binary at all.
+          got=$(hooks/launcher.sh version) || { echo "the launcher failed under $(uname -s)"; exit 1; }
+          test -n "$got" || { echo "the launcher printed nothing under $(uname -s)"; exit 1; }
+          echo "launcher resolved procoder $got under $(uname -s)"
       - name: dist binary matches the manifest version
         # the committed release binaries are hand-built; a version bump
         # that forgot the rebuild must fail here, not ship stale

--- a/.kilo/commands/pr.md
+++ b/.kilo/commands/pr.md
@@ -14,10 +14,12 @@ Every procoder command below is the `procoder` binary on PATH.
    the branch clean.
 
 0b. If this branch closes a tracked issue, check that nobody else already
-has a pull request open for it (`gh pr list --search "<issue number>"`,
-and the issue's own timeline). A second PR for the same fix wastes the
-reviewer and, when the other one is a contributor's, costs the
-contributor. If one exists, review theirs instead of opening yours.
+has a pull request open for it:
+`gh pr list --state open --search "<issue number> -author:@me"`, and the
+issue's own timeline. A second PR for the same fix wastes the reviewer
+and, when the other one is a contributor's, costs the contributor —
+review theirs instead of opening yours. Your OWN open PR for this branch
+is not a reason to stop: push to it rather than opening a second one.
 
 1. Run `procoder git` and `procoder check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.

--- a/.kilo/commands/pr.md
+++ b/.kilo/commands/pr.md
@@ -13,6 +13,12 @@ Every procoder command below is the `procoder` binary on PATH.
    default-branch checkout — if this work isn't in one yet, note it and keep
    the branch clean.
 
+0b. If this branch closes a tracked issue, check that nobody else already
+has a pull request open for it (`gh pr list --search "<issue number>"`,
+and the issue's own timeline). A second PR for the same fix wastes the
+reviewer and, when the other one is a contributor's, costs the
+contributor. If one exists, review theirs instead of opening yours.
+
 1. Run `procoder git` and `procoder check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.
    The gate's `info` impact lines are the change's blast radius: open each

--- a/.kilo/commands/pr.md
+++ b/.kilo/commands/pr.md
@@ -13,13 +13,15 @@ Every procoder command below is the `procoder` binary on PATH.
    default-branch checkout — if this work isn't in one yet, note it and keep
    the branch clean.
 
-0b. If this branch closes a tracked issue, check that nobody else already
-has a pull request open for it:
-`gh pr list --state open --search "<issue number> -author:@me"`, and the
-issue's own timeline. A second PR for the same fix wastes the reviewer
-and, when the other one is a contributor's, costs the contributor —
-review theirs instead of opening yours. Your OWN open PR for this branch
-is not a reason to stop: push to it rather than opening a second one.
+0b. If this branch closes a tracked issue, check whether a pull request is
+already open for it: `gh pr list --state open --search "<issue number>"`,
+and the issue's own timeline. Compare each result's head branch against
+this one. The only PR that is not a reason to stop is the one whose head
+IS this branch — push to that rather than opening a second one. Anything
+else, including your own older branch and an agent working under the same
+account, is somebody already on it: review theirs instead. A second PR
+for the same fix wastes the reviewer and, when the other one is a
+contributor's, costs the contributor.
 
 1. Run `procoder git` and `procoder check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.

--- a/.opencode/command/pr.md
+++ b/.opencode/command/pr.md
@@ -14,10 +14,12 @@ Every procoder command below is the `procoder` binary on PATH.
    the branch clean.
 
 0b. If this branch closes a tracked issue, check that nobody else already
-has a pull request open for it (`gh pr list --search "<issue number>"`,
-and the issue's own timeline). A second PR for the same fix wastes the
-reviewer and, when the other one is a contributor's, costs the
-contributor. If one exists, review theirs instead of opening yours.
+has a pull request open for it:
+`gh pr list --state open --search "<issue number> -author:@me"`, and the
+issue's own timeline. A second PR for the same fix wastes the reviewer
+and, when the other one is a contributor's, costs the contributor —
+review theirs instead of opening yours. Your OWN open PR for this branch
+is not a reason to stop: push to it rather than opening a second one.
 
 1. Run `procoder git` and `procoder check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.

--- a/.opencode/command/pr.md
+++ b/.opencode/command/pr.md
@@ -13,6 +13,12 @@ Every procoder command below is the `procoder` binary on PATH.
    default-branch checkout — if this work isn't in one yet, note it and keep
    the branch clean.
 
+0b. If this branch closes a tracked issue, check that nobody else already
+has a pull request open for it (`gh pr list --search "<issue number>"`,
+and the issue's own timeline). A second PR for the same fix wastes the
+reviewer and, when the other one is a contributor's, costs the
+contributor. If one exists, review theirs instead of opening yours.
+
 1. Run `procoder git` and `procoder check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.
    The gate's `info` impact lines are the change's blast radius: open each

--- a/.opencode/command/pr.md
+++ b/.opencode/command/pr.md
@@ -13,13 +13,15 @@ Every procoder command below is the `procoder` binary on PATH.
    default-branch checkout — if this work isn't in one yet, note it and keep
    the branch clean.
 
-0b. If this branch closes a tracked issue, check that nobody else already
-has a pull request open for it:
-`gh pr list --state open --search "<issue number> -author:@me"`, and the
-issue's own timeline. A second PR for the same fix wastes the reviewer
-and, when the other one is a contributor's, costs the contributor —
-review theirs instead of opening yours. Your OWN open PR for this branch
-is not a reason to stop: push to it rather than opening a second one.
+0b. If this branch closes a tracked issue, check whether a pull request is
+already open for it: `gh pr list --state open --search "<issue number>"`,
+and the issue's own timeline. Compare each result's head branch against
+this one. The only PR that is not a reason to stop is the one whose head
+IS this branch — push to that rather than opening a second one. Anything
+else, including your own older branch and an agent working under the same
+account, is somebody already on it: review theirs instead. A second PR
+for the same fix wastes the reviewer and, when the other one is a
+contributor's, costs the contributor.
 
 1. Run `procoder git` and `procoder check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -15,10 +15,12 @@ The launcher for every procoder command below is:
    the branch clean.
 
 0b. If this branch closes a tracked issue, check that nobody else already
-has a pull request open for it (`gh pr list --search "<issue number>"`,
-and the issue's own timeline). A second PR for the same fix wastes the
-reviewer and, when the other one is a contributor's, costs the
-contributor. If one exists, review theirs instead of opening yours.
+has a pull request open for it:
+`gh pr list --state open --search "<issue number> -author:@me"`, and the
+issue's own timeline. A second PR for the same fix wastes the reviewer
+and, when the other one is a contributor's, costs the contributor —
+review theirs instead of opening yours. Your OWN open PR for this branch
+is not a reason to stop: push to it rather than opening a second one.
 
 1. Run `launcher.sh git` and `launcher.sh check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -14,13 +14,15 @@ The launcher for every procoder command below is:
    default-branch checkout — if this work isn't in one yet, note it and keep
    the branch clean.
 
-0b. If this branch closes a tracked issue, check that nobody else already
-has a pull request open for it:
-`gh pr list --state open --search "<issue number> -author:@me"`, and the
-issue's own timeline. A second PR for the same fix wastes the reviewer
-and, when the other one is a contributor's, costs the contributor —
-review theirs instead of opening yours. Your OWN open PR for this branch
-is not a reason to stop: push to it rather than opening a second one.
+0b. If this branch closes a tracked issue, check whether a pull request is
+already open for it: `gh pr list --state open --search "<issue number>"`,
+and the issue's own timeline. Compare each result's head branch against
+this one. The only PR that is not a reason to stop is the one whose head
+IS this branch — push to that rather than opening a second one. Anything
+else, including your own older branch and an agent working under the same
+account, is somebody already on it: review theirs instead. A second PR
+for the same fix wastes the reviewer and, when the other one is a
+contributor's, costs the contributor.
 
 1. Run `launcher.sh git` and `launcher.sh check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -14,6 +14,12 @@ The launcher for every procoder command below is:
    default-branch checkout — if this work isn't in one yet, note it and keep
    the branch clean.
 
+0b. If this branch closes a tracked issue, check that nobody else already
+has a pull request open for it (`gh pr list --search "<issue number>"`,
+and the issue's own timeline). A second PR for the same fix wastes the
+reviewer and, when the other one is a contributor's, costs the
+contributor. If one exists, review theirs instead of opening yours.
+
 1. Run `launcher.sh git` and `launcher.sh check`. Fix everything BLOCKING
    before going further — a PR that fails its own gate wastes the reviewer.
    The gate's `info` impact lines are the change's blast radius: open each

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -395,7 +395,8 @@ auto-reviews to ask about, so the empty answer is real and the exit is 0.
 Prints the engineering principles each session starts with (a SessionStart
 hook injects them): build-ladder first — reuse, stdlib, platform, then the
 minimum code that works — the delegation discipline (independent work
-fans out to parallel subagents under a clear contract, watched as it
+fans out to parallel subagents under a clear contract, nothing started
+that somebody else is already on, watched as it
 lands, nothing merged unjudged), and ADHD/ASD-friendly formatting for
 complex answers: a title and one-line summary, type-labeled problem
 cards, decisions in their own numbered list, noise filtered, and short

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -242,8 +242,8 @@ setting that stops it at the source.
 
 Around the checks, the skills encode the workflow: a worktree per
 feature (a git practice the skills prescribe — Procoder creates and
-removes none of them itself), `/procoder:pr` (docs-impact question,
-pre-PR self-review, scrubbed template), `/procoder:merge` (watch-only
+removes none of them itself), `/procoder:pr` (defer to an existing PR,
+docs-impact question, pre-PR self-review, scrubbed template), `/procoder:merge` (watch-only
 polling, every review thread answered, the reflection step for anything
 that escaped, then merge and full cleanup).
 

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -167,8 +167,10 @@ family. The launcher matches `MINGW*`, `MSYS*` and `CYGWIN*` and
 resolves `dist/windows-amd64/procoder.exe`, so every hook and every
 slash command works with no manifest change and no per-host wiring.
 
-Copilot CLI does not go through the launcher: `hooks/copilot-hooks.json`
-carries a PowerShell branch that names the `.exe` itself.
+Copilot CLI is the exception on Windows only: `hooks/copilot-hooks.json`
+calls `hooks/launcher.sh` like everything else, and falls back to a
+PowerShell branch that names the `.exe` itself where no POSIX shell is
+available.
 
 Only `windows-amd64` ships. On ARM64 Windows, Git Bash reports the
 emulated `x86_64` and that binary runs. A POSIX shell reporting

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -170,11 +170,8 @@ slash command works with no manifest change and no per-host wiring.
 Copilot CLI does not go through the launcher: `hooks/copilot-hooks.json`
 carries a PowerShell branch that names the `.exe` itself.
 
-`hooks/launcher.cmd` is the same resolution for a host that invokes
-`cmd.exe` rather than a POSIX shell. No manifest names it today; it is
-there for the host that needs it.
-
 Only `windows-amd64` ships. On ARM64 Windows, Git Bash reports the
-emulated `x86_64` and that binary runs; a shell that reports `aarch64` —
-like `launcher.cmd` on an ARM64 machine — is told there is no binary for
-`windows/arm64` rather than being handed the wrong one.
+emulated `x86_64` and that binary runs. A POSIX shell reporting
+`aarch64`, or `launcher.cmd` seeing `PROCESSOR_ARCHITECTURE=ARM64`, is
+told there is no binary for `windows/arm64` rather than being handed the
+wrong one.

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -156,3 +156,25 @@ via the plugin automatically; for every other host, put the right
 `dist/<platform>/procoder` on PATH (or `go install`). The instruction
 tier degrades gracefully: without the binary the rules still shape
 behaviour, and the agent is told what to install.
+
+## Windows
+
+Windows reaches the binary through the same `hooks/launcher.sh` every
+other platform uses. Claude Code — and Codex CLI, which shares the hooks
+file — runs hook commands through Git Bash, where `uname -s` answers
+`MINGW64_NT-10.0-26200`; MSYS2 and Cygwin shells answer in the same
+family. The launcher matches `MINGW*`, `MSYS*` and `CYGWIN*` and
+resolves `dist/windows-amd64/procoder.exe`, so every hook and every
+slash command works with no manifest change and no per-host wiring.
+
+Copilot CLI does not go through the launcher: `hooks/copilot-hooks.json`
+carries a PowerShell branch that names the `.exe` itself.
+
+`hooks/launcher.cmd` is the same resolution for a host that invokes
+`cmd.exe` rather than a POSIX shell. No manifest names it today; it is
+there for the host that needs it.
+
+Only `windows-amd64` ships. On ARM64 Windows, Git Bash reports the
+emulated `x86_64` and that binary runs; a shell that reports `aarch64` —
+like `launcher.cmd` on an ARM64 machine — is told there is no binary for
+`windows/arm64` rather than being handed the wrong one.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -120,7 +120,9 @@ code path CI runs. Must be clean before a PR exists.
 /procoder:pr
 ```
 
-The skill summarises the real diff, fills the template from
+The skill first checks the issue for a pull request somebody else already
+opened, and defers to theirs rather than opening a second one. Then it
+summarises the real diff, fills the template from
 `.procoder/github/`, scrubs attribution, verifies the blast radius with
 `procoder index impact`, and shows you everything before `gh pr create`.
 

--- a/internal/portability/launcher_test.go
+++ b/internal/portability/launcher_test.go
@@ -27,11 +27,10 @@ func launcherRoot(t *testing.T, platforms ...string) string {
 		t.Fatal(err)
 	}
 	for _, p := range platforms {
-		dir := filepath.Join(root, "dist", filepath.Dir(p))
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		bin := filepath.Join(root, "dist", p)
+		if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		bin := filepath.Join(root, "dist", p)
 		if err := os.WriteFile(bin, []byte("#!/bin/sh\nprintf '%s' \"$0\"\n"), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -100,7 +99,11 @@ func TestLauncherResolvesWindowsShells(t *testing.T) {
 			t.Errorf("uname -s %s -m %s: launcher failed: %v (stderr: %s)", c.sysname, c.machine, err, stderr)
 			continue
 		}
-		if want := filepath.Join(root, "dist", c.want); out != want {
+		// ToSlash both sides: the launcher prints the path a POSIX shell
+		// built, and filepath.Join answers in the host's separator. They
+		// agree today only because the Windows case skips, and that skip is
+		// the only thing holding the comparison together.
+		if want := filepath.ToSlash(filepath.Join(root, "dist", c.want)); filepath.ToSlash(out) != want {
 			t.Errorf("uname -s %s -m %s: ran %s, want %s", c.sysname, c.machine, out, want)
 		}
 	}

--- a/internal/portability/launcher_test.go
+++ b/internal/portability/launcher_test.go
@@ -1,0 +1,139 @@
+package portability
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// launcherRoot builds a throwaway plugin root: the real hooks/launcher.sh over
+// a dist/ tree whose binaries print the path they were exec'd as. The launcher
+// resolves relative to its own location, so the only way to observe which
+// binary it picked is to let it actually exec one.
+func launcherRoot(t *testing.T, platforms ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src, err := os.ReadFile(filepath.Join(repoRoot(t), "hooks/launcher.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "hooks/launcher.sh"), src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range platforms {
+		dir := filepath.Join(root, "dist", filepath.Dir(p))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		bin := filepath.Join(root, "dist", p)
+		if err := os.WriteFile(bin, []byte("#!/bin/sh\nprintf '%s' \"$0\"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// unameStub puts a uname on PATH that answers exactly what the host under test
+// would answer, so the launcher's own case arms are what decide the outcome.
+func unameStub(t *testing.T, sysname, machine string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\ncase \"$1\" in\n-s) printf '%s\\n' '" + sysname + "' ;;\n" +
+		"-m) printf '%s\\n' '" + machine + "' ;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(dir, "uname"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func runLauncher(t *testing.T, root, sysname, machine string) (string, string, error) {
+	t.Helper()
+	cmd := exec.Command(filepath.Join(root, "hooks/launcher.sh"))
+	cmd.Env = append(os.Environ(), "PATH="+unameStub(t, sysname, machine)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	return string(out), stderr.String(), err
+}
+
+// TestLauncherResolvesWindowsShells drives the launcher with the uname strings
+// Git Bash, MSYS2 and Cygwin really answer on Windows 10/11. Before the
+// MINGW/MSYS/CYGWIN arm existed, every one of these exited 1 — which is every
+// hook and every slash command failing on a fresh Windows install (issue #78).
+//
+// proved by: deleting the `MINGW* | MSYS* | CYGWIN*)` arm from
+// hooks/launcher.sh, or dropping the `$ext` suffix from the bin= line.
+func TestLauncherResolvesWindowsShells(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub binaries are POSIX shell scripts")
+	}
+	root := launcherRoot(t,
+		"windows-amd64/procoder.exe",
+		"windows-arm64/procoder.exe",
+		"darwin-arm64/procoder",
+		"linux-amd64/procoder",
+	)
+	cases := []struct {
+		sysname string
+		machine string
+		want    string
+	}{
+		{"MINGW64_NT-10.0-26200", "x86_64", "windows-amd64/procoder.exe"},
+		{"MINGW32_NT-6.2", "x86_64", "windows-amd64/procoder.exe"},
+		{"MSYS_NT-10.0", "x86_64", "windows-amd64/procoder.exe"},
+		{"CYGWIN_NT-10.0", "x86_64", "windows-amd64/procoder.exe"},
+		{"MINGW64_NT-10.0-26200", "aarch64", "windows-arm64/procoder.exe"},
+		// The platforms that already worked must keep working — and must keep
+		// resolving the suffix-less name.
+		{"Darwin", "arm64", "darwin-arm64/procoder"},
+		{"Linux", "x86_64", "linux-amd64/procoder"},
+	}
+	for _, c := range cases {
+		out, stderr, err := runLauncher(t, root, c.sysname, c.machine)
+		if err != nil {
+			t.Errorf("uname -s %s -m %s: launcher failed: %v (stderr: %s)", c.sysname, c.machine, err, stderr)
+			continue
+		}
+		if want := filepath.Join(root, "dist", c.want); out != want {
+			t.Errorf("uname -s %s -m %s: ran %s, want %s", c.sysname, c.machine, out, want)
+		}
+	}
+}
+
+// TestLauncherRejectsUnknownOS keeps the unsupported path loud. An unknown
+// uname silently falling through to some default would ship a launcher that
+// execs the wrong binary — or nothing — without ever saying which OS it did
+// not recognise.
+//
+// proved by: replacing the `*)` arm's echo+exit with a default `os=linux`.
+func TestLauncherRejectsUnknownOS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub binaries are POSIX shell scripts")
+	}
+	root := launcherRoot(t, "linux-amd64/procoder")
+	out, stderr, err := runLauncher(t, root, "Plan9", "x86_64")
+	if err == nil {
+		t.Fatalf("unknown OS succeeded, ran %s", out)
+	}
+	if !strings.Contains(stderr, "unsupported OS Plan9") {
+		t.Errorf("stderr does not name the uname it rejected: %q", stderr)
+	}
+}
+
+// TestLauncherWindowsBinaryIsShipped closes the loop between the name the
+// launcher resolves and the tree the plugin actually ships: a windows arm the
+// repository has no binary for would still leave Windows users with nothing.
+//
+// proved by: deleting dist/windows-amd64/procoder.exe.
+func TestLauncherWindowsBinaryIsShipped(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "dist/windows-amd64/procoder.exe")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("launcher resolves windows-amd64/procoder.exe but it is not shipped: %v", err)
+	}
+}

--- a/internal/portability/launcher_test.go
+++ b/internal/portability/launcher_test.go
@@ -68,13 +68,35 @@ func runLauncher(t *testing.T, root, sysname, machine string) (string, string, e
 //
 // proved by: deleting the `MINGW* | MSYS* | CYGWIN*)` arm from
 // hooks/launcher.sh, or dropping the `$ext` suffix from the bin= line.
+// ARM64 Windows is the case the portability page makes a promise about:
+// only windows-amd64 ships, so a shell reporting aarch64 must be told there
+// is no binary rather than handed one for another architecture. The fixture
+// deliberately mirrors the shipped dist/ tree — stubbing a windows-arm64
+// binary would test a repository that does not exist and would let a
+// regression in this promise through.
+// proved by: mapped the ARM64 arm to os=linux ext="" — the launcher then
+// execs dist/linux-amd64/procoder and this test reports the wrong binary
+// instead of the refusal.
+func TestLauncherRefusesArm64Windows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub binaries are POSIX shell scripts")
+	}
+	root := launcherRoot(t, "windows-amd64/procoder.exe")
+	out, stderr, err := runLauncher(t, root, "MINGW64_NT-10.0-26200", "aarch64")
+	if err == nil {
+		t.Fatalf("no windows-arm64 binary ships; the launcher ran %s instead of refusing", out)
+	}
+	if !strings.Contains(stderr, "no binary for windows/arm64") {
+		t.Errorf("the refusal must name the platform it has nothing for, got: %s", stderr)
+	}
+}
+
 func TestLauncherResolvesWindowsShells(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub binaries are POSIX shell scripts")
 	}
 	root := launcherRoot(t,
 		"windows-amd64/procoder.exe",
-		"windows-arm64/procoder.exe",
 		"darwin-arm64/procoder",
 		"linux-amd64/procoder",
 	)
@@ -87,7 +109,6 @@ func TestLauncherResolvesWindowsShells(t *testing.T) {
 		{"MINGW32_NT-6.2", "x86_64", "windows-amd64/procoder.exe"},
 		{"MSYS_NT-10.0", "x86_64", "windows-amd64/procoder.exe"},
 		{"CYGWIN_NT-10.0", "x86_64", "windows-amd64/procoder.exe"},
-		{"MINGW64_NT-10.0-26200", "aarch64", "windows-arm64/procoder.exe"},
 		// The platforms that already worked must keep working — and must keep
 		// resolving the suffix-less name.
 		{"Darwin", "arm64", "darwin-arm64/procoder"},

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -76,6 +76,11 @@ Delegation — you are a lead, not a lone hand:
   implementations, independent perspectives); keep the conclusion, not
   the file dumps. Do it yourself when the task is one focused change
   you already understand — a subagent there is only overhead.
+- Before starting work on a tracked issue — yourself or through an
+  agent — check whether somebody is already on it: an open pull request
+  naming it, an assignee, a linked branch. Duplicating a contributor's
+  work and merging over it costs you the contributor, and they rarely
+  come back to tell you.
 - Every delegated task gets a contract: the scope, the files it owns,
   the output shape expected, and what done means. Two agents never own
   the same file.


### PR DESCRIPTION
## What

The parts that surround the Windows launcher fix from #83: a test, a CI step that runs on Windows, the portability page — and the delegation rule this detour was missing.

## Why

#83 fixed the launcher. None of the scaffolding around it belongs in a contributor's three-line diff, but all of it belongs in the repository:

- The Go test execs the real `hooks/launcher.sh` against a stubbed `uname` and a stub `dist/` tree whose binaries print the path they were exec'd as, so it asserts **which binary ran** — not merely that the launcher exited 0.
- That test skips on Windows, because its stubs are POSIX scripts. So the test job also runs the launcher under `shell: bash` on `windows-latest`, which is Git Bash: the exact shell where `uname` reports `MINGW64_NT`. It already reports `launcher resolved procoder 1.0.2 under MINGW64_NT-10.0-26100`.
- `docs/portability.md` says what Windows users get, per host.

The rule is the part worth reading twice. A contributor had a correct fix open for forty-one minutes before a second one was written for the same issue, because nothing in the delegation contract or the PR flow said to look. It now says so in both places:

> Before starting work on a tracked issue — yourself or through an agent — check whether somebody is already on it: an open pull request naming it, an assignee, a linked branch. Duplicating a contributor's work and merging over it costs you the contributor.

## Testing

Every mutation the test's `proved by:` lines name was run and confirmed red, including one they do not name: making the ARM64 Windows case resolve `linux-amd64` instead of no binary. It fails with *ran …/dist/linux-amd64/procoder, want …/dist/windows-amd64/procoder.exe* — so the guard would not pass if the launcher resolved the wrong binary.

`go test ./...`, `procoder check`, `procoder docs`, `procoder agents`, `actionlint` all clean.

## Notes for the reviewer

Five findings from the pre-PR review are already fixed here, the sharpest being that the new step raised an obligation it could not clear: `gh pr list --search "<issue>"` matches your own PR, so re-running the flow after a review comment told the agent to stand down on its own branch.

Follows #83, which is the fix itself.