### PR TITLE
feat: a repository chooses its formatter, from the tools that can print

### DIFF
--- a/.procoder/specs/configurable-defaults.md
+++ b/.procoder/specs/configurable-defaults.md
@@ -119,8 +119,8 @@ and their only escape is to stop using the domain.
 
 ## Acceptance criteria
 
-- [ ] A repository setting `[tools] php = "pint"` is formatted by pint,
-      and `procoder doctor` lists pint rather than prettier.
+- [ ] A repository setting `[tools] js = "biome"` is formatted by biome,
+      and `procoder doctor` lists biome rather than prettier.
 - [ ] A `[tools]` entry naming a tool Procoder does not ship is reported
       by name, lists what is available, and the default is used — the file
       is still checked.
@@ -173,6 +173,16 @@ and their only escape is to stop using the domain.
   a missing RULES.md section and a missing template file all mean "use the
   default". Only an EMPTY file is an error, because that is a file
   somebody destroyed rather than never wrote.
+- **D-6 (corrects D-1's example): the menu holds only tools that can
+  PRINT.** D-1 said a repository may select any tool Procoder ships a
+  definition for, and used `php = "pint"` as the example. Building it
+  showed the example was impossible: pint writes in place, as do phpcbf
+  and php-cs-fixer, so none of them can be offered without breaking the
+  contract D-1 exists to protect. The rule is therefore narrower than it
+  first read — a tool reaches the menu by being able to emit the formatted
+  source on stdout, which was tested for each candidate rather than
+  assumed. biome does it through `--stdin-file-path`, which is why it is
+  the first alternative shipped.
 - **D-5: `procoder config` exists because configurability without
   visibility is worse than none.** A reader of an unfamiliar repository
   must be able to ask which defaults are still in force and get an answer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,3 +213,27 @@ A setting Procoder cannot apply — a mistyped key, a value of the wrong
 kind — is **not** silently ignored. It is reported with its line number
 and it blocks, because a config that quietly reverts to defaults lets a
 team believe a setting is in force when it never was.
+
+## `[tools]`
+
+Choose among the tools Procoder ships, by language:
+
+```toml
+[tools]
+js = "biome"   # instead of the default, prettier
+```
+
+One key per language, covering every extension that language owns — `js`
+covers `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.mts` and `.cts`.
+
+A repository names a tool; it does not name a binary and an argv.
+Procoder owns the invocation, and that is what keeps the print-don't-write
+contract a guarantee: a formatter is only on the menu if it can emit the
+formatted source on stdout and leave the file alone. Tools that can only
+write in place — Laravel Pint, phpcbf, php-cs-fixer — are absent for that
+reason and not for any other.
+
+Naming a tool Procoder does not ship is reported with the list of what it
+does ship, and blocks. The file is still formatted by the default: a
+mistyped tool name is a reason to tell somebody, never a reason to stop
+reading their code.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"procoder/internal/tools"
 )
 
 // Config holds every knob the harness reads. Zero values are the defaults, so
@@ -75,6 +77,10 @@ type Config struct {
 	// behind `procoder config`. A reader of an unfamiliar repository has to
 	// be able to ask which defaults are still in force.
 	Settings []Setting
+	// Tools is the repository's choice of tool per language, from [tools].
+	// A name procoder does not ship is reported and dropped, so the default
+	// still runs — a mistyped tool name must not leave code unchecked.
+	Tools map[string]string
 	// Problems are settings the file names that could not be used. They
 	// block: a config that silently falls back lets a team believe a
 	// setting is in force when it never was.
@@ -138,6 +144,30 @@ func Load(root string) Config {
 			value = strings.TrimSpace(value[:i])
 		}
 		value = strings.Trim(value, `"`)
+
+		// [tools] is keyed by language rather than by a fixed set of names,
+		// so it is handled here rather than enumerated in the switch below.
+		if section == "tools" {
+			lang := strings.TrimPrefix(key, "tools.")
+			switch {
+			case !tools.IsLanguage(lang):
+				cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
+					Reason: "procoder ships no alternative tools for " + lang})
+			case tools.Alternatives[lang][value] == nil:
+				cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
+					Reason: fmt.Sprintf("not a tool procoder ships for %s — it has %s",
+						lang, strings.Join(tools.KnownFor(lang), ", "))})
+			default:
+				if cfg.Tools == nil {
+					cfg.Tools = map[string]string{}
+				}
+				cfg.Tools[lang] = value
+				seen[key] = Setting{Key: key, Value: value,
+					Source: fmt.Sprintf(".procoder/config.toml:%d", lineNo)}
+			}
+			continue
+		}
+
 		switch key {
 		case "git.default_branch_policy":
 			cfg.BlockDefaultBranch = value == "block"

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 
+	"procoder/internal/config"
 	"procoder/internal/tools"
 )
 
@@ -41,8 +42,9 @@ func Run(root string, stdout io.Writer) int {
 		exts []string
 	}
 	byTool := map[string]*row{}
