### PR TITLE
docs: the changelog entry is a release page, so lay it out like one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 gitleaks:allow
+        with:
+          # The notes below name the previous tag to build a compare link,
+          # and a depth-1 checkout of a tag ref carries no other tag to
+          # compare against. The link would simply be missing — the guard
+          # there is written so it never comes out wrong — but missing is
+          # the whole point of adding it.
+          fetch-depth: 0
       - name: the changelog entry is the release notes
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -240,7 +247,38 @@ jobs:
             echo "no CHANGELOG.md entry for $version — refusing to publish empty release notes" >&2
             exit 1
           fi
-          head -3 /tmp/notes.md
+
+          # The prose says what changed; this says what to do about it.
+          # Without it the release page is five identical-looking binaries
+          # and no statement of which one, how to verify it, or that
+          # upgrading in place is a thing procoder does for you.
+          #
+          # The previous tag is found by walking the tag list rather than
+          # asking git for "the parent": tags are not ordered by ancestry,
+          # and a compare link built from the wrong end reads as though the
+          # release contained everything ever done.
+          prev=$(git tag --list 'v*' --sort=-version:refname | grep -A1 -x "$GITHUB_REF_NAME" | tail -1)
+          {
+            echo
+            echo "---"
+            echo
+            echo "**Upgrade in place:** \`procoder self-upgrade\` — it asks first, and installs"
+            echo "only after the download matches the \`SHA256SUMS\` published below."
+            echo
+            echo "**Or download** the binary for your platform below and check it against"
+            echo "\`SHA256SUMS\` before running it."
+          } >> /tmp/notes.md
+          # A first release has no previous tag, and grep -A1 then returns
+          # the tag itself: a compare of a tag with itself is an empty diff
+          # presented as the release contents, so it is left out instead.
+          if [ -n "$prev" ] && [ "$prev" != "$GITHUB_REF_NAME" ]; then
+            {
+              echo
+              echo "**Every commit in this release:**"
+              echo "https://github.com/${GITHUB_REPOSITORY}/compare/${prev}...${GITHUB_REF_NAME}"
+            } >> /tmp/notes.md
+          fi
+          cat /tmp/notes.md
       - name: stage the binaries under names that do not collide
         run: |
           # gh takes an asset's NAME from the file name; `path#text` sets only

--- a/.kilo/commands/release.md
+++ b/.kilo/commands/release.md
@@ -22,7 +22,13 @@ The command below is the `procoder` binary on PATH.
    committed binaries, so a hand-built `dist/` goes red before the tag.
 4. Fix everything the release controller listed — bump the files, write
    the changelog entry, commit — then rerun `procoder release` until
-   it answers ready.
+   it answers ready. The entry's layout is not free-form: CHANGELOG.md
+   opens with the template, and the release job publishes the entry
+   verbatim as the GitHub Release notes, so what you write there is what
+   someone downloading the binary reads. A one-sentence italic summary
+   first, then headlines that open with their kind — Added, Fixed,
+   Changed, Removed, Security — each linking its issue, worst breakage
+   first. A test over the newest entry holds the shape.
 5. When the release controller answers ready it prints the tag command;
    run that command yourself and push the tag. The binary never tags
    (P-CONTROL).

--- a/.opencode/command/release.md
+++ b/.opencode/command/release.md
@@ -22,7 +22,13 @@ The command below is the `procoder` binary on PATH.
    committed binaries, so a hand-built `dist/` goes red before the tag.
 4. Fix everything the release controller listed — bump the files, write
    the changelog entry, commit — then rerun `procoder release` until
-   it answers ready.
+   it answers ready. The entry's layout is not free-form: CHANGELOG.md
+   opens with the template, and the release job publishes the entry
+   verbatim as the GitHub Release notes, so what you write there is what
+   someone downloading the binary reads. A one-sentence italic summary
+   first, then headlines that open with their kind — Added, Fixed,
+   Changed, Removed, Security — each linking its issue, worst breakage
+   first. A test over the newest entry holds the shape.
 5. When the release controller answers ready it prints the tag command;
    run that command yourself and push the tag. The binary never tags
    (P-CONTROL).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,69 @@
 
 Every release, in words a user can read. Newest first.
 
+<!--
+How an entry is written. This layout is the template — the release notes
+GitHub publishes are this entry, extracted verbatim by the release job, so
+what is written here is what a person downloading the binary reads.
+
+    ## <version> — <YYYY-MM-DD>
+
+    *One sentence: what this release is for, for someone deciding whether
+    to upgrade.*
+
+    **Fixed — the headline, as a statement.** (link the issue here) Then
+    the prose: what was wrong, what it cost the person using it, what is
+    true now. Paragraphs, not bullet lists — a changelog is read, not
+    parsed.
+
+Rules that earn their place:
+
+- The summary line comes first and is one sentence. It is the only part a
+  reader skimming a release page is guaranteed to see.
+- Every headline opens with its kind — Added, Fixed, Changed, Removed,
+  Security — so a reader can tell a new feature from a broken thing made
+  whole without reading the paragraph.
+- Something that was broken for everyone leads. Order by what it costs the
+  reader, not by what it cost to build.
+- Link the issue or PR in the headline. An entry a reader cannot get from
+  the sentence to the change is a claim they have to take on faith.
+- Name outside contributors. They are why the thing got fixed.
+-->
+
 ## 1.1.1 — 2026-08-21
 
