### PR TITLE
feat: the configuration says what it is, and what it could not apply

### DIFF
--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -500,6 +500,8 @@ func run(args []string) int {
 		return sprintCmd(args[1:])
 	case "check":
 		return gate.Run(args[1:], doctor.Root(), os.Stdout)
+	case "config":
+		return config.Report(doctor.Root(), os.Stdout)
 	case "doctor":
 		return doctor.Run(doctor.Root(), os.Stdout)
 	case "init":

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,3 +190,26 @@ where the code is:
   `procoder bench` compares against. Committed rather than derived: it
   is a deliberate decision, written only by `bench --save`, and a
   baseline recorded on another GOOS/GOARCH compares with a warning.
+
+## `[security]`
+
+| key              | values                     | default | meaning                                         |
+| ---------------- | -------------------------- | ------- | ----------------------------------------------- |
+| `sast_blocks_at` | `INFO`, `WARNING`, `ERROR` | `ERROR` | the lowest semgrep severity that stops a commit |
+
+`ERROR` is the level semgrep reserves for findings it is confident about.
+Lowering the bar to `WARNING` makes more findings block — a strengthening,
+and silent. Raising it makes fewer block, which is a relaxation and prints
+on every gate run.
+
+## Seeing the effective configuration
+
+`procoder config` prints every setting, its value, and where that value
+came from — `default`, or the config file and line. A setting weaker than
+its default is marked, so a reader of an unfamiliar repository can tell at
+a glance which of Procoder's defaults are still in force.
+
+A setting Procoder cannot apply — a mistyped key, a value of the wrong
+kind — is **not** silently ignored. It is reported with its line number
+and it blocks, because a config that quietly reverts to defaults lets a
+team believe a setting is in force when it never was.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -65,22 +67,54 @@ type Config struct {
 	// being reported. Off by default — procoder never blocks a repository
 	// by surprise on upgrade.
 	DocsBlock bool
+	// SastBlocksAt is the lowest semgrep severity that stops a commit.
+	// ERROR by default: the level the tool itself reserves for findings it
+	// is confident about.
+	SastBlocksAt string
+	// Settings is every effective value and where it came from — the data
+	// behind `procoder config`. A reader of an unfamiliar repository has to
+	// be able to ask which defaults are still in force.
+	Settings []Setting
+	// Problems are settings the file names that could not be used. They
+	// block: a config that silently falls back lets a team believe a
+	// setting is in force when it never was.
+	Problems []Problem
 }
 
 // Defaults per the design contract.
 const defaultMaxFileMB = 5
 
+// defaultSastBlocksAt is the severity semgrep reserves for findings it is
+// confident about. Lower it and more blocks; raise it and less does.
+const defaultSastBlocksAt = "ERROR"
+
 // Load reads .procoder/config.toml under root. A missing file is the normal
 // case and returns defaults; an unreadable line is skipped rather than
 // guessed at.
 func Load(root string) Config {
-	cfg := Config{MaxFileMB: defaultMaxFileMB, DebtMarker: "debt:", CommitGate: "block"}
+	cfg := Config{MaxFileMB: defaultMaxFileMB, DebtMarker: "debt:", CommitGate: "block",
+		SastBlocksAt: defaultSastBlocksAt}
+	defaults := map[string]string{
+		"git.commit_gate": "block",
+		"git.max_file_mb": strconv.Itoa(defaultMaxFileMB),
+		"version.check":   "warn",
+		"sprint.retro":    "on",
+		// 10, not 0: zero is the field's unset value and bench turns it
+		// into 10 downstream. Calling 10 a relaxation from 0 would print a
+		// warning at every repository that set the default explicitly, and
+		// a false relaxation line teaches the reader to skim the real ones.
+		"bench.threshold":         "10",
+		"security.sast_blocks_at": defaultSastBlocksAt,
+	}
 	raw, err := os.ReadFile(filepath.Join(root, ".procoder", "config.toml"))
 	if err != nil {
+		cfg.Settings = defaultSettings(defaults)
 		return cfg
 	}
+	seen := map[string]Setting{}
 	section := ""
-	for _, line := range strings.Split(string(raw), "\n") {
+	for n, line := range strings.Split(string(raw), "\n") {
+		lineNo := n + 1
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -91,6 +125,11 @@ func Load(root string) Config {
 		}
 		key, value, ok := strings.Cut(line, "=")
 		if !ok {
+			// A line that is neither a section nor an assignment was meant
+			// to be something. Reporting it is the difference between a
+			// typo the writer can see and a setting they think is on.
+			cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
+				Reason: "not a section header or a key = value assignment"})
 			continue
 		}
 		key = section + "." + strings.TrimSpace(key)
@@ -142,10 +181,76 @@ func Load(root string) Config {
 		case "git.max_file_mb":
 			if n, err := strconv.Atoi(value); err == nil && n > 0 {
 				cfg.MaxFileMB = n
+			} else {
+				cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
+					Reason: "git.max_file_mb wants a positive whole number"})
+			}
+		case "security.sast_blocks_at":
+			if KnownSeverity(value) {
+				cfg.SastBlocksAt = value
+			} else {
+				cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
+					Reason: "not a severity semgrep reports (INFO, WARNING, ERROR)"})
+			}
+		default:
+			// A key procoder does not know is a key that does nothing, and
+			// a writer who mistypes `policy` believes their policy is set.
+			cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
+				Reason: "no setting by this name — it has no effect"})
+			continue
+		}
+		seen[key] = Setting{Key: key, Value: value,
+			Source: fmt.Sprintf(".procoder/config.toml:%d", lineNo)}
+	}
+	cfg.Settings = mergeSettings(defaults, seen)
+	return cfg
+}
+
+// defaultSettings is the effective set for a repository with no config.
+func defaultSettings(defaults map[string]string) []Setting {
+	return mergeSettings(defaults, nil)
+}
+
+// mergeSettings lists every setting that has a default, plus anything the
+// file set, marking the ones whose value is weaker than the default.
+func mergeSettings(defaults map[string]string, seen map[string]Setting) []Setting {
+	keys := map[string]bool{}
+	for k := range defaults {
+		keys[k] = true
+	}
+	for k := range seen {
+		keys[k] = true
+	}
+	names := make([]string, 0, len(keys))
+	for k := range keys {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	out := make([]Setting, 0, len(names))
+	for _, k := range names {
+		def := defaults[k]
+		s, ok := seen[k]
+		if !ok {
+			s = Setting{Key: k, Value: def, Source: "default"}
+		}
+		s.Default = def
+		if ok && def != "" {
+			if weaker, why := isRelaxed(k, s.Value, def); weaker {
+				s.Relaxed, s.Why = true, why
 			}
 		}
+		out = append(out, s)
 	}
-	return cfg
+	return out
+}
+
+func isRelaxed(key, value, def string) (bool, string) {
+	f, ok := relaxations[key]
+	if !ok {
+		return false, ""
+	}
+	return f(value, def)
 }
 
 // parseList reads the one list shape the config uses: ["a", "b"]. The

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -46,6 +47,14 @@ default_branch_policy = "report"
 	cfg := Load(dir)
 	if cfg.MaxFileMB != 5 || cfg.BlockDefaultBranch {
 		t.Fatalf("got %+v", cfg)
+	}
+	// Skipped, and no longer silently: a value procoder could not use is
+	// reported, or the writer believes a limit is in force that is not.
+	if len(cfg.Problems) != 1 {
+		t.Fatalf("the unusable value must be reported: %+v", cfg.Problems)
+	}
+	if !strings.Contains(cfg.Problems[0].Reason, "whole number") {
+		t.Errorf("the reason must say what was wanted: %q", cfg.Problems[0].Reason)
 	}
 }
 

