### PR TITLE
ci: the pins learn to tell us when they are stale

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # The action pins in .github/workflows/ are SHAs, and a SHA rots the same
+  # way a tool version does — with the difference that it is the one an
+  # attacker would rather move. Dependabot resolves the tag, rewrites the
+  # SHA and keeps the trailing version comment truthful, all of which is
+  # already what every reviewer here recognises.
+  #
+  # The trailing `gitleaks:allow` on each pin must survive the rewrite: the
+  # gate reads a bare 40-hex string as a secret, so a bump that drops the
+  # marker fails the gate rather than merging quietly.
+  #
+  # .github/tool-versions.env is NOT an ecosystem Dependabot knows about;
+  # .github/workflows/bump-tools.yml covers those twelve pins.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/bump-tools.yml
+++ b/.github/workflows/bump-tools.yml
@@ -88,7 +88,16 @@ jobs:
             exit 1
           fi
 
-          base="$GITHUB_REF_NAME"
+          # The default branch, not the ref this run happened to start from:
+          # a workflow_dispatch on a tag or a feature branch would otherwise
+          # open bump PRs against that ref, and the pins it exists to keep
+          # fresh are the default branch's.
+          base=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+          if [ -z "$base" ]; then
+            echo "cannot determine the default branch" >&2
+            exit 1
+          fi
+          git fetch -q origin "$base"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -110,7 +119,11 @@ jobs:
             esac
             # A source that answers 200 with something that is not a version —
             # an error page, a moved field — must not be written into the file.
