### PR TITLE
fix: a spec with undecided questions is not COMPLETE, and dist/ can be rebuilt

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -491,8 +491,15 @@ never the same as verified, and treating a missing file as permission would
 make deleting one small file the whole attack.
 
 `scripts/build-dist.sh` is what writes both the `dist/` binaries and that
-`SHA256SUMS`. It builds every platform with `CGO_ENABLED=0 -trimpath`, so
-the same Go toolchain produces the same bytes anywhere, and the test suite
+`SHA256SUMS`. It builds every platform with `CGO_ENABLED=0 -trimpath
+-buildvcs=false`, stamping the version it reads from
+`.claude-plugin/plugin.json` — the same manifest CI compares the binaries
+against. `-buildvcs=false` is what makes the output reproducible at all:
+without it Go records the commit hash, the commit time and whether the
+tree was dirty inside every binary, so the same source at two commits
+produces different bytes. The Go toolchain is part of the input too, and
+`go.mod` pins one. With both fixed, two builds of one tree produce
+identical digests, and the test suite
 checks the recorded digests against the committed binaries — a rebuild that
 skipped the script goes red there rather than after a tag is cut.
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -191,6 +191,17 @@ func checkOne(path string, out func(string)) int {
 	if n := len(openRe.FindAllString(text, -1)); n > 0 {
 		gaps = append(gaps, fmt.Sprintf("%d unresolved OPEN: question(s) — resolve each with the user and rewrite it as a decision", n))
 	}
+	// The section itself, not just the marker. Two specs in this repository
+	// carried seven undecided questions between them written as `- [O-1] …`
+	// and were reported COMPLETE, because the rule only recognised the
+	// `OPEN:` prefix — and `backlog seed` refuses anything that is not
+	// COMPLETE, so it would have seeded stories from a design nobody had
+	// finished. A question is unresolved because it is still in the
+	// section, whatever it is called.
+	if q := strings.TrimSpace(textutil.StripComments(textutil.Section(text, "Open questions"))); q != "" {
+		gaps = append(gaps, fmt.Sprintf("Open questions still has %d line(s) — resolve each with the user and rewrite it as a decision, or empty the section",
+			len(strings.Split(q, "\n"))))
+	}
 	criteria := textutil.Section(text, "Acceptance criteria")
 	boxes := checkboxRe.FindAllStringSubmatch(criteria, -1)
 	if strings.Contains(text, "## Acceptance criteria") && len(boxes) == 0 {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -189,3 +189,39 @@ func TestASpecClaimingCompleteWithGapsIsContradicted(t *testing.T) {
 		t.Errorf("the contradiction must be named: %v", *lines)
 	}
 }
+
+// A question is unresolved because it is still in the section, whatever it
+// is called. Two specs in this repository carried seven undecided questions
+// between them, written as `- [O-1] …` rather than `OPEN:`, and were
+// reported COMPLETE — and `backlog seed` refuses anything that is not
+// COMPLETE, so it would have seeded stories from a design nobody had
+// finished.
+// proved by: matched only the OPEN: prefix again — the [O-1] spec then
+// passes and the controller blesses an unfinished design.
+func TestOpenQuestionsAreUnresolvedWhateverTheyAreCalled(t *testing.T) {
+	root := t.TempDir()
+	for _, shape := range []string{
+		"- [O-1] Should answers persist across runs?",
+		"OPEN: should answers persist across runs?",
+		"Should answers persist? Nobody has decided.",
+		"1. persist or re-ask",
+	} {
+		spec := strings.Replace(completeSpec(), "## Open questions\n\n", "## Open questions\n\n"+shape+"\n\n", 1)
+		writeSpec(t, root, "widget", spec)
+		out, lines := collect()
+		if code := Check(root, "widget", out); code != 1 {
+			t.Errorf("an undecided question must block, whatever its shape (%q): exit %d", shape, code)
+		}
+		if !strings.Contains(strings.Join(*lines, "\n"), "Open questions") {
+			t.Errorf("the refusal must name the section (%q): %v", shape, *lines)
+		}
+	}
+
+	// A section holding only the template's comment is resolved: that is how
+	// a finished spec records "none — decisions above".
+	writeSpec(t, root, "widget", completeSpec())
+	out, lines := collect()
+	if code := Check(root, "widget", out); code != 0 {
+		t.Errorf("an empty section is a resolved one: exit %d %v", code, *lines)
+	}
+}

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -23,8 +23,11 @@ export CGO_ENABLED=0
 # the committed binaries against the manifest. A rebuild that omitted it
 # would produce binaries reporting "dev" and fail that check — so the same
 # manifest CI reads is the one this script reads.
-version=$(python3 -c 'import json;print(json.load(open(".claude-plugin/plugin.json"))["version"])')
-if [ -z "$version" ]; then
+# The read is guarded rather than trusted: under `set -e` a missing file, a
+# missing key, broken JSON or no python3 at all kills the script inside the
+# substitution, so the friendly message below would never print and the
+# maintainer would meet a traceback instead of a sentence.
+if ! version=$(python3 -c 'import json;print(json.load(open(".claude-plugin/plugin.json"))["version"])' 2>/dev/null) || [ -z "$version" ]; then
 	echo "cannot read the version from .claude-plugin/plugin.json — refusing to build unstamped binaries" >&2
 	exit 1
 fi

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -18,6 +18,18 @@ cd "$(dirname "$0")/.."
 # committed files instead of taking the committer's word.
 export CGO_ENABLED=0
 
+# The version is part of the binary, not a label beside it: the release
+# stamps it through -ldflags, `procoder version` prints it, and CI checks
+# the committed binaries against the manifest. A rebuild that omitted it
+# would produce binaries reporting "dev" and fail that check — so the same
+# manifest CI reads is the one this script reads.
+version=$(python3 -c 'import json;print(json.load(open(".claude-plugin/plugin.json"))["version"])')
+if [ -z "$version" ]; then
+	echo "cannot read the version from .claude-plugin/plugin.json — refusing to build unstamped binaries" >&2
+	exit 1
+fi
+echo "building procoder $version"
+
 # Go embeds its own version in every binary, so the toolchain is part of the
 # input. Printing it makes a byte difference between two rebuilds traceable
 # to a patch bump rather than to a mystery.
@@ -45,7 +57,15 @@ for target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64 windows-amd64; d
 		ext=.exe
 	fi
 	mkdir -p "dist/$target"
-	GOOS="$os" GOARCH="$arch" go build -trimpath -o "dist/$target/procoder$ext" ./cmd/procoder
+	# -buildvcs=false is what makes this reproducible at all: without it Go
+	# stamps the commit hash, the commit time and whether the tree was dirty
+	# into the binary, so the same source at two commits produces different
+	# bytes and a hash comparison can never pass. -s -w strip the symbol and
+	# DWARF tables, matching how the published binaries have always been
+	# built and cutting roughly a third of the size.
+	GOOS="$os" GOARCH="$arch" go build -trimpath -buildvcs=false \
+		-ldflags "-s -w -X main.version=$version" \
+		-o "dist/$target/procoder$ext" ./cmd/procoder
 	# The names recorded here are the RELEASE ASSET names, not the dist/
 	# paths. This file is published beside the assets and read by
 	# self-upgrade, which knows a download only by the name it asked for; a


### PR DESCRIPTION
## What

Two defects found by checking whether the open issues were really open, rather than reading their titles.

## The spec controller blessed unfinished designs

`interactive-qa` and `marketplace-strategy` were both reported COMPLETE while carrying seven undecided questions between them. The rule matched only the `OPEN:` prefix; both specs write `- [O-1] …`.

That is not cosmetic: `backlog seed` refuses anything that is not COMPLETE, so the controller would have seeded stories from a design nobody had finished — the exact failure the spec gate exists to prevent. A question is unresolved because it is still in the section, whatever it is called. Both specs now correctly report NOT ready.

## The build script could not do what the release flow tells you to do

`scripts/build-dist.sh` never stamped the version, so every binary it produced reported `dev` while the committed ones report `1.0.2`. `commands/release.md` instructs the maintainer to run it before tagging — straight into CI's check that the committed binaries match the manifest. That instruction was a trap.

It also could not reproduce anything. Go records the commit hash, the commit time and whether the tree was dirty inside every binary, so the same source at two commits produces different bytes and a hash comparison can never pass. With `-buildvcs=false` and the version read from the same manifest CI compares against, two builds of one tree produce identical digests — verified by building twice and diffing, not by reasoning about it.

## What this does not fix

`dist/` still does not reproduce from source, for a reason worth recording: the committed binaries were built with **go1.26.3**, while `go.mod` pins `go1.23.12`. Go embeds its own version, so the toolchain is part of the input. Closing that needs one rebuild-`dist/` commit at the next release, or a decision to move the pin — which is #79's remaining scope, not this PR's.

## Testing

`TestOpenQuestionsAreUnresolvedWhateverTheyAreCalled` covers four question shapes and the resolved case; verified red by restoring the prefix-only rule. Determinism verified by two consecutive builds producing identical `SHA256SUMS`. `go test ./...`, `procoder check`, `shellcheck` and `shfmt` clean.

The commit gate blocked the first attempt with a documentation obligation — `docs/commands.md` described the old build flags — which is the gate doing its job on its own author.

Refs #79