--- a/internal/config/report.go
+++ b/internal/config/report.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"io"
+
+	"procoder/internal/gitx"
+)
+
+// Report is `procoder config`: every effective setting, its value, and
+// where that value came from.
+//
+// This exists because configurability without visibility is worse than
+// none. Once a repository can change this much, a person reading an
+// unfamiliar one has to be able to ask which of procoder's defaults are
+// still in force — and get an answer that names the source of each rather
+// than a file they have to diff against a version they do not have.
+func Report(root string, stdout io.Writer) int {
+	cfg := Load(root)
+	fmt.Fprintln(stdout, "setting                     value        source")
+	for _, s := range cfg.Settings {
+		mark := ""
+		if s.Relaxed {
+			mark = "  ← relaxed from " + s.Default
+		}
+		fmt.Fprintf(stdout, "%-27s %-12s %s%s\n", s.Key, s.Value, s.Source, mark)
+	}
+	if len(cfg.Problems) == 0 {
+		return 0
+	}
+	fmt.Fprintln(stdout)
+	for _, p := range cfg.Problems {
+		fmt.Fprintln(stdout, "NOT applied  "+p.String())
+	}
+	return 1
+}
+
+// Findings are the configuration's contribution to the gate: what could
+// not be applied, and what was deliberately loosened.
+//
+// A problem blocks. A relaxation does not — the repository chose it, and
+// blocking would make the setting useless — but it prints on every run,
+// because a green gate must never be able to mean "the config was
+// loosened" without saying so.
+func (c Config) Findings() []gitx.Finding {
+	var out []gitx.Finding
+	for _, p := range c.Problems {
+		out = append(out, gitx.Finding{Blocking: true, File: ".procoder/config.toml", Line: p.Line,
+			Message: "NOT applied — " + p.Reason + ": " + p.Text + " (config)"})
+	}
+	for _, s := range c.Settings {
+		if !s.Relaxed {
+			continue
+		}
+		out = append(out, gitx.Finding{File: ".procoder/config.toml",
+			Message: fmt.Sprintf("relaxed: %s = %s, weaker than the default %s — %s (config)",
+				s.Key, s.Value, s.Default, s.Why)})
+	}
+	return out
+}

