### PR TITLE
backlog: sprint 010 opens over configurable-defaults

### DIFF
--- a/.procoder/backlog/epics/configurable-defaults.md
+++ b/.procoder/backlog/epics/configurable-defaults.md
@@ -1,0 +1,12 @@
+# configurable-defaults
+
+Status: open
+Created: 2026-08-21
+Spec: configurable-defaults @ a301ce2e50e0
+
+## Description
+
+<!-- What this epic delivers and why it is one coherent unit of value.
+     Stories reference this epic by its file name. -->
+
+Seeded from .procoder/specs/configurable-defaults.md — one story per acceptance criterion.

--- a/.procoder/backlog/sprints/010-configurable-defaults-the-repository-decides-and-says-so.md
+++ b/.procoder/backlog/sprints/010-configurable-defaults-the-repository-decides-and-says-so.md
@@ -1,0 +1,36 @@
+# Configurable defaults: the repository decides, and says so
+
+Status: active
+Created: 2026-08-21
+
+## Goal
+
+A team can drive Procoder with the tools and thresholds they already
+chose, instead of running a second set beside them or abandoning the
+domain. Which tool answers for a language, what severity blocks, what a
+template says, what a baseline checks — all of it moves from being
+Procoder's decision to being the repository's, through the mechanisms
+`.procoder/` already has rather than a new one.
+
+Two things hold it honest. A repository can only select tools Procoder
+knows how to invoke, so the print-don't-write contract stays a guarantee
+rather than a hope. And a setting that weakens a default prints a line
+naming what was relaxed, because a green gate must never be able to mean
+"the config was loosened" without saying so.
+
+The sprint is finished when a repository that changes nothing behaves
+exactly as it did, and a repository that changes everything can still be
+read by a stranger — `procoder config` names every effective setting and
+where it came from.
+
+## Stories
+
+<!-- pulled below -->
+
+## Retro
+
+<!-- What slowed us down this sprint. -->
+
+<!-- What we change next sprint because of it. -->
+
+<!-- One adaptation from this sprint worth keeping. -->

