### PR TITLE
build(deps): bump five actions, and say which versions they are

### DIFF
--- a/.github/workflows/bump-tools.yml
+++ b/.github/workflows/bump-tools.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 gitleaks:allow
       - name: one PR per pin that is behind
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 gitleaks:allow
         with:
           # The reproducibility check below rebuilds dist/ at the commit that
           # last touched it, which a depth-1 checkout does not contain.
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 gitleaks:allow
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7 gitleaks:allow
         with:
           go-version-file: go.mod
@@ -105,7 +105,7 @@ jobs:
         run: grep -E '^[A-Z][A-Z0-9_]*=' .github/tool-versions.env >> "$GITHUB_ENV"
       - name: the tools that have to be compiled, from cache when possible
         id: gotools
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 gitleaks:allow
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6 gitleaks:allow
         with:
           # gopls and scip-go publish no binaries, so these are the only two
           # the gate still builds. Keyed on the versions file: bumping a line
@@ -113,7 +113,7 @@ jobs:
           path: ~/go/bin
           key: gate-gotools-${{ runner.os }}-${{ hashFiles('.github/tool-versions.env') }}
       - name: python and node package caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 gitleaks:allow
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6 gitleaks:allow
         with:
           # mermaid-cli pulls puppeteer, which downloads a browser — and that
           # browser lands in ~/.cache/puppeteer, not in the npm cache. Caching
@@ -221,7 +221,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 gitleaks:allow
       - name: the changelog entry is the release notes
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -295,16 +295,16 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4 gitleaks:allow
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 gitleaks:allow
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 gitleaks:allow
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7 gitleaks:allow
         with:
           python-version: "3.12"
       - run: pip install mkdocs-material
       - name: the changelog is one file, served twice
         run: cp CHANGELOG.md docs/changelog.md
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3 gitleaks:allow
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5 gitleaks:allow
         with:
           path: site
-      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4 gitleaks:allow
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5 gitleaks:allow
         id: deployment


### PR DESCRIPTION
Consolidates #98, #99, #100, #101 and #102 into one branch and one CI run. All five were opened against a main that has moved a long way since, so each would otherwise need its own rebase and its own full matrix.

| action | from | to | SHA verified against tag |
| --- | --- | --- | --- |
| actions/checkout | v4 | **v7.0.1** | ✅ |
| actions/setup-python | v5 | **v7.0.0** | ✅ |
| actions/cache | v4 | **v6.1.0** | ✅ |
| actions/upload-pages-artifact | v3 | **v5.0.0** | ✅ |
| actions/deploy-pages | v4 | **v5.0.0** | ✅ |

Each SHA was resolved through the API to the tag it claims before being taken, rather than trusted from the PR title.

**The version comments are corrected.** Dependabot moves the SHA and leaves `# v4` in place. Pinning by SHA is what makes the pin safe; the comment is the only part a human reads. `# v4` beside a v7 commit is worse than no comment, because it gets believed.

**Breaking changes, checked against how we actually use them:**

- **checkout v7** blocks fork checkout for `pull_request_target` and `workflow_run` — every workflow here is plain `pull_request`.
- **setup-python v7** removes the `pip-install` input — never used; `mkdocs-material` has its own `run` step.
- **cache v5**, **deploy-pages v5** are node24 runtime bumps requiring runner ≥2.327.1 — GitHub-hosted, and the inputs we pass are unchanged.
- **upload-pages-artifact v5** adds `include-hidden-files` and moves to upload-artifact v7; our `path: site` is unchanged.

⚠️ **One gap worth stating.** The `docs` job is `if: github.ref == 'refs/heads/main' && github.event_name == 'push'`, so `upload-pages-artifact` and `deploy-pages` are **not exercised by this PR's checks** — they only run after merge. I'll watch the main run and revert if the Pages deploy breaks.