--- a/internal/config/visibility.go
+++ b/internal/config/visibility.go
@@ -1,0 +1,79 @@
+package config
+
+import "fmt"
+
+// A repository may weaken any default, and must not be able to do it
+// quietly. The gate already refuses to let "nothing checked this" look
+// like "this is clean"; a loosened setting is the same claim wearing a
+// different hat — a green verdict that means the config was relaxed, not
+// that the code was good.
+//
+// Strengthening prints nothing. A team raising its own bar does not need
+// to be told, and a line for every tightened setting would train the
+// reader to skim exactly the place the relaxations appear.
+
+// Setting is one effective configuration value and where it came from.
+type Setting struct {
+	Key     string
+	Value   string
+	Source  string // "default", or "config.toml:<line>"
+	Default string
+	Relaxed bool   // weaker than the default
+	Why     string // what the relaxation costs, in one clause
+}
+
+// Problem is a setting the file names that procoder could not use. It
+// blocks: a config that silently reverts to defaults lets a team believe
+// a setting is in force when it never was, which is the failure this
+// whole feature would otherwise introduce.
+type Problem struct {
+	Line   int
+	Text   string
+	Reason string
+}
+
+func (p Problem) String() string {
+	return fmt.Sprintf(".procoder/config.toml:%d — %s (%s)", p.Line, p.Reason, p.Text)
+}
+
+// relaxations describes, for each setting that CAN be weakened, what
+// weaker means. A setting absent here cannot be relaxed — either because
+// any value is a lateral move, or because the stricter direction is the
+// only one the key offers.
+var relaxations = map[string]func(value, def string) (bool, string){
+	"git.commit_gate": func(v, _ string) (bool, string) {
+		return v != "block", "commits with blocking findings are no longer stopped"
+	},
+	"version.check": func(v, _ string) (bool, string) {
+		return v == "off", "an out-of-date procoder no longer says so"
+	},
+	"sprint.retro": func(v, _ string) (bool, string) {
+		return v == "off", "a sprint can close without recording what it taught"
+	},
+	"git.max_file_mb": func(v, def string) (bool, string) {
+		return atoiOr(v, 0) > atoiOr(def, 0), "larger files reach the repository"
+	},
+	"bench.threshold": func(v, def string) (bool, string) {
+		return atoiOr(v, 0) > atoiOr(def, 0), "a bigger performance regression passes"
+	},
+	"security.sast_blocks_at": func(v, def string) (bool, string) {
+		return severityRank(v) > severityRank(def), "SAST findings below this severity no longer block"
+	},
+}
+
+// severityRank orders the severities semgrep reports. Higher means fewer
+// findings block, so a higher rank than the default is a relaxation.
+func severityRank(s string) int {
+	switch s {
+	case "INFO":
+		return 0
+	case "WARNING":
+		return 1
+	case "ERROR":
+		return 2
+	}
+	return -1 // unknown: never treated as a relaxation, and reported elsewhere
+}
+
+// KnownSeverity reports whether s is a severity procoder can act on.
+func KnownSeverity(s string) bool { return severityRank(s) >= 0 }

