### PR TITLE
fix: the attribution gate recognises more than one vendor

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -234,6 +234,12 @@ The finishing discipline — most of it rides the gate:
 | Agent-layer drift (rule copies vs `AGENTS.md`, manifest versions)                 | **blocks**                                        |
 | Commit subject shape (≤72, blank line before body); working on the default branch | reports (`[git] default_branch_policy` can block) |
 
+The attribution check reads a named list of machine authors — Claude,
+Codex, Copilot, Cursor, Devin, Gemini, aider, the robot emoji — and says
+in the finding which one it matched. A `Co-Authored-By:` naming a person
+is left alone; the header long predates AI coders and pair programming,
+carried patches and squashes all use it correctly.
+
 The attribution line is the one most likely to come back: the host adds
 it, so amending the commit clears the finding without changing what
 produced it. [The trailer your host

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -93,6 +93,16 @@ The gate blocks the ones it recognises, and blocks them without a knob:
 the work is the author's, and a repository that wants the rule off
 already has `[git] commit_gate`.
 
+What it recognises is a named list of machine authors — Claude, Codex,
+Copilot, Cursor, Devin, Gemini, aider, and the robot emoji — matched on
+the trailer that names one, plus the "Generated with …" and vendor
+`noreply@` forms. Not every `Co-Authored-By:`: the header is a decade
+older than AI coders and is right for pair programming, a patch carried
+on someone's behalf, or a squash that credits everyone who touched the
+branch, so those keep passing. The finding names which identity it
+matched, so a wrong one can be argued with rather than worked around. A
+host outside the list is a silent miss and worth an issue.
+
 That makes the trailer a recurring wall rather than a one-time fix.
 Amending the message clears the finding; the host writes the trailer
 again on the next commit, because the setting that produced it never

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -345,7 +345,11 @@ type aiIdentity struct {
 var aiIdentities = []aiIdentity{
 	// Claude Code writes the trailer, the "Generated with" line and the
 	// session emoji; `attribution` in settings.json turns all three off.
-	{name: "Claude", inTrailer: `claude|anthropic`, anywhere: `generated with[^\n]*\bclaude\b|noreply@anthropic\.com`},
+	// `anthropic` is deliberately NOT in the trailer pattern: it would match
+	// a person at that company co-authoring from their own address, which is
+	// the rule this list states — the vendor's noreply mailbox is the tool,
+	// the domain is an employer.
+	{name: "Claude", inTrailer: `claude`, anywhere: `generated with[^\n]*\bclaude\b|noreply@anthropic\.com`},
 	// Codex injects the trailer from an account-level policy, so a user who
 	// cannot administer the account meets it on every commit.
 	{name: "Codex", inTrailer: `codex|noreply@openai\.com`},

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -314,7 +314,79 @@ func Oversized(files []string, maxMB int) []Finding {
 
 // AI attribution in commit messages. The work is the author's; a line crediting
 // the tool is noise at best and a policy violation at worst, and it BLOCKS.
-var attribution = regexp.MustCompile(`(?im)^[ \t]*co-authored-by:.*\b(claude|anthropic)\b|generated with.*\bclaude\b|noreply@anthropic\.com|🤖`)
+//
+// aiIdentity is one machine author the gate recognises: the name the finding
+// reports, the alternation that spots it inside a Co-Authored-By trailer, and
+// the shapes it takes outside one. Both the pattern and the wording come from
+// here, so a host is added in a single place.
+type aiIdentity struct {
+	name string
+	// inTrailer matches only on a co-author line, never on prose: the
+	// Co-Authored-By header predates AI coders by a decade and is correct for
+	// pair programming, patches carried on someone's behalf and squashed
+	// contributions. A gate that blocked every one of those is a gate its
+	// users learn to route around, so the header alone is never the signal —
+	// the identity named on it is.
+	inTrailer string
+	// anywhere matches the forms that are not trailers at all: a "generated
+	// with" sentence, a vendor's noreply address in a body, a robot emoji.
+	anywhere string
+}
+
+// aiIdentities is the whole rule. Vendor addresses are matched as the literal
+// noreply mailbox rather than by domain, because a human employed by an AI lab
+// co-authors commits from that same domain and is a person, not a tool.
+//
+// debt: a named list is stale the moment a host nobody has heard of ships a
+// trailer of its own, and every miss is silent — the user has the policy
+// without the enforcement, which is the failure this list exists to fix.
+// Revisit when a host outside it is reported writing one, or when keeping it
+// current stops being a matter of reading the host's own settings docs.
+var aiIdentities = []aiIdentity{
+	// Claude Code writes the trailer, the "Generated with" line and the
+	// session emoji; `attribution` in settings.json turns all three off.
+	{name: "Claude", inTrailer: `claude|anthropic`, anywhere: `generated with[^\n]*\bclaude\b|noreply@anthropic\.com`},
+	// Codex injects the trailer from an account-level policy, so a user who
+	// cannot administer the account meets it on every commit.
+	{name: "Codex", inTrailer: `codex|noreply@openai\.com`},
+	// VS Code's git extension, when git.addAICoAuthor is anything but "off".
+	{name: "Copilot", inTrailer: `copilot`, anywhere: `\bcopilot@github\.com\b`},
+	// Cursor's agent attributes with a "Made with Cursor" trailer rather than
+	// a co-author line; its cloud agent adds a co-author on top.
+	{name: "Cursor", inTrailer: `cursor`, anywhere: `made[ -]with:?[ \t]*cursor`},
+	// The bot handle, not the bare first name: "Devin" belongs to plenty of
+	// human co-authors and blocking them would teach users to distrust the gate.
+	{name: "Devin", inTrailer: `devin-ai-integration`},
+	{name: "Gemini", inTrailer: `gemini`},
+	{name: "aider", inTrailer: `aider|noreply@aider\.chat`},
+	// Not an identity but the sign of one: the emoji no human types into a
+	// commit subject.
+	{name: "a robot emoji", anywhere: `🤖`},
+}
+
+// pattern is the identity's two halves as one expression: case-insensitive,
+// multi-line, so the trailer half anchors per line instead of per message.
+func (a aiIdentity) pattern() string {
+	var alts []string
+	if a.inTrailer != "" {
+		// The trailing run to end-of-line is what makes the finding quote the
+		// whole trailer: without it the match stops mid-address and the reader
+		// is shown half the line they are being asked to delete.
+		alts = append(alts, `^[ \t]*co-authored-by:.*\b(?:`+a.inTrailer+`)\b[^\n]*`)
+	}
+	if a.anywhere != "" {
+		alts = append(alts, a.anywhere)
+	}
+	return `(?im)` + strings.Join(alts, "|")
+}
+
+var aiMatchers = func() []*regexp.Regexp {
+	out := make([]*regexp.Regexp, len(aiIdentities))
+	for i, a := range aiIdentities {
+		out[i] = regexp.MustCompile(a.pattern())
+	}
+	return out
+}()
 
 // Where the per-host settings that stop the trailer at its source are written
 // down. The finding carries it because amending is only half the fix: the host
@@ -326,12 +398,26 @@ const attributionRemedyURL = "https://procoder.azrty.com/portability/#the-traile
 func Attribution(messages []string) []Finding {
 	var out []Finding
 	for _, m := range messages {
-		if loc := attribution.FindString(m); loc != "" {
+		// The finding names the identity as well as the line, so someone who
+		// believes it is wrong can say which entry is wrong and argue with it,
+		// instead of reading a blocked commit as the gate being mysterious.
+		if name, loc := matchAIIdentity(m); loc != "" {
 			out = append(out, Finding{Blocking: true,
-				Message: fmt.Sprintf("commit message carries an AI-attribution line: %q — the work is the author's; remove it (git commit --amend / rebase). If the host added it, it will add it again on the next commit — turn it off at the source: %s", strings.TrimSpace(firstLineOf(loc)), attributionRemedyURL)})
+				Message: fmt.Sprintf("commit message carries an AI-attribution line crediting %s: %q — the work is the author's; remove it (git commit --amend / rebase). If the host added it, it will add it again on the next commit — turn it off at the source: %s", name, strings.TrimSpace(firstLineOf(loc)), attributionRemedyURL)})
 		}
 	}
 	return out
+}
+
+// matchAIIdentity reports the first recognised identity in the text and the
+// line that carried it.
+func matchAIIdentity(text string) (name, line string) {
+	for i, re := range aiMatchers {
+		if loc := re.FindString(text); loc != "" {
+			return aiIdentities[i].name, loc
+		}
+	}
+	return "", ""
 }
 
 // ScrubText applies the same attribution patterns to arbitrary text — the PR

--- a/internal/gitx/gitx_test.go
+++ b/internal/gitx/gitx_test.go
@@ -201,6 +201,7 @@ func TestAttributionLeavesLegitimateCoAuthorsAlone(t *testing.T) {
 		// A human at an AI lab is a person; only the vendor's noreply mailbox
 		// is the tool.
 		"fix parser\n\nCo-authored-by: Jane Roe <jane@openai.com>",
+		"fix parser\n\nCo-authored-by: Jane Roe <jane@anthropic.com>",
 		"fix parser\n\nCo-authored-by: Devin Marsh <devin@example.com>",
 	}
 	for _, m := range clean {

--- a/internal/gitx/gitx_test.go
+++ b/internal/gitx/gitx_test.go
@@ -148,21 +148,78 @@ func TestIgnoreCoverageNamesTheGapAndTheReason(t *testing.T) {
 	}
 }
 
-func TestAttributionBlocksInAllItsCostumes(t *testing.T) {
-	bad := []string{
-		"fix parser\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>",
-		"fix parser\n\nGenerated with Claude Code",
-		"fix parser\n\n🤖 automated",
+// One case per trailer a host is known to write. The two hosts a procoder user
+// is most likely to be sitting in — Codex and VS Code — wrote lines the gate
+// used to wave through, which left those users with the policy and none of the
+// enforcement.
+//
+// proved by: deleting the Codex entry from aiIdentities — the Codex trailer
+// went unfound and this test failed. Same with the Copilot entry deleted.
+func TestAttributionBlocksEveryRecognisedIdentity(t *testing.T) {
+	bad := []struct{ message, identity string }{
+		{"fix parser\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>", "Claude"},
+		{"fix parser\n\nGenerated with Claude Code", "Claude"},
+		{"fix parser\n\n🤖 automated", "a robot emoji"},
+		{"fix parser\n\nCo-authored-by: Codex <noreply@openai.com>", "Codex"},
+		{"fix parser\n\nCo-authored-by: Copilot <copilot@github.com>", "Copilot"},
+		{"fix parser\n\nCo-authored-by: Cursor Agent <agent@cursor.com>", "Cursor"},
+		{"fix parser\n\nMade with Cursor", "Cursor"},
+		{"fix parser\n\nCo-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>", "Devin"},
+		{"fix parser\n\nCo-authored-by: gemini-code-assist[bot] <176961590+gemini-code-assist[bot]@users.noreply.github.com>", "Gemini"},
+		{"fix parser\n\nCo-authored-by: aider (gpt-4) <noreply@aider.chat>", "aider"},
 	}
-	for _, m := range bad {
-		got := Attribution([]string{m})
-		if len(got) == 0 || !got[0].Blocking {
-			t.Fatalf("not caught: %q -> %+v", m, got)
+	for _, c := range bad {
+		got := Attribution([]string{c.message})
+		if len(got) != 1 || !got[0].Blocking {
+			t.Fatalf("not caught: %q -> %+v", c.message, got)
+		}
+		// Naming the identity is what makes a false positive arguable: the
+		// reader can point at the list entry that was wrong about them.
+		if !strings.Contains(got[0].Message, c.identity) {
+			t.Errorf("finding must name %q: %q", c.identity, got[0].Message)
 		}
 	}
-	clean := "fix parser\n\nHandles the empty-input case the old loop skipped."
-	if got := Attribution([]string{clean}); len(got) != 0 {
-		t.Fatalf("false positive on a clean message: %+v", got)
+}
+
+// The other half of the rule, and the half that decides whether anyone leaves
+// the gate switched on. Co-Authored-By predates AI coders by a decade: pair
+// programming, a patch carried on someone's behalf and a squashed contribution
+// all use it correctly, and so does a human who happens to work at an AI lab or
+// to be called Devin. Blocking those teaches users to bypass the gate, which
+// costs more than the trailers it would have caught.
+//
+// proved by: replacing the Claude entry's inTrailer with a bare `.*` so any
+// co-author line matched — every case below fired and this test failed.
+func TestAttributionLeavesLegitimateCoAuthorsAlone(t *testing.T) {
+	clean := []string{
+		"fix parser\n\nHandles the empty-input case the old loop skipped.",
+		"fix parser\n\nCo-authored-by: Jane Roe <jane@example.com>",
+		// A noreply address belonging to a person, not to a vendor.
+		"fix parser\n\nCo-authored-by: Jane Roe <12345+janeroe@users.noreply.github.com>",
+		// A squash carrying everyone who touched the branch.
+		"feat: the importer\n\nCo-authored-by: Jane Roe <jane@example.com>\nCo-authored-by: Sam Poe <sam@example.com>",
+		// A human at an AI lab is a person; only the vendor's noreply mailbox
+		// is the tool.
+		"fix parser\n\nCo-authored-by: Jane Roe <jane@openai.com>",
+		"fix parser\n\nCo-authored-by: Devin Marsh <devin@example.com>",
+	}
+	for _, m := range clean {
+		if got := Attribution([]string{m}); len(got) != 0 {
+			t.Errorf("false positive on a legitimate message %q: %+v", m, got)
+		}
+	}
+}
+
+// The quoted match is the whole trailer, not the fragment that happened to
+// satisfy the pattern: a reader shown half an address cannot grep their own
+// history for the line the gate is refusing.
+//
+// proved by: dropping the `[^\n]*` tail from aiIdentity.pattern — the finding
+// quoted "Co-authored-by: Codex <noreply@openai" and this test failed.
+func TestAttributionQuotesTheWholeTrailer(t *testing.T) {
+	got := Attribution([]string{"fix parser\n\nCo-authored-by: Codex <noreply@openai.com>"})
+	if len(got) != 1 || !strings.Contains(got[0].Message, "Co-authored-by: Codex <noreply@openai.com>") {
+		t.Fatalf("the finding must quote the trailer in full: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## What

The AI-attribution rule becomes a named list of identities instead of one vendor's patterns, and the finding says which one it matched.

## Why

The docs state the rule generally — "never add AI-attribution lines" — and the regex recognised Claude and Anthropic. Two trailers verified in the wild passed straight through: `Co-authored-by: Codex <noreply@openai.com>`, injected by Codex from an account-level policy, and `Co-authored-by: Copilot`, added by VS Code's git extension. A procoder user on those hosts had the policy without the enforcement.

## How

One `aiIdentities` list, with the trailer form separated from the free-text form. Regexps compile from the list, the matcher returns which identity fired, and the message names it — a false positive is arguable rather than mysterious. `ScrubText` already delegates to `Attribution`, so the gate and `procoder scrub` cannot diverge.

Widening to any `Co-authored-by:` was explicitly rejected: the header predates AI coders by a decade and is correct for pair programming, carried patches and squashes. A gate that blocks those is one every user learns to bypass.

Two judgement calls worth reviewing:

- **Vendor addresses match the literal noreply mailbox, never the domain.** `jane@openai.com` is a person who works at an AI lab, and stays legitimate.
- **Devin matches the bot handle `devin-ai-integration`, not the bare name.** "Devin" belongs to plenty of human co-authors.

## Provenance, stated rather than implied

Verified from primary sources: Claude/Anthropic, Codex (`openai/codex`, `codex-rs/ext/git-attribution`), Copilot (`git.addAICoAuthor` in microsoft/vscode, with the `copilot@github.com` address from its issue tracker), Cursor's "Made with Cursor" trailer (cursor.com docs), Devin's app handle.

On reputation, and labelled as such in the report rather than dressed up: Cursor's co-author form, Gemini's handles, aider's noreply address. The list carries a `debt:` naming the ceiling — a host outside it is a silent miss — and the condition to revisit.

## Testing

Every recognised trailer has a test, and so does every legitimate one that must keep passing: a human co-author, a personal `users.noreply.github.com` address, a multi-author squash, a human at an AI lab, and a person called Devin. That second half is what stops this becoming a gate people disable.

Four mutations were run and confirmed red, including widening Claude's trailer pattern to any co-author line — which fails on all five legitimate messages. I re-ran the Codex-entry deletion independently: `not caught: Co-authored-by: Codex <noreply@openai.com>`.

`go test ./...`, `procoder check` 0 blocking, and `procoder git` reports this repository's own history hygiene clean under the wider rule.

## Not done, deliberately

The quotation problem from the issue's side note — `procoder scrub` flags a document that quotes a trailer — is unchanged. Making the matcher fence-aware trades a loud false positive for a silent miss, and that was not the decision taken here.

Closes #84