### PR TITLE
backlog: sprint 009 closes, eleven of eleven

### DIFF
--- a/.procoder/backlog/epics/no-silent-green.md
+++ b/.procoder/backlog/epics/no-silent-green.md
@@ -1,6 +1,6 @@
 # no-silent-green
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Spec: no-silent-green @ 803cae7338c1
 

--- a/.procoder/backlog/sprints/009-no-silent-green-every-gate-says-when-it-did-not-run.md
+++ b/.procoder/backlog/sprints/009-no-silent-green-every-gate-says-when-it-did-not-run.md
@@ -1,6 +1,6 @@
 # No silent green: every gate says when it did not run
 
-Status: active
+Status: closed 2026-08-21
 Created: 2026-08-21
 
 ## Goal
@@ -21,6 +21,20 @@ not claim stays out of scope, stays silent, stays green.
 ## Stories
 
 <!-- pulled below -->
+
+## Retro
+
+<!-- What slowed us down this sprint. -->
+
+<!-- What we change next sprint because of it. -->
+
+<!-- One adaptation from this sprint worth keeping. -->
+
+## Result
+
+committed: 11
+done: 11 (20260821-a-c-file-in-a-repository-with-no-clang-format-is-formatted, 20260821-a-c-file-reaches-clang-tidy-and-a-real-finding-is-reported, 20260821-a-file-type-procoder-does-not-claim-is-still-out-of-scope, 20260821-a-language-procoder-formats-but-cannot-lint-reports-not, 20260821-a-php-file-with-no-prettier-plugin-is-unchecked-with-the, 20260821-a-repository-carrying-its-own-clang-format-is-formatted-by, 20260821-a-ts-file-in-a-repository-with-no-eslint-config-is-linted, 20260821-mts-and-cts-files-reach-the-same-linter-as-ts-and-pyi, 20260821-no-domain-anywhere-in-the-tree-reports-a-check-that-did-not, 20260821-procoder-doctor-lists-every-new-default-tool-with-its, 20260821-with-no-linter-installed-procoder-check-over-a-file-of-that)
+carried: 0
 
 ## Retro
 

--- a/.procoder/backlog/sprints/009-no-silent-green-every-gate-says-when-it-did-not-run.md
+++ b/.procoder/backlog/sprints/009-no-silent-green-every-gate-says-when-it-did-not-run.md
@@ -24,11 +24,39 @@ not claim stays out of scope, stays silent, stays green.
 
 ## Retro
 
-<!-- What slowed us down this sprint. -->
+**What slowed us down.** Asked whether the rule covered all the gates,
+the honest answer was that it covered the two that had been noticed. The
+other three — tflint, helm, GitHub Pages — were found only by reading
+every Finding literal in the tree. A policy is not a diff, and reviewing
+the diff is how three domains kept their exemption through a change whose
+entire purpose was to remove it.
 
-<!-- What we change next sprint because of it. -->
+Worse, two of the blocking refusals had remedies that did not work.
+`brew install llvm` is keg-only, so init would install clang-tidy and the
+resurvey would still report it missing; the PHP plugin install candidate
+was global while resolution walks the project. Both would have printed a
+command, run it successfully, and left the file blocked — a wall with no
+door, which is worse than the silence this sprint replaced. Neither was
+caught by writing them; both were caught by review.
 
-<!-- One adaptation from this sprint worth keeping. -->
+And one new test could only ever skip: it looked for the real
+typescript-eslint inside its own temp directory, where nothing had put
+it. It would have sat green in CI forever looking like coverage.
+
+**What we change.** A refusal is not finished until its remedy has been
+run and the check re-verified afterwards — installing is a claim, the
+tool answering is the fact, and that is the rule `init` already applies
+to itself in its resurvey. And a test that skips is written with its skip
+deliberately exercised: run it once with the dependency present, once
+without, and know which of the two CI will get.
+
+**Worth keeping.** The source-level audit. `TestNoDomainReports...` reads
+every Finding literal in internal/ and fails naming file and line. No
+behavioural test could have covered the domains that were missing,
+because the failure was code nobody had thought to look at — and it is
+the only form of test that will cover the domain somebody writes next
+month. For a rule that is supposed to hold everywhere, assert it
+everywhere.
 
 ## Result
 
@@ -37,9 +65,3 @@ done: 11 (20260821-a-c-file-in-a-repository-with-no-clang-format-is-formatted, 2
 carried: 0
 
 ## Retro
-
-<!-- What slowed us down this sprint. -->
-
-<!-- What we change next sprint because of it. -->
-
-<!-- One adaptation from this sprint worth keeping. -->

--- a/.procoder/backlog/stories/20260821-a-c-file-in-a-repository-with-no-clang-format-is-formatted.md
+++ b/.procoder/backlog/stories/20260821-a-c-file-in-a-repository-with-no-clang-format-is-formatted.md
@@ -1,23 +1,21 @@
 # A C++ file in a repository with no `.clang-format` is formatted against procoder's baseline style and reported clean or unformatted, never out of scope.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A C or C++ project with no style file was formatted by nothing and told it was fine, because out of scope counts as skipped and passes. Done means the file is formatted against a baseline named on the command line, with nothing written to the repo.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A C++ file in a repository with no `.clang-format` is formatted against procoder's baseline style and reported clean or unformatted, never out of scope.
+- [x] A C++ file in a repository with no `.clang-format` is formatted against procoder's baseline style and reported clean or unformatted, never out of scope.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/format/ -run TestCWithoutProjectConfigIsStillFormatted`: PASS. Proved by mutation: restoring NeedsProjectConfig on clang-format returns OutOfScope and the test names the verdict. Run end to end — `procoder format a.cpp` in a directory with no .clang-format printed `int main() { return 0; }`.

--- a/.procoder/backlog/stories/20260821-a-c-file-reaches-clang-tidy-and-a-real-finding-is-reported.md
+++ b/.procoder/backlog/stories/20260821-a-c-file-reaches-clang-tidy-and-a-real-finding-is-reported.md
@@ -1,23 +1,21 @@
 # A C++ file reaches clang-tidy and a real finding is reported with its file and line.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+C and C++ were formatted and linted by nothing at all: the gate looked at a .cpp file and reported clean with no analysis having happened.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A C++ file reaches clang-tidy and a real finding is reported with its file and line.
+- [x] A C++ file reaches clang-tidy and a real finding is reported with its file and line.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+Run end to end: `procoder lint bug.cpp` reports `bug.cpp:4 warning: The right operand of '+' is a garbage value [clang-analyzer-core.UndefinedBinaryOperatorResult]`. Verified with PATH stripped to /usr/bin:/bin, which also proves the keg-directory resolution review asked for. clang-tidy's trailing `note:` lines are filtered — one uninitialised variable arrived as three findings before.

--- a/.procoder/backlog/stories/20260821-a-file-type-procoder-does-not-claim-is-still-out-of-scope.md
+++ b/.procoder/backlog/stories/20260821-a-file-type-procoder-does-not-claim-is-still-out-of-scope.md
@@ -1,23 +1,21 @@
 # A file type procoder does not claim is still out of scope and still passes, asserted so the change cannot swallow every unknown file.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The rule must not grow into noise. A text file, an image, a CSV is genuinely out of scope and must stay silent, or the gate gets switched off.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A file type procoder does not claim is still out of scope and still passes, asserted so the change cannot swallow every unknown file.
+- [x] A file type procoder does not claim is still out of scope and still passes, asserted so the change cannot swallow every unknown file.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/lint/ -run TestAFileTypeProcoderDoesNotClaimStaysSilent`: PASS for notes.txt, logo.png, data.csv. Proved by mutation: making lintUnlinted report on any unrecognised extension makes a .txt file block the gate, and the test names it. Run end to end — `procoder check notes.txt` exits 0 with the file counted under out of scope.

--- a/.procoder/backlog/stories/20260821-a-language-procoder-formats-but-cannot-lint-reports-not.md
+++ b/.procoder/backlog/stories/20260821-a-language-procoder-formats-but-cannot-lint-reports-not.md
@@ -1,23 +1,21 @@
 # A language procoder formats but cannot lint reports NOT checked, blocking, naming the language — never nothing.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+C# and Dart are formatted and have no linter. Done means the gate says so rather than counting the file as clean.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A language procoder formats but cannot lint reports NOT checked, blocking, naming the language — never nothing.
+- [x] A language procoder formats but cannot lint reports NOT checked, blocking, naming the language — never nothing.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/lint/ -run TestEveryFormattedExtensionReachesALinterOrSaysItDoesNot` covers .cs and .dart. Run end to end — `procoder lint A.cs` prints `BLOCK A.cs NOT linted — C#: procoder has no linter for it yet` and the run reports 1 blocking.

--- a/.procoder/backlog/stories/20260821-a-php-file-with-no-prettier-plugin-is-unchecked-with-the.md
+++ b/.procoder/backlog/stories/20260821-a-php-file-with-no-prettier-plugin-is-unchecked-with-the.md
@@ -1,23 +1,21 @@
 # A PHP file with no prettier plugin is UNCHECKED with the install line and fails the gate, where it previously passed as out of scope.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The plugin is what parses PHP; its absence was modelled as a missing style config, which made it out of scope and green. Done means it is a missing tool and fails the gate.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A PHP file with no prettier plugin is UNCHECKED with the install line and fails the gate, where it previously passed as out of scope.
+- [x] A PHP file with no prettier plugin is UNCHECKED with the install line and fails the gate, where it previously passed as out of scope.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/format/ -run TestWithoutThePluginPHPIsUncheckedWithTheInstallLine`: PASS. Proved by mutation: returning OutOfScope again makes a plugin-less PHP project pass `procoder check`. Run end to end — `procoder check bug.php` printed `UNCHECKED ... the prettier PHP plugin is not installed` and exited 1.

--- a/.procoder/backlog/stories/20260821-a-repository-carrying-its-own-clang-format-is-formatted-by.md
+++ b/.procoder/backlog/stories/20260821-a-repository-carrying-its-own-clang-format-is-formatted-by.md
@@ -1,23 +1,21 @@
 # A repository carrying its own `.clang-format` is formatted by that file, asserted by a style that differs from the baseline.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+D-OVERRIDE on the tool that used to demand a config: the fallback exists so an unconfigured repo is still checked, not so procoder's taste beats the project's.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A repository carrying its own `.clang-format` is formatted by that file, asserted by a style that differs from the baseline.
+- [x] A repository carrying its own `.clang-format` is formatted by that file, asserted by a style that differs from the baseline.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/format/ -run TestARepositoryClangFormatWinsOverTheBaseline`: PASS. The fixture sets ColumnLimit: 20, which no builtin style would produce, so a wrapped result distinguishes "the project's file was read" from "a builtin was used". Proved by mutation: dropping --style=file leaves the line unwrapped.

--- a/.procoder/backlog/stories/20260821-a-ts-file-in-a-repository-with-no-eslint-config-is-linted.md
+++ b/.procoder/backlog/stories/20260821-a-ts-file-in-a-repository-with-no-eslint-config-is-linted.md
@@ -1,23 +1,21 @@
 # A `.ts` file in a repository with no eslint config is linted against procoder's baseline and reports a real finding.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The most common TypeScript setup there is — a tsconfig and no eslint config — got no linting and a green gate. Done means it is linted against procoder's baseline.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A `.ts` file in a repository with no eslint config is linted against procoder's baseline and reports a real finding.
+- [x] A `.ts` file in a repository with no eslint config is linted against procoder's baseline and reports a real finding.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+Three tests in internal/lint/tsbaseline_test.go: the generated config imports the entry by absolute path; a stub package proves the wiring end to end with a no-debugger finding at its line (runs in CI); and the real package proves a type annotation is not a syntax error. Proved by mutation: dropping the parser config yields `Parsing error: Unexpected token :`, and making lintTSBaseline return notChecked unconditionally kills the success-path test while the refusal test still passes — which is exactly the hole review found.

--- a/.procoder/backlog/stories/20260821-mts-and-cts-files-reach-the-same-linter-as-ts-and-pyi.md
+++ b/.procoder/backlog/stories/20260821-mts-and-cts-files-reach-the-same-linter-as-ts-and-pyi.md
@@ -1,23 +1,21 @@
 # `.mts` and `.cts` files reach the same linter as `.ts`, and `.pyi` reaches ruff, asserted by a fixture of each.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+`.mjs` and `.cjs` linted while `.mts` and `.cts` did not, and `.pyi` was formatted and never linted. Silence by omission, not by decision.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `.mts` and `.cts` files reach the same linter as `.ts`, and `.pyi` reaches ruff, asserted by a fixture of each.
+- [x] `.mts` and `.cts` files reach the same linter as `.ts`, and `.pyi` reaches ruff, asserted by a fixture of each.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/lint/ -run TestEveryFormattedExtensionReachesALinterOrSaysItDoesNot`: PASS over .mts, .cts, .pyi, .cpp, .c, .cs and .dart. Proved by mutation: removing .mts/.cts from the dispatch reports `a.mts reaches no linter and reports nothing — a silent pass`. Run end to end — `procoder lint bad.mts bad.cts` returned four findings where it previously returned none.

--- a/.procoder/backlog/stories/20260821-no-domain-anywhere-in-the-tree-reports-a-check-that-did-not.md
+++ b/.procoder/backlog/stories/20260821-no-domain-anywhere-in-the-tree-reports-a-check-that-did-not.md
@@ -1,23 +1,21 @@
 # No domain anywhere in the tree reports a check that did not run as merely informational — asserted by an audit over the source, so a domain that does not exist yet is covered too.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The question was whether this covered all the gates. It did not: it covered the two that had been noticed. Done means every domain, and an audit that covers domains not written yet.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] No domain anywhere in the tree reports a check that did not run as merely informational — asserted by an audit over the source, so a domain that does not exist yet is covered too.
+- [x] No domain anywhere in the tree reports a check that did not run as merely informational — asserted by an audit over the source, so a domain that does not exist yet is covered too.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/audit/ -run TestNoDomainReportsAnUnrunCheckAsMerelyInformational`: PASS, 13 NOT-checked findings across the tree, 0 non-blocking. The sweep found three more — tflint missing left Terraform unlinted, helm lint failing without findings left a chart unchecked, and a missing gh left GitHub Pages unverified. Proved by mutation: un-blocking the tflint branch makes the audit name internal/infra/infra.go:258. It reads source rather than behaviour because the failure worth preventing is a domain nobody has written yet.

--- a/.procoder/backlog/stories/20260821-procoder-doctor-lists-every-new-default-tool-with-its.md
+++ b/.procoder/backlog/stories/20260821-procoder-doctor-lists-every-new-default-tool-with-its.md
@@ -1,23 +1,21 @@
 # `procoder doctor` lists every new default tool with its install line, and `procoder init` plans to install them.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A blocking refusal with no remedy is a wall. Done means doctor names every default tool and init can install it — and that the install actually resolves afterwards.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder doctor` lists every new default tool with its install line, and `procoder init` plans to install them.
+- [x] `procoder doctor` lists every new default tool with its install line, and `procoder init` plans to install them.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+Run end to end: `procoder doctor` in a TypeScript project lists `typescript-eslint ... present` via the Resolved hook (a library has no binary to find on PATH), and in a bare PHP project prints `GAP phpstan ... missing` with `procoder init` planning `composer global require phpstan/phpstan`. Two remedies that did not work were found in review and fixed: brew's llvm keg leaves clang-tidy off PATH, and the PHP plugin was installed globally while resolution walks the project — both would have installed successfully and left the file still blocked.

--- a/.procoder/backlog/stories/20260821-with-no-linter-installed-procoder-check-over-a-file-of-that.md
+++ b/.procoder/backlog/stories/20260821-with-no-linter-installed-procoder-check-over-a-file-of-that.md
@@ -1,23 +1,21 @@
 # With no linter installed, `procoder check` over a file of that language exits 1 and the NOT-checked line is BLOCKING, not info.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: no-silent-green
 Sprint: 009-no-silent-green-every-gate-says-when-it-did-not-run
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+Anyone adopting procoder needs the first green gate to mean the code was checked, not that the machine was empty. Done means a linter that could not run stops the commit, the way a missing gitleaks always has.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] With no linter installed, `procoder check` over a file of that language exits 1 and the NOT-checked line is BLOCKING, not info.
+- [x] With no linter installed, `procoder check` over a file of that language exits 1 and the NOT-checked line is BLOCKING, not info.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/lint/ -run TestAMissingLinterBlocksRegardlessOfPolicy`: PASS. Proved by mutation: removing `Blocking: true` from notChecked makes it fail. Run end to end — a Go file with PATH stripped to /usr/bin:/bin printed `BLOCKING ... NOT checked — golangci-lint` and procoder exited 1, where the same command exited 0 before.


### PR DESCRIPTION
Bookkeeping for #114. Every story carries the command that proved it and the mutation that makes its test fail.

Two of the eleven record remedies that **did not work** until review caught them — worth keeping in the record because they were worse than the silence the sprint replaced:

- `brew install llvm` is keg-only, so `clang-tidy` stayed off PATH: init would install it, the resurvey would still say missing, and C/C++ stayed blocked by a command already run.
- The PHP plugin installed globally while resolution walks the project's `node_modules`.

Sprint 008's retro is in here too — the controller refuses to open a new sprint without it, which is how it got written rather than skipped.