--- a/internal/config/visibility_test.go
+++ b/internal/config/visibility_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".procoder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".procoder", "config.toml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// A setting procoder cannot apply must block. Silently falling back to the
+// default lets a team believe a setting is in force when it never was —
+// which is the failure configurability would otherwise introduce, and the
+// same shape as a gate that reports green over code nothing read.
+// proved by: restored the switch's silent fall-through for unknown keys —
+// `polcy = "block"` is accepted as configured, does nothing, and the gate
+// says nothing.
+func TestASettingProcoderCannotApplyBlocks(t *testing.T) {
+	root := writeConfig(t, "[lint]\npolcy = \"block\"\nthis line is broken\n")
+	cfg := Load(root)
+	if len(cfg.Problems) != 2 {
+		t.Fatalf("both the typo and the broken line must be reported: %+v", cfg.Problems)
+	}
+	var blocking int
+	for _, f := range cfg.Findings() {
+		if f.Blocking {
+			blocking++
+		}
+	}
+	if blocking != 2 {
+		t.Errorf("a setting that could not be applied must block, got %d blocking", blocking)
+	}
+	// The line number is the point: a person has to find it.
+	if cfg.Problems[0].Line != 2 {
+		t.Errorf("the problem must name its line, got %d", cfg.Problems[0].Line)
+	}
+}
+
+// Weakening is allowed and visible; strengthening is allowed and silent.
+// A line for every tightened setting would train the reader to skim the
+// place the relaxations appear.
+// proved by: made isRelaxed return true for any value differing from the
+// default — raising the SAST bar then prints a relaxation line for a
+// repository that made its gate stricter.
+func TestLoweringADefaultPrintsAndRaisingOneDoesNot(t *testing.T) {
+	relaxed := Load(writeConfig(t, "[git]\ncommit_gate = \"report\"\n"))
+	var found bool
+	for _, f := range relaxed.Findings() {
+		if strings.Contains(f.Message, "relaxed: git.commit_gate") {
+			found = true
+			if f.Blocking {
+				t.Error("a relaxation the repository chose must not block — that would make the setting useless")
+			}
+			if !strings.Contains(f.Message, "no longer stopped") {
+				t.Errorf("the line must say what the relaxation costs: %q", f.Message)
+			}
+		}
+	}
+	if !found {
+		t.Error("lowering a default must print")
+	}
+
+	// WARNING is a LOWER bar than ERROR: more findings block. That is a
+	// strengthening and must be silent.
+	strict := Load(writeConfig(t, "[security]\nsast_blocks_at = \"WARNING\"\n"))
+	for _, f := range strict.Findings() {
+		if strings.Contains(f.Message, "relaxed") {
+			t.Errorf("strengthening must print nothing: %q", f.Message)
+		}
+	}
+}
+
+// An unrecognised severity is named and the default used — the run still
+// reports findings rather than silently blocking on nothing.
+// proved by: accepted any string as a severity — `sast_blocks_at =
+// "SEVERE"` then ranks below every real severity and nothing ever blocks.
+func TestAnUnrecognisedSeverityIsNamedAndTheDefaultUsed(t *testing.T) {
+	cfg := Load(writeConfig(t, "[security]\nsast_blocks_at = \"SEVERE\"\n"))
+	if cfg.SastBlocksAt != defaultSastBlocksAt {
+		t.Errorf("an unknown severity must leave the default in force, got %q", cfg.SastBlocksAt)
+	}
+	if len(cfg.Problems) != 1 || !strings.Contains(cfg.Problems[0].Reason, "severity") {
+		t.Fatalf("it must be named: %+v", cfg.Problems)
+	}
+}
+
+// The story that protects everyone who is happy as things are: a
+// repository that changes nothing behaves exactly as it did. Every source
+// reads "default", nothing is relaxed, and nothing blocks.
+// proved by: gave any setting a non-default effective value — a repo with
+// no config.toml then shows a source that is not "default".
+func TestARepositoryWithNoConfigIsAllDefaults(t *testing.T) {
+	root := t.TempDir()
+	cfg := Load(root)
+	if len(cfg.Problems) != 0 {
+		t.Errorf("no config is not a problem: %+v", cfg.Problems)
+	}
+	if len(cfg.Findings()) != 0 {
+		t.Errorf("a repository that configured nothing must produce no config findings: %+v", cfg.Findings())
+	}
+	if len(cfg.Settings) == 0 {
+		t.Fatal("the effective settings must still be listed")
+	}
+	for _, s := range cfg.Settings {
+		if s.Source != "default" {
+			t.Errorf("%s came from %q, want default", s.Key, s.Source)
+		}
+		if s.Relaxed {
+			t.Errorf("%s cannot be relaxed when nothing was configured", s.Key)
+		}
+	}
+
+	// And `procoder config` says so plainly.
+	var buf bytes.Buffer
+	if code := Report(root, &buf); code != 0 {
+		t.Errorf("a repository with no config is not an error, exit %d", code)
+	}
+	if !strings.Contains(buf.String(), "default") {
+		t.Errorf("the report must name the source:\n%s", buf.String())
+	}
+}

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -111,7 +111,11 @@ func CollectFor(root string, cfg config.Config, changed []string, commitMessage 
 // share: it asks only questions whose answer does not depend on something
 // having just changed.
 func collectHygiene(root string, cfg config.Config, changed []string) []gitx.Finding {
-	var out []gitx.Finding
+	// The configuration's own contribution, first: a setting that could not
+	// be applied blocks, and a setting deliberately loosened prints on
+	// every run. It rides here so `check`, `git` and CI cannot disagree
+	// about the config any more than they can about the code.
+	out := cfg.Findings()
 	out = append(out, gitx.ConflictMarkers(changed)...)
 	out = append(out, gitx.JunkFiles(changed)...)
 	out = append(out, gitx.Oversized(changed, cfg.MaxFileMB)...)

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"procoder/internal/config"
 	"procoder/internal/gitx"
 	"procoder/internal/tools"
 )
@@ -227,7 +228,24 @@ func SecretsChangedFiles(root string, files []string) []gitx.Finding {
 
 // Sast runs semgrep with the community rulesets over the repository.
 // ERROR severity blocks; WARNING and INFO report.
+// severityAtLeast reports whether a finding's severity is at or above the
+// bar. An unknown severity from the tool never blocks silently: it is
+// ranked below everything, so it still reports and a human still reads it.
+func severityAtLeast(found, bar string) bool {
+	rank := map[string]int{"INFO": 0, "WARNING": 1, "ERROR": 2}
+	f, ok := rank[found]
+	if !ok {
+		return false
+	}
+	b, ok := rank[bar]
+	if !ok {
+		b = rank["ERROR"]
+	}
+	return f >= b
+}
+
 func Sast(root string) []gitx.Finding {
+	blocksAt := config.Load(root).SastBlocksAt
 	bin := tools.Resolve(Semgrep, root)
 	if bin == "" {
 		return []gitx.Finding{{Blocking: true,
@@ -264,7 +282,13 @@ func Sast(root string) []gitx.Finding {
 	}
 	var out []gitx.Finding
 	for _, r := range rep.Results {
-		blocking := r.Extra.Severity == "ERROR"
+		// The bar is the repository's, not procoder's. ERROR by default —
+		// the level semgrep reserves for findings it is confident about —
+		// and a team that wants WARNING to stop a commit says so in
+		// [security] sast_blocks_at. Lowering it is a strengthening and
+		// prints nothing; raising it is a relaxation and prints on every
+		// gate run.
+		blocking := severityAtLeast(r.Extra.Severity, blocksAt)
 		msg := r.Extra.Message
 		if len(msg) > 200 {
 			msg = msg[:200]


### PR DESCRIPTION
Seven of sprint 010's twelve stories — the visibility half. Without it, the rest of the sprint would make repositories *less* legible rather than more.

### A setting procoder cannot apply now blocks

The loader fell through its `switch` for any key it did not recognise. So this was accepted, did nothing, and said nothing:

```toml
[lint]
polcy = "block"     # believed to be set; was never read
```

Unknown keys, malformed lines, and values of the wrong kind are each reported **with their line number**, and they block — a config that quietly reverts to defaults lets a team believe a setting is in force when it never was.

```
BLOCKING  .procoder/config.toml:6  NOT applied — no setting by this name — it has no effect: polcy = "block"
```

### Weakening prints; strengthening is silent

```
info  relaxed: git.commit_gate = report, weaker than the default block
      — commits with blocking findings are no longer stopped
```

Lowering `sast_blocks_at` to `WARNING` makes *more* findings block — a strengthening, and silent. A line for every tightened setting would train the reader to skim exactly the place the relaxations appear.

### `procoder config`

```
setting                     value    source
git.commit_gate             block    default
git.max_file_mb             10       .procoder/config.toml:16  ← relaxed from 5
security.sast_blocks_at     ERROR    default
```

Configurability without visibility is worse than none.

### The first knob

`[security] sast_blocks_at` — where the code had `r.Extra.Severity == "ERROR"` as a literal.

### One correction found by running it

`bench.threshold`'s real default is **10**, not the field's zero value — bench turns 0 into 10 downstream. My first version called an explicit `10` a relaxation from `0`, which would have printed a warning at every repository that set the default deliberately. A false relaxation line teaches the reader to skim the real ones, so this mattered more than it looks.

All four new tests verified against their named mutations. The story protecting existing users is covered: a repository with no config produces no config findings and every source reads `default`.