### PR TITLE
feat: an unconfigured PHP project gets a real linter, and init installs it

### DIFF
--- a/.procoder/specs/php-support.md
+++ b/.procoder/specs/php-support.md
@@ -153,12 +153,31 @@ their language. People have asked for it.
   php-cs-fixer, phpcbf and pint all either write in place or emit a diff,
   and working around that would mean temp files, which the formatter
   registry exists to avoid.
-- **D-2: the linter is whichever the project configured, with `php -l` as
-  the floor.** phpstan when a phpstan config is present, phpcs when a phpcs
-  config is present, both when both. With neither, `php -l` reports real
-  syntax errors and nothing else. This follows the eslint and clang-format
-  precedent already in the registry: the project's own config always wins,
-  and procoder never imposes a standard nobody chose.
+- **D-2: the linter is whichever the project configured; with none,
+  procoder brings its own.** phpstan when a phpstan config is present,
+  phpcs when a phpcs config is present, both when both. The project's own
+  config always wins (D-OVERRIDE).
+- **D-5 (revises D-2): an unconfigured project gets procoder's phpstan
+  baseline, not a syntax floor.** D-2 originally stopped at `php -l` when
+  nothing was configured, on the reasoning that procoder imposes no
+  standard. That reasoning was right about style and wrong about bugs: a
+  wrong return type and a call to a function that does not exist are not
+  matters of taste, and leaving them unreported meant most PHP
+  repositories — the ones with no linter configured on the day procoder
+  arrives — got a gate that only checked whether the file parsed. procoder
+  now supplies a curated phpstan config, written to a temp file so nothing
+  lands in the repository, exactly as it already does for Go's golangci
+  baseline and Java's bundled google_checks. `php -l` remains as the floor
+  for when phpstan itself is absent, alongside a NOT-checked line naming
+  it so `procoder init` installs it.
+- **D-6: the baseline is phpstan at level 5, and phpstan rather than
+  phpcs.** phpcs is a style checker and formatting is already prettier's
+  job here, so a phpcs default would put two tools in charge of the same
+  thing. The level was measured, not chosen: against ordinary untyped
+  legacy PHP, levels 0 through 5 report nothing while level 6 demands a
+  typehint on every parameter and produced four findings on fourteen
+  lines. A default that shouts at every existing codebase is a default
+  people turn off.
 - **D-3: phpunit ships in the same change as format and lint.** PHP
   support that stops at the gate leaves `procoder test` telling a PHP team
   it has no recognized test setup, which is the same wrong answer in a

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -125,11 +125,15 @@ func init() {
 		// tell a reader to install a tool procoder is never going to run
 		// there — doctor's job is what this repository needs, not what PHP
 		// has available.
+		// phpstan is procoder's default PHP linter, so it is required
+		// wherever PHP is — not only where the project already configured
+		// it. Listing it conditionally was the bug: a repository with no
+		// PHP tooling at all was told nothing was missing, `procoder init`
+		// installed nothing, and the lint domain fell back to a syntax
+		// check forever. phpcs stays conditional because it is the
+		// project's choice, not procoder's default.
 		if exts[".php"] {
-			out = append(out, lint.PHP)
-			if lint.HasPhpstanConfig(root) {
-				out = append(out, lint.Phpstan)
-			}
+			out = append(out, lint.PHP, lint.Phpstan)
 			if lint.HasPhpcsConfig(root) {
 				out = append(out, lint.Phpcs)
 			}

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -35,18 +35,18 @@ comments or `.gitleaksignore`, each a reviewed decision — the flow is in
 The canonical linter per ecosystem, under the project's own config —
 Procoder imposes nothing where the repo has spoken.
 
-| Ecosystem | Tool           | Baseline when the repo has no config                                                                                                               |
-| --------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Go        | golangci-lint  | curated set: standard + gosec, gocritic, errorlint, unparam, copyloopvar, nilerr                                                                   |
-| Python    | ruff check     | ruff's defaults                                                                                                                                    |
-| Shell     | shellcheck     | shellcheck's defaults                                                                                                                              |
-| JS/TS     | eslint         | plain JS gets eslint's built-in core rules; configless TypeScript is out of scope (a parser would have to be imposed)                              |
-| Rust      | cargo clippy   | clippy's defaults (needs a Cargo workspace; findings filtered to the changed files)                                                                |
-| Kotlin    | ktlint         | ktlint's defaults                                                                                                                                  |
-| Swift     | swiftlint      | swiftlint's defaults                                                                                                                               |
-| Ruby      | rubocop        | rubocop's defaults                                                                                                                                 |
-| Java      | checkstyle     | the bundled google_checks; a repo `checkstyle.xml` wins                                                                                            |
-| PHP       | phpstan, phpcs | whichever the repo configured (`phpstan.neon`, `phpcs.xml`); both if both. With neither, `php -l` reports syntax errors only — no style is imposed |
+| Ecosystem | Tool           | Baseline when the repo has no config                                                                                                                          |
+| --------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Go        | golangci-lint  | curated set: standard + gosec, gocritic, errorlint, unparam, copyloopvar, nilerr                                                                              |
+| Python    | ruff check     | ruff's defaults                                                                                                                                               |
+| Shell     | shellcheck     | shellcheck's defaults                                                                                                                                         |
+| JS/TS     | eslint         | plain JS gets eslint's built-in core rules; configless TypeScript is out of scope (a parser would have to be imposed)                                         |
+| Rust      | cargo clippy   | clippy's defaults (needs a Cargo workspace; findings filtered to the changed files)                                                                           |
+| Kotlin    | ktlint         | ktlint's defaults                                                                                                                                             |
+| Swift     | swiftlint      | swiftlint's defaults                                                                                                                                          |
+| Ruby      | rubocop        | rubocop's defaults                                                                                                                                            |
+| Java      | checkstyle     | the bundled google_checks; a repo `checkstyle.xml` wins                                                                                                       |
+| PHP       | phpstan, phpcs | Procoder's curated phpstan baseline (level 5) when the repo configures neither; a repo `phpstan.neon` or `phpcs.xml` wins, and both run when both are present |
 
 Report by default; `[lint] policy = "block"` in config.toml makes
 findings block. Lint is judgment where formatting was not — the findings

--- a/internal/lint/php.go
+++ b/internal/lint/php.go
@@ -75,9 +75,58 @@ func lintPHP(root string, files []string, block bool) []gitx.Finding {
 		out = append(out, run(root, Phpcs, append([]string{"--report=emacs", "--no-colors"}, files...), files, block)...)
 	}
 	if stan == "" && cs == "" {
-		out = append(out, lintPHPSyntax(root, files, block)...)
+		out = append(out, lintPHPBaseline(root, files, block)...)
 	}
 	return out
+}
+
+// phpstanBaseline is procoder's curated default for a PHP project that
+// carries no linter config of its own — the same bargain Go gets from the
+// golangci baseline: a real linter rather than nothing, written to a temp
+// file so the repository is never touched, and overridden the moment the
+// project adds its own config.
+//
+// Level 5 is the level, chosen by measuring rather than by taste. Against
+// ordinary untyped legacy PHP — no declare, no typehints, associative
+// arrays everywhere — levels 0 through 5 report nothing, while level 6
+// demands a typehint on every parameter and produced four findings on a
+// fourteen-line file. A default that shouts at every existing PHP codebase
+// on the day it is installed is a default people turn off. Level 5 still
+// catches the things that are bugs in any style: a function that returns
+// the wrong type, a call to something that does not exist.
+const phpstanBaseline = `parameters:
+    level: 5
+`
+
+// lintPHPBaseline lints a project that configured nothing, with procoder's
+// own default. When phpstan is absent it says so — the tool is named so
+// `procoder init` installs it — and still runs `php -l`, because a syntax
+// error caught by the binary already on the machine is worth more than a
+// silence explained by a footnote.
+func lintPHPBaseline(root string, files []string, block bool) []gitx.Finding {
+	if tools.Resolve(Phpstan, root) == "" {
+		out := notChecked(files[0], Phpstan.Name)
+		return append(out, lintPHPSyntax(root, files, block)...)
+	}
+	cfg, err := os.CreateTemp("", "procoder-phpstan-*.neon")
+	if err == nil {
+		_, err = cfg.WriteString(phpstanBaseline)
+		// a failed Close can mean the write never reached disk; treat it as
+		// a write failure rather than a success
+		if cerr := cfg.Close(); err == nil {
+			err = cerr
+		}
+		defer func() { _ = os.Remove(cfg.Name()) }()
+	}
+	if err != nil {
+		// The baseline could not be written, so the analysis procoder
+		// promised did not happen. Falling silently back to the syntax
+		// floor would report a thinner check as if it were the full one.
+		out := []gitx.Finding{{File: files[0],
+			Message: fmt.Sprintf("NOT checked — could not write the phpstan baseline: %v (lint)", err)}}
+		return append(out, lintPHPSyntax(root, files, block)...)
+	}
+	return runPhpstan(root, cfg.Name(), files, block)
 }
 
 // hasAny walks up from the file to the repository root looking for any of

--- a/internal/lint/php_test.go
+++ b/internal/lint/php_test.go
@@ -146,10 +146,73 @@ func TestWithoutPHPTheFloorSaysNotChecked(t *testing.T) {
 	// anything without ever going red.
 	t.Setenv("PATH", t.TempDir())
 	got := lintPHP(root, []string{file}, true)
-	if len(got) != 1 {
-		t.Fatalf("want one NOT-checked finding, got %+v", got)
+	if len(got) == 0 {
+		t.Fatal("a file nothing could check must never be silently clean")
 	}
-	if !strings.Contains(got[0].Message, "NOT checked") || !strings.Contains(got[0].Message, "php") {
-		t.Errorf("the refusal must say it did not check, and name php: %q", got[0].Message)
+	// The count is deliberately not asserted: with no config procoder also
+	// reports its default linter missing, and pinning the number here would
+	// make this test fail every time the set of things it reports changes,
+	// for a reason that has nothing to do with what it is guarding.
+	var named bool
+	for _, f := range got {
+		if strings.Contains(f.Message, "NOT checked") && strings.Contains(f.Message, "php") {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("the refusal must say it did not check, and name php: %+v", got)
+	}
+}
+
+// A PHP project that configured nothing must still be linted. Before this
+// it fell to `php -l`, which reports syntax errors and nothing else — so a
+// wrong return type or a call to a function that does not exist passed the
+// gate on every unconfigured PHP repository, which is most of them on the
+// day procoder arrives.
+// proved by: pointed the no-config branch back at lintPHPSyntax — the
+// baseline never runs, and a project with no config gets a syntax check
+// wearing the name of a linter.
+func TestAnUnconfiguredProjectStillGetsARealLinter(t *testing.T) {
+	// phpstan absent is the case this can assert without the tool: the
+	// refusal must name phpstan, so `procoder init` knows what to install,
+	// AND still run the syntax floor rather than leaving the file unread.
+	root := t.TempDir()
+	file := filepath.Join(root, "a.php")
+	if err := os.WriteFile(file, []byte("<?php\nfunction f( {\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir()) // neither phpstan nor php can answer
+	got := lintPHP(root, []string{file}, true)
+	if len(got) == 0 {
+		t.Fatal("an unconfigured project must not be silently clean")
+	}
+	var named bool
+	for _, f := range got {
+		if strings.Contains(f.Message, "phpstan") && strings.Contains(f.Message, "NOT checked") {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("the missing default linter must be named so init can install it: %+v", got)
+	}
+}
+
+// The baseline is level 5, and the level is the whole decision: it must
+// catch what is a bug in any style without demanding a typed codebase.
+// Level 6 requires a typehint on every parameter, which shouts at every
+// existing PHP project on the day procoder is installed — and a default
+// people turn off protects nobody.
+// proved by: set the baseline to level 6 — this test names it, and the
+// measurement behind it (four findings on fourteen lines of ordinary
+// untyped PHP, where level 5 reports none) is in the comment above it.
+func TestTheBaselineLevelIsTheMeasuredOne(t *testing.T) {
+	if !strings.Contains(phpstanBaseline, "level: 5") {
+		t.Errorf("the curated baseline must be level 5:\n%s", phpstanBaseline)
+	}
+	// It is a config procoder writes to a temp file, never into the repo:
+	// a baseline that appeared as phpstan.neon in someone's tree would be
+	// procoder imposing a config it promised not to impose.
+	if strings.Contains(phpstanBaseline, "paths:") {
+		t.Error("the baseline must not pin paths — the files come from the command line")
 	}
 }


### PR DESCRIPTION
**If a project brings its own tools, procoder uses them. If it brings none, procoder should bring its own** — and it didn't. Two gaps, both in the PHP support that just landed in #112.

### 1. The linter never arrived

`phpstan` and `phpcs` only reached the required-tools list **when the project already carried a config for them**. So a PHP repo with no tooling was told nothing was missing, and `procoder init` installed nothing.

phpstan is procoder's default now, so it's required wherever PHP is. phpcs stays conditional — that one is the project's choice, not procoder's default.

```
 GAP  phpstan  (repo)  missing
      run `procoder init` to install it (manual: composer require --dev phpstan/phpstan)

procoder init: 1 formatter(s) missing
  phpstan   composer global require phpstan/phpstan
```

### 2. With nothing configured, the gate only checked that the file parsed

`php -l` reports syntax errors and nothing else — so a wrong return type, or a call to a function that doesn't exist, **passed the gate on every unconfigured PHP repository**, which is most of them on day one.

That was the right instinct about *style* applied to the wrong thing. procoder now supplies a curated phpstan config written to a **temp file** — nothing lands in the repo — exactly as it already does for Go's golangci baseline and Java's bundled google_checks. A repo config wins the moment it exists.

| project has | procoder runs |
| --- | --- |
| `phpstan.neon` | phpstan with it |
| `phpcs.xml` | phpcs with it |
| both | both |
| **neither** | **phpstan with procoder's baseline** ← was `php -l` |
| neither, and no phpstan | `php -l` floor **+** NOT-checked naming phpstan |

### Level 5, measured rather than chosen

| level | findings on 14 lines of ordinary untyped legacy PHP |
| --- | --- |
| 0–5 | 0 |
| 6 | 4 (a typehint demanded on every parameter) |

A default that shouts at every existing codebase on the day it's installed is a default people turn off. Level 5 still catches what's a bug in any style. phpstan rather than phpcs because phpcs checks style and formatting is already prettier's job — two tools in charge of one thing is how a gate starts contradicting itself.

### Process

The spec records **D-5 and D-6 revising D-2** rather than quietly disagreeing with the code — D-2 said "php -l floor" and the code no longer does. Docs table updated to what actually runs.

### Still open, deliberately not changed here

Two other "nothing configured" cases are documented decisions I haven't reversed without asking: **configless TypeScript** is out of scope for eslint (a parser would have to be imposed), and **clang-format** without a project config is out of scope for C/C++. Say the word and they get the same treatment.