-**`procoder ask` puts the open questions to a human instead of letting
-the coder guess.** A spec's undecided questions and the gate's own
-findings are collected into `.procoder/ask/QA.md`, answered in
-`answers.md`, and an answered question stops blocking the spec
-controller. A flagged secret's value never travels — not into a
-question, not into the terminal, not into a hook payload.
+_The pi adapter installs at all, generated ids stop welding words
+together, and a spec's open questions reach a human instead of being
+guessed._
 
-**pi could not install procoder at all.** The pi extension was a
-CommonJS module and pi validates the export shape at install time, so
-`omp plugin install` failed outright while the portability docs listed
-pi as supported. Nothing local caught it: Node hands a CommonJS export
-back as `default` on import, so every load test passed. The adapter is
-an ES module now, and the check reads adapter source rather than
-importing it. Reported by @striderZA, who supplied the diagnosis and
-the fix.
+**Fixed — pi could not install procoder at all.**
+([#105](https://github.com/azrtydxb/procoder/issues/105)) The pi
+extension was a CommonJS module and pi validates the export shape at
+install time, so `omp plugin install` failed outright while the
+portability docs listed pi as a supported host. Nothing here caught it:
+Node hands a CommonJS export back as `default` on import, so every load
+test passed and only pi's own validator could see the difference. The
+adapter is an ES module now, and the check reads adapter source rather
+than importing it. Reported and diagnosed by
+[@striderZA](https://github.com/striderZA), who supplied the fix.
 
-**Generated ids no longer weld words together.** Dropping a dot left
-`answers.md` filed as "answersmd" — a story unfindable by the name of
-the file it is about — and collapsed `v1.2.3` and `v12.3` onto one id,
-which surfaced as a refusal with no visible cause. Punctuation
-separates now, accented letters fold to their letters (`café` → `cafe`)
-rather than vanishing, and two criteria that still land on the same id
-get two stories instead of one written over the other. Names already on
-disk are untouched.
+**Fixed — generated ids welded words together.**
+([#103](https://github.com/azrtydxb/procoder/issues/103)) Dropping a dot
+left `answers.md` filed as "answersmd", so the story about a file could
+not be found by the name of the file, and `v1.2.3` and `v12.3` collapsed
+onto one id — a collision that surfaced as `backlog story` refusing with
+nothing on screen to say why. Punctuation separates now, accented
+letters fold to their letters (`café` → `cafe`) instead of vanishing,
+and two criteria that still land on the same id get two stories rather
+than one written over the other. Names already on disk are untouched.
+
+**Added — `procoder ask` puts the open questions to a human.**
+([#104](https://github.com/azrtydxb/procoder/pull/104)) A spec's
+undecided questions and the gate's own findings are collected into
+`.procoder/ask/QA.md`, answered in `answers.md`, and an answered
+question stops blocking the spec controller. A flagged secret's value
+never travels — not into a question, not into the terminal, not into a
+hook payload.
 
 ## 1.1.0 — 2026-08-21
 

--- a/commands/release.md
+++ b/commands/release.md
@@ -22,7 +22,13 @@ The launcher is: "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"
    committed binaries, so a hand-built `dist/` goes red before the tag.
 4. Fix everything the release controller listed — bump the files, write
    the changelog entry, commit — then rerun `launcher.sh release` until
-   it answers ready.
+   it answers ready. The entry's layout is not free-form: CHANGELOG.md
+   opens with the template, and the release job publishes the entry
+   verbatim as the GitHub Release notes, so what you write there is what
+   someone downloading the binary reads. A one-sentence italic summary
+   first, then headlines that open with their kind — Added, Fixed,
+   Changed, Removed, Security — each linking its issue, worst breakage
+   first. A test over the newest entry holds the shape.
 5. When the release controller answers ready it prints the tag command;
    run that command yourself and push the tag. The binary never tags
    (P-CONTROL).

--- a/internal/release/changelog_test.go
+++ b/internal/release/changelog_test.go
@@ -1,0 +1,87 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// newestEntry returns the body of the top `## <version>` section of this
+// repository's own changelog — the text the release job publishes verbatim
+// as the GitHub Release notes.
+func newestEntry(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "CHANGELOG.md"))
+	if err != nil {
+		t.Fatalf("the changelog must be readable: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatal("the changelog has no version heading")
+	}
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			return strings.Join(lines[start+1:i], "\n")
+		}
+	}
+	return strings.Join(lines[start+1:], "\n")
+}
+
+var (
+	headline    = regexp.MustCompile(`(?m)^\*\*(Added|Fixed|Changed|Removed|Security) — `)
+	anyHeadline = regexp.MustCompile(`(?m)^\*\*`)
+)
+
+// The newest entry is what the release job publishes as the release notes,
+// so the layout rules at the top of CHANGELOG.md are a promise to whoever
+// lands on that page — not a style note. A convention nothing checks is one
+// that decays entry by entry until the page is a wall again.
+// proved by: dropped the leading "Fixed — " from a headline and the italic
+// summary line — this test names both, where nothing else in the repository
+// reads the changelog's shape at all.
+func TestTheNewestChangelogEntryFollowsTheLayout(t *testing.T) {
+	entry := newestEntry(t)
+
+	// The summary is what a reader skimming a release page is guaranteed to
+	// see, so it comes first, before any headline. It is checked as a
+	// paragraph rather than a line because the changelog is hard-wrapped:
+	// one sentence of prose occupies three lines, and a line-anchored check
+	// would demand the summary be short enough not to wrap.
+	//
+	// Underscores as well as asterisks: prettier normalises *italic* to
+	// _italic_ and prettier is what the gate runs, so accepting only the
+	// asterisk form would fail every formatted changelog.
+	first, _, _ := strings.Cut(strings.TrimSpace(entry), "\n\n")
+	italic := func(s string, mark string) bool {
+		return strings.HasPrefix(s, mark) && strings.HasSuffix(s, mark)
+	}
+	if !italic(first, "_") && !italic(first, "*") {
+		t.Errorf("the entry must open with an italic one-sentence summary, got:\n%s", first)
+	}
+
+	kinds := headline.FindAllString(entry, -1)
+	all := anyHeadline.FindAllString(entry, -1)
+	if len(all) == 0 {
+		t.Fatal("the entry has no **headline** at all")
+	}
+	// Every headline carries its kind. A reader must be able to tell a new
+	// feature from a broken thing made whole without reading the paragraph.
+	if len(kinds) != len(all) {
+		t.Errorf("%d of %d headlines do not open with Added/Fixed/Changed/Removed/Security",
+			len(all)-len(kinds), len(all))
+	}
+	// An entry a reader cannot get from the sentence to the change is a
+	// claim they have to take on faith.
+	if !strings.Contains(entry, "](https://github.com/") {
+		t.Error("no headline links an issue or PR — the reader cannot reach the change")
+	}
+}

--- a/internal/release/changelog_test.go
+++ b/internal/release/changelog_test.go
@@ -17,7 +17,10 @@ func newestEntry(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("the changelog must be readable: %v", err)
 	}
-	lines := strings.Split(string(raw), "\n")
+	// CRLF leveled first: a Windows checkout rewrites line endings, so the
+	// paragraph below would end in "\r" and an italic closing "_" would
+	// never be the last character.
+	lines := strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n")
 	start := -1
 	for i, line := range lines {
 		if strings.HasPrefix(line, "## ") {


### PR DESCRIPTION
The release job publishes the newest changelog entry **verbatim** as the GitHub Release notes. That page is what someone downloading a binary actually reads — and [v1.1.1](https://github.com/azrtydxb/procoder/releases/tag/v1.1.1) opens mid-sentence with a bold paragraph, has no links, and says nothing about the five identically-named binaries below it.

### What was wrong with the layout

- **No summary.** Nothing to skim. A reader deciding whether to upgrade has to read three paragraphs.
- **No kinds.** A total breakage and a new convenience look identical.
- **No links.** No issue, no PR, no compare — every claim taken on faith.
- **No next step.** The most-read surface never mentions that `procoder self-upgrade` exists or that `SHA256SUMS` is there to check against.

### The template

Written at the top of `CHANGELOG.md`, where whoever writes the next entry will meet it:

- One-sentence *italic summary* first — the only part a skimming reader is guaranteed to see.
- Headlines open with their kind: **Added / Fixed / Changed / Removed / Security**.
- The issue linked in the headline.
- Worst breakage first — ordered by what it cost the reader, not what it cost to build.
- Outside contributors named.
- Prose stays prose. A changelog is read, not parsed.

1.1.1 is rewritten as the worked example. **Older entries are left alone** — they are the published record of what those releases said, and rewriting them would be rewriting the record.

### The published footer

Added by the release job rather than repeated in every entry: that `self-upgrade` exists and verifies its download, that the binaries can be checked against `SHA256SUMS`, and a compare link. The previous tag comes from the tag list, not from ancestry — tags are not ordered by ancestry, and a compare built from the wrong end reads as though the release contained everything ever done. The release checkout takes `fetch-depth: 0`, since a depth-1 checkout of a tag carries no other tag to compare against.

### The guard

`TestTheNewestChangelogEntryFollowsTheLayout` holds the shape — a convention nothing checks decays entry by entry until the page is a wall again. It reads a *paragraph*, not a line (the file is hard-wrapped, and a line-anchored check would demand summaries short enough not to wrap), and accepts `_italic_` because prettier rewrites asterisks and prettier is what the gate runs. Verified failing on both halves of its named mutation.