-            if ! printf '%s' "$latest" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+            # The WHOLE answer must be a version. A prefix match would
+            # accept "1.2.3<garbage>", and `grep -x` would accept a second
+            # line, either of which sed writes straight into the file for the
+            # next gate run to choke on.
+            if ! [[ "$latest" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               record_failure "$key: its source answered '$latest', which is not a version"
               continue
             fi
@@ -133,8 +146,15 @@ jobs:
               continue
             fi
 
-            git checkout -q -B "$branch" "$base"
-            sed -i "s|^$key=.*|$key=$latest|" .github/tool-versions.env
+            if ! git checkout -q -B "$branch" "origin/$base"; then
+              record_failure "$key: could not start a branch from $base"
+              continue
+            fi
+            if ! sed -i "s|^$key=.*|$key=$latest|" .github/tool-versions.env; then
+              record_failure "$key: could not rewrite its line in tool-versions.env"
+              git checkout -qf "$base" || true
+              continue
+            fi
             # One tool per commit and per PR: each bump is independently
             # reviewable and revertable, and its CI verdict is unambiguous —
             # a new golangci-lint ruleset turning the tree red leaves nothing

--- a/.github/workflows/bump-tools.yml
+++ b/.github/workflows/bump-tools.yml
@@ -1,0 +1,180 @@
+name: bump-tools
+on:
+  schedule:
+    # Monday morning UTC. A bump that lands at the start of the week gets
+    # read; one that lands on a Friday sits over the weekend.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+concurrency:
+  # Two runs at once would race each other's force pushes onto the same
+  # bump branches and open duplicate PRs. Never cancelled: a half-finished
+  # run leaves branches pushed with no PR attached to them.
+  group: bump-tools
+  cancel-in-progress: false
+permissions:
+  contents: write # push one bump branch per tool
+  pull-requests: write # open one PR per bump branch
+jobs:
+  bump:
+    # The other half of pinning. A pin never moves on its own, so without
+    # this the gate's tools rot quietly until one is three majors behind or
+    # a fixed CVE is still sitting in CI.
+    #
+    # The action SHAs in .github/workflows/ are NOT this job's business —
+    # .github/dependabot.yml owns those.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
+      - name: one PR per pin that is behind
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+
+          # Nothing here is skipped in silence: a pin whose source cannot be
+          # reached, cannot be parsed, or has no source wired up at all is
+          # recorded and re-raised at the end of the run. A bump workflow that
+          # quietly passes over two of its twelve entries reports success while
+          # leaving them pinned forever — unknown is never the same as current.
+          failed=0
+          record_failure() {
+            echo "::error::$*"
+            failed=1
+          }
+
+          gh_release_tag() { gh api "repos/$1/releases/latest" --jq '.tag_name'; }
+          # --retry covers a registry blipping; -f turns an HTTP error into a
+          # non-zero exit instead of a body that jq would read as garbage, and
+          # jq -e does the same for a 200 that carries no version field.
+          pypi_version() { curl -sSfL --retry 3 "https://pypi.org/pypi/$1/json" | jq -er '.info.version'; }
+          npm_version() { curl -sSfL --retry 3 "https://registry.npmjs.org/$1/latest" | jq -er '.version'; }
+
+          # Each source answers in its own shape, and tool-versions.env records
+          # each pin the way ci.yml consumes it: OSV_SCANNER, SCIP_GO and GOPLS
+          # keep the leading v because the URL or the module path uses the tag
+          # verbatim, the rest drop it because their consumer writes "v${VAR}"
+          # itself. Writing the wrong shape breaks the next gate run, so the
+          # normalisation lives on the same line as the source it undoes.
+          # Exit 3 means no source is wired up, which is a failure of its own.
+          latest_version() {
+            case "$1" in
+            OSV_SCANNER) gh_release_tag google/osv-scanner ;;
+            GOLANGCI_LINT) gh_release_tag golangci/golangci-lint | sed 's|^v||' ;;
+            ACTIONLINT) gh_release_tag rhysd/actionlint | sed 's|^v||' ;;
+            LYCHEE) gh_release_tag lycheeverse/lychee | sed 's|^lychee-v||' ;;
+            SCIP) gh_release_tag sourcegraph/scip | sed 's|^v||' ;;
+            SCIP_GO) gh_release_tag scip-code/scip-go ;;
+            # golang/tools publishes no GitHub releases at all and tags gopls
+            # as gopls/vX.Y.Z among every other x/tools tag, so releases/latest
+            # answers nothing for it. The module proxy resolves exactly what
+            # `go install golang.org/x/tools/gopls@latest` would, which is the
+            # command the gate actually runs.
+            GOPLS) curl -sSfL --retry 3 "https://proxy.golang.org/golang.org/x/tools/gopls/@latest" | jq -er '.Version' ;;
+            SEMGREP) pypi_version semgrep ;;
+            RUFF) pypi_version ruff ;;
+            MKDOCS_MATERIAL) pypi_version mkdocs-material ;;
+            PRETTIER) npm_version prettier ;;
+            MERMAID_CLI) npm_version @mermaid-js/mermaid-cli ;;
+            *) return 3 ;;
+            esac
+          }
+
+          # A renamed or emptied file would otherwise run the loop zero times
+          # and report success, which is the silence D-5 exists to forbid.
+          if ! grep -qE '^[A-Z][A-Z0-9_]*=' .github/tool-versions.env; then
+            echo "no pins found in .github/tool-versions.env" >&2
+            exit 1
+          fi
+
+          base="$GITHUB_REF_NAME"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Only the assignments: the file leads with the paragraph explaining
+          # why the pins exist, and ci.yml reads it through the same filter.
+          while IFS='=' read -r key current; do
+            rc=0
+            latest=$(latest_version "$key") || rc=$?
+            case "$rc" in
+            0) ;;
+            3)
+              record_failure "$key: no version source is wired up for this pin — add one to latest_version"
+              continue
+              ;;
+            *)
+              record_failure "$key: its source could not be reached or read"
+              continue
+              ;;
+            esac
+            # A source that answers 200 with something that is not a version —
+            # an error page, a moved field — must not be written into the file.
+            if ! printf '%s' "$latest" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+              record_failure "$key: its source answered '$latest', which is not a version"
+              continue
+            fi
+            if [ "$latest" = "$current" ]; then
+              echo "$key: $current is current"
+              continue
+            fi
+
+            branch="bump-tools/$(printf '%s' "$key" | tr 'A-Z_' 'a-z-')"
+            # A bump whose CI went red stays open as the record that the
+            # upgrade exists and is blocked; re-proposing it every week would
+            # bury that under identical PRs. Closing one says "not this
+            # version", and the next run offers whatever came after it.
+            if ! open_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[].number'); then
+              record_failure "$key: could not ask whether a bump PR is already open"
+              continue
+            fi
+            if [ -n "$open_pr" ]; then
+              echo "$key: PR #$open_pr is already open for this pin, leaving it alone"
+              continue
+            fi
+
+            git checkout -q -B "$branch" "$base"
+            sed -i "s|^$key=.*|$key=$latest|" .github/tool-versions.env
+            # One tool per commit and per PR: each bump is independently
+            # reviewable and revertable, and its CI verdict is unambiguous —
+            # a new golangci-lint ruleset turning the tree red leaves nothing
+            # else stuck behind it.
+            if ! git commit -q -am "ci: bump $key from $current to $latest"; then
+              record_failure "$key: rewriting its line in tool-versions.env changed nothing"
+              git checkout -qf "$base"
+              continue
+            fi
+            # --force, not --force-with-lease: a closed PR leaves its branch
+            # behind at an unrelated commit, and the next offer for that tool
+            # is a fresh branch off the base rather than a descendant of it.
+            if ! git push -q --force origin "$branch"; then
+              record_failure "$key: could not push $branch"
+              git checkout -qf "$base"
+              continue
+            fi
+            # debt: a PR opened with GITHUB_TOKEN does not trigger workflow
+            # runs, so the gate does not start on its own and the body says so.
+            # Ceiling: the reviewer has to close and reopen the PR to get the
+            # verdict this workflow exists to produce. Revisit when that step
+            # is missed once, or when a repo-owned PAT is worth the key.
+            if ! gh pr create --base "$base" --head "$branch" \
+              --title "ci: bump $key from $current to $latest" \
+              --body "\`$key\` moves from \`$current\` to \`$latest\` in \`.github/tool-versions.env\`.
+
+          Bumping that line invalidates the tool cache, so the gate on this PR installs the new version and its verdict is the evidence — read the tool's changelog before merging, because a linter's new rule turning a green tree red is exactly what the pin exists to make visible.
+
+          Close and reopen this PR to start CI: it was opened by the workflow's own token, which does not trigger workflow runs.
+
+          Opened by \`.github/workflows/bump-tools.yml\`. Refs #92"; then
+              record_failure "$key: pushed $branch but could not open its PR"
+              git checkout -qf "$base"
+              continue
+            fi
+            echo "$key: proposed $current -> $latest on $branch"
+            git checkout -qf "$base"
+          done < <(grep -E '^[A-Z][A-Z0-9_]*=' .github/tool-versions.env)
+
+          if [ "$failed" -ne 0 ]; then
+            echo "at least one pin could not be checked — unknown is never the same as current" >&2
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,11 @@ A few repo-specific rules:
   stamped with the release version and rebuilt by the maintainer at release
   time; a PR that touches them will be asked to drop those changes.
 - **Don't bump versions.** The version lives in several manifests at once
-  and moves only in release commits.
+  and moves only in release commits. The pinned tool versions in
+  `.github/tool-versions.env` are the same rule with a different owner: a
+  weekly workflow opens one PR per tool that is behind, so a hand-written
+  bump collides with it. Report a tool that needs upgrading sooner rather
+  than editing that file.
 - **Changelog entries ride releases**, not PRs — describe the change well in
   the PR body and it will be told in `CHANGELOG.md` when it ships.
 - **Every non-trivial change leaves a test behind** — the smallest thing


### PR DESCRIPTION
## What

A weekly workflow that reads `.github/tool-versions.env`, asks each tool's own source for the newest version, and opens one PR per tool that is behind. Plus `.github/dependabot.yml` for the action SHAs.

## Why

#89 pinned every gate tool so the verdict stops drifting between two runs of the same commit. A pin never moves on its own, so the versions rot silently instead — this is the other half.

It is not hypothetical: on its first dry run against the real sources, **three of the twelve pins were already behind** — semgrep 1.173.0 → 1.174.0, ruff 0.16.3 → 0.16.4, mkdocs-material 9.6.23 → 9.7.7. Those PRs will be its first output.

## How, against the decisions in #92

- **D-1** a hand-written workflow, not Renovate. One bash step, no app with write access, linted by the same actionlint and shellcheck the rest of the repo gets.
- **D-2** one PR per tool, on a version-free branch name.
- **D-3** a red bump stays open: `gh pr list --head` short-circuits a tool that already has one, so a blocked upgrade is one PR rather than a new identical one every week.
- **D-4** Dependabot owns the six action SHAs; this covers the env file only.
- **D-5** a pin that cannot be checked fails the run. Each failure is a `::error::` naming the tool, the loop continues so one dead registry does not hide the other eleven, and the run exits 1. An emptied or renamed pin file exits before the loop — running zero checks would otherwise report success.

The loop reads the file rather than a hard-coded list, using the same `grep` filter `ci.yml` uses, so a thirteenth pin is checked or fails as unwired instead of being invisible.

**gopls needed its own answer.** `golang/tools` publishes no GitHub releases and tags gopls as `gopls/vX.Y.Z` among every other x/tools tag, so `releases/latest` answers nothing. It resolves through the Go module proxy — exactly what `go install …/gopls@latest` would resolve. Verified live: `v0.23.0`, matching the pin.

## Two things a reviewer should know

**A PR opened with `GITHUB_TOKEN` does not trigger workflow runs**, so the gate will not start on a bump PR by itself; the reviewer closes and reopens it to get a verdict. Marked with a `debt:` naming that ceiling and its revisit condition. The alternative was a PAT, and the task was to work without one.

**The `gitleaks:allow` marker on each action SHA must survive Dependabot's comment rewrite.** If it is dropped, the gate reads the bare 40-hex string as a secret — loudly, on the first bump, rather than quietly.

## Testing

`actionlint` clean (with shellcheck on PATH, so the embedded shell was linted too). The extracted script was dry-run against the real sources with git, gh and sed stubbed: twelve pins resolved in the right shape, nine current, three behind. Edge cases exercised individually against a doctored pin file — open-PR skip, unreachable source, a 200 that is not a version, an unknown key, an empty file — each producing the right annotation and exit code.

Closes #92