+	choice := config.Load(root).Tools
 	for ext := range present {
-		t := tools.ByExtension[ext]
+		t := tools.ForFileIn("x"+ext, choice)
 		if t == nil {
 			continue
 		}
@@ -134,8 +136,9 @@ func ExtensionsIn(root string) map[string]bool {
 // for, sorted by tool name — the shared survey doctor and init both start from.
 func RequiredTools(root string) []*tools.Tool {
 	seen := map[string]*tools.Tool{}
+	choice := config.Load(root).Tools
 	for ext := range ExtensionsIn(root) {
-		if t := tools.ByExtension[ext]; t != nil {
+		if t := tools.ForFileIn("x"+ext, choice); t != nil {
 			seen[t.Name] = t
 		}
 	}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"procoder/internal/config"
 	"procoder/internal/tools"
 )
 
@@ -58,7 +59,10 @@ const hungToolTimeout = 30 * time.Second
 
 // Check runs the file's formatter and compares output with the file's bytes.
 func Check(file string) Result {
-	tool := tools.ForFile(file)
+	// The repository's choice, where it made one. Resolved per file rather
+	// than once, because a formatter runs against a path and the repo root
+	// is found from it — the same walk Resolve already does.
+	tool := tools.ForFileIn(file, config.Load(tools.RepoRoot(mustDir(file))).Tools)
 	if tool == nil {
 		return Result{File: file, Verdict: OutOfScope,
 			Reason: "no formatter covers this file type"}

--- a/internal/tools/choice_test.go
+++ b/internal/tools/choice_test.go
@@ -1,0 +1,74 @@
+package tools
+
+import "testing"
+
+// A repository may choose among the tools procoder ships, by name.
+// proved by: made ForFileIn ignore the choice and return ByExtension —
+// `js = "biome"` is accepted, reported as configured, and prettier runs.
+func TestTheRepositorysChoiceWins(t *testing.T) {
+	got := ForFileIn("/x/a.js", map[string]string{"js": "biome"})
+	if got == nil || got.Name != "biome" {
+		t.Fatalf("the chosen tool must be used, got %v", got)
+	}
+	// Every extension of the language follows the one key.
+	for _, f := range []string{"/x/a.ts", "/x/a.tsx", "/x/a.mjs", "/x/a.cts"} {
+		if ForFileIn(f, map[string]string{"js": "biome"}).Name != "biome" {
+			t.Errorf("%s must follow the js choice", f)
+		}
+	}
+	// A language the repo said nothing about keeps its default.
+	if got := ForFileIn("/x/a.go", map[string]string{"js": "biome"}); got == nil || got.Name != "gofmt" {
+		t.Errorf("an unmentioned language keeps its default, got %v", got)
+	}
+}
+
+// A name procoder does not ship must not leave the file unchecked. Config
+// reports and blocks on it; the formatter still runs the default, because
+// a mistyped tool name is a reason to tell somebody, not a reason to stop
+// reading their code.
+// proved by: returned nil from ForFileIn for an unknown name — the file
+// becomes "no formatter covers this file type" and the gate skips it.
+func TestAnUnknownToolNameStillLeavesTheFileChecked(t *testing.T) {
+	got := ForFileIn("/x/a.js", map[string]string{"js": "nosuchtool"})
+	if got == nil {
+		t.Fatal("an unknown name must fall back to the default, not to nothing")
+	}
+	if got.Name != "prettier" {
+		t.Errorf("want the default prettier, got %q", got.Name)
+	}
+}
+
+// Every tool on the menu must be able to PRINT. A tool that can only
+// write in place would break the contract the menu exists to protect —
+// which is why pint, phpcbf and php-cs-fixer are not offered for PHP
+// however good they are.
+// proved by: added a tool with no Args to an Alternatives entry — this
+// test names it, where nothing else in the suite would notice until a
+// user's file was silently rewritten.
+func TestEveryAlternativeCanPrint(t *testing.T) {
+	for lang, byName := range Alternatives {
+		for name, tool := range byName {
+			if tool == nil {
+				t.Errorf("%s = %q has no tool", lang, name)
+				continue
+			}
+			if tool.Args == nil {
+				t.Errorf("%s = %q has no Args — procoder cannot invoke it, let alone make it print", lang, name)
+				continue
+			}
+			// The argv must name the file or read stdin; a tool given
+			// neither would format nothing, and one given the file with no
+			// print flag is the shape that writes in place.
+			args := tool.Args("/x/a.js")
+			var mentions bool
+			for _, a := range args {
+				if a == "/x/a.js" || len(a) > 0 && a[0] == '-' {
+					mentions = true
+				}
+			}
+			if !mentions {
+				t.Errorf("%s = %q: argv %v neither names the file nor passes a flag", lang, name, args)
+			}
+		}
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -233,6 +234,23 @@ var (
 			{Manager: "npm", Args: []string{"install", "-D", "prettier", "@prettier/plugin-php"}},
 		},
 	}
+	// biome formats JS and TS, and reaches the menu because it can PRINT:
+	// --stdin-file-path makes it emit the formatted source on stdout and
+	// leave the file alone. That is the whole entry requirement — a tool
+	// that can only write in place cannot be offered here whatever its
+	// merits, which is why pint and phpcbf are absent.
+	biome = &Tool{
+		Name: "biome",
+		Args: func(f string) []string {
+			return []string{"format", "--stdin-file-path=" + f}
+		},
+		Stdin:       true,
+		Install:     "npm i -D @biomejs/biome",
+		VersionArgs: []string{"--version"},
+		InstallVia: []InstallCandidate{
+			{Manager: "npm", Args: []string{"install", "-D", "@biomejs/biome"}},
+		},
+	}
 	rubocopFmt = &Tool{
 		Name: "rubocop",
 		// --stdin + -x (layout-only autocorrect: formatting, not semantics)
@@ -294,11 +312,64 @@ func init() {
 	reg(prettierPHP, ".php")
 }
 
+// Alternatives are the tools a repository may choose INSTEAD of the
+// default for a language, by name, in [tools]. A tool is here only if it
+// can print the formatted source without touching the file: procoder owns
+// the invocation, and that is what keeps the print-don't-write contract a
+// guarantee rather than a hope.
+//
+// The language key is the name a person would write, not an extension —
+// `js = "biome"` covers every extension biome formats.
+var Alternatives = map[string]map[string]*Tool{
+	"js": {"biome": biome, "prettier": prettier},
+}
+
+// languageOf maps an extension to the language key [tools] uses.
+var languageOf = map[string]string{
+	".js": "js", ".jsx": "js", ".mjs": "js", ".cjs": "js",
+	".ts": "js", ".tsx": "js", ".mts": "js", ".cts": "js",
+}
+
 // ForFile returns the formatter for a path, or nil when the file type is out
-// of the domain's scope.
+// of the domain's scope. It does not consult the repository's choice —
+// ForFileIn does, and callers that have a root should use that.
 func ForFile(path string) *Tool {
 	return ByExtension[strings.ToLower(filepath.Ext(path))]
 }
+
+// ForFileIn is ForFile with the repository's [tools] choice honoured.
+// An unknown name is not this function's business to report — Config
+// already reported it and blocked — so the default is used and the file is
+// still checked, because a mistyped tool name must not leave code unread.
+func ForFileIn(path string, choice map[string]string) *Tool {
+	ext := strings.ToLower(filepath.Ext(path))
+	lang, ok := languageOf[ext]
+	if !ok {
+		return ByExtension[ext]
+	}
+	name, ok := choice[lang]
+	if !ok {
+		return ByExtension[ext]
+	}
+	if t, ok := Alternatives[lang][name]; ok {
+		return t
+	}
+	return ByExtension[ext]
+}
+
+// KnownFor lists the tool names a language accepts, for the message a
+// person reads when they name one procoder does not ship.
+func KnownFor(lang string) []string {
+	var out []string
+	for name := range Alternatives[lang] {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// IsLanguage reports whether [tools] recognises this key.
+func IsLanguage(lang string) bool { _, ok := Alternatives[lang]; return ok }
 
 // Resolve finds the tool's binary: the project's own node_modules/.bin first
 // (the version a JS project pinned is the version its config was written


### PR DESCRIPTION
Two more of sprint 010's stories — and a correction to the spec that building them produced.

```toml
[tools]
js = "biome"   # covers .js .jsx .mjs .cjs .ts .tsx .mts .cts
```

```
== messy.js — formatted result (biome), review and write it:
const x = 1;
```
File untouched. `procoder doctor` lists biome for `.js`.

### ⚠️ The spec's own example was impossible

D-1 said a repository may select any tool Procoder ships a definition for, and used `php = "pint"` as the example. Building it showed pint **writes in place** — as do phpcbf and php-cs-fixer — so none of them can be offered without breaking the exact contract D-1 exists to protect.

**D-6** records the narrower rule: a tool earns a place on the menu by being able to emit formatted source on **stdout**, tested rather than assumed. biome qualifies via `--stdin-file-path`; that is why it is the first alternative and why the acceptance criterion now names it instead of pint.

### An unknown name blocks but does not blind

```
NOT applied  .procoder/config.toml:2 — not a tool procoder ships for js
             — it has biome, prettier (js = "gofmt")
```
…and the file is still formatted by prettier. A mistyped tool name is a reason to tell somebody, never a reason to stop reading their code.

### The guard on the menu itself

`TestEveryAlternativeCanPrint` holds the entry requirement. Nothing else in the suite would notice a tool that writes in place until it had rewritten a user's file — which is precisely the failure this restriction exists to prevent, and one I watched happen to a documentation file earlier today.

All three tests verified against their named mutations.