--- a/.procoder/backlog/stories/20260821-a-checks-list-in-a-domain-s-rules-md-replaces-that-domain-s.md
+++ b/.procoder/backlog/stories/20260821-a-checks-list-in-a-domain-s-rules-md-replaces-that-domain-s.md
@@ -1,0 +1,23 @@
+# A `## checks` list in a domain's RULES.md replaces that domain's baseline check set; a RULES.md with no such section keeps the default.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A `## checks` list in a domain's RULES.md replaces that domain's baseline check set; a RULES.md with no such section keeps the default.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-config-toml-that-cannot-be-parsed-reports-the-failure.md
+++ b/.procoder/backlog/stories/20260821-a-config-toml-that-cannot-be-parsed-reports-the-failure.md
@@ -1,0 +1,23 @@
+# A config.toml that cannot be parsed reports the failure, blocks, and does not silently run on defaults.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A config.toml that cannot be parsed reports the failure, blocks, and does not silently run on defaults.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-repository-lowering-any-default-gets-a-line-in-the-gate.md
+++ b/.procoder/backlog/stories/20260821-a-repository-lowering-any-default-gets-a-line-in-the-gate.md
@@ -1,0 +1,23 @@
+# A repository lowering any default gets a line in the gate output naming the setting, its value, and the default it replaced.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository lowering any default gets a line in the gate output naming the setting, its value, and the default it replaced.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint.md
+++ b/.procoder/backlog/stories/20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint.md
@@ -1,0 +1,23 @@
+# A repository setting `[tools] php = "pint"` is formatted by pint, and `procoder doctor` lists pint rather than prettier.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository setting `[tools] php = "pint"` is formatted by pint, and `procoder doctor` lists pint rather than prettier.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-repository-upgrading-with-no-config-changes-produces-byte.md
+++ b/.procoder/backlog/stories/20260821-a-repository-upgrading-with-no-config-changes-produces-byte.md
@@ -1,0 +1,23 @@
+# A repository upgrading with no config changes produces byte-identical gate output to the previous version, asserted on a fixture.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository upgrading with no config changes produces byte-identical gate output to the previous version, asserted on a fixture.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-tools-entry-naming-a-tool-procoder-does-not-ship-is.md
+++ b/.procoder/backlog/stories/20260821-a-tools-entry-naming-a-tool-procoder-does-not-ship-is.md
@@ -1,0 +1,23 @@
+# A `[tools]` entry naming a tool Procoder does not ship is reported by name, lists what is available, and the default is used — the file is still checked.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A `[tools]` entry naming a tool Procoder does not ship is reported by name, lists what is available, and the default is used — the file is still checked.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-an-empty-template-file-blocks-rather-than-falling-back-to.md
+++ b/.procoder/backlog/stories/20260821-an-empty-template-file-blocks-rather-than-falling-back-to.md
@@ -1,0 +1,23 @@
+# An empty template file blocks rather than falling back to the default, asserted against the existing empty-documentation guard.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] An empty template file blocks rather than falling back to the default, asserted against the existing empty-documentation guard.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-procoder-config-prints-every-effective-setting-with-its.md
+++ b/.procoder/backlog/stories/20260821-procoder-config-prints-every-effective-setting-with-its.md
@@ -1,0 +1,23 @@
+# `procoder config` prints every effective setting with its source, and a repository with no config.toml shows every source as default.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder config` prints every effective setting with its source, and a repository with no config.toml shows every source as default.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-procoder-templates-story-md-replaces-the-embedded-story.md
+++ b/.procoder/backlog/stories/20260821-procoder-templates-story-md-replaces-the-embedded-story.md
@@ -1,0 +1,23 @@
+# `.procoder/templates/story.md` replaces the embedded story template in `backlog story` output, and a repository without the file gets the embedded one unchanged.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `.procoder/templates/story.md` replaces the embedded story template in `backlog story` output, and a repository without the file gets the embedded one unchanged.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-raising-a-default-prints-no-such-line-strengthening-is-not.md
+++ b/.procoder/backlog/stories/20260821-raising-a-default-prints-no-such-line-strengthening-is-not.md
@@ -1,0 +1,23 @@
+# Raising a default prints no such line — strengthening is not a warning.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] Raising a default prints no such line — strengthening is not a warning.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-security-sast-blocks-at-warning-makes-a-warning-finding.md
+++ b/.procoder/backlog/stories/20260821-security-sast-blocks-at-warning-makes-a-warning-finding.md
@@ -1,0 +1,23 @@
+# `[security] sast_blocks_at = "WARNING"` makes a WARNING finding block, where the default blocks only at ERROR.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `[security] sast_blocks_at = "WARNING"` makes a WARNING finding block, where the default blocks only at ERROR.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-setting-a-severity-procoder-does-not-recognise-names-it-and.md
+++ b/.procoder/backlog/stories/20260821-setting-a-severity-procoder-does-not-recognise-names-it-and.md
@@ -1,0 +1,23 @@
+# Setting a severity Procoder does not recognise names it and uses the default, and the run still reports findings.
+
+Status: open
+Created: 2026-08-21
+Epic: configurable-defaults
+Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] Setting a severity Procoder does not recognise names it and uses the default, and the run still reports findings.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->


### PR DESCRIPTION
Seeds #121's spec into twelve stories, one per acceptance criterion, and opens sprint 010.

The story list, in the order the sprint will meet them:

| | |
| --- | --- |
| `[tools] php = "pint"` formats with pint, and doctor lists it | tool selection |
| an unknown tool name is reported, and the default still checks the file | tool selection |
| `sast_blocks_at = "WARNING"` makes a WARNING block | security levels |
| an unrecognised severity is named, default used, findings still reported | security levels |
| lowering a default prints what was relaxed | visibility |
| raising one prints nothing | visibility |
| `.procoder/templates/story.md` replaces the embedded template | templates |
| an empty template blocks rather than falling back | templates |
| a `## checks` list in RULES.md replaces a baseline | rule sets |
| `procoder config` names every setting and its source | visibility |
| an unparseable config blocks rather than running on defaults | safety |
| **a repo that changes nothing produces byte-identical output** | safety |

That last one is the story protecting everyone who is happy as things are, and it is why the sprint can be large without being risky.