### PR TITLE
feat: the templates and the check lists are the repository's too

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,3 +237,35 @@ Naming a tool Procoder does not ship is reported with the list of what it
 does ship, and blocks. The file is still formatted by the default: a
 mistyped tool name is a reason to tell somebody, never a reason to stop
 reading their code.
+
+## `.procoder/templates/`
+
+The nine templates that drive the quality chain — spec, plan, ADR, todo,
+milestone, epic, story, sprint, bug — plus a changelog template, are the
+repository's to replace. Put a file at `.procoder/templates/<name>.md` and
+it wins; leave it out and Procoder's own is used.
+
+An **empty** template file is an error, not a fallback. It blocks, and
+Procoder uses its own template for that run while saying so. The reason is
+specific: `procoder format` prints a single header line for a file that is
+already formatted and nothing after it, so a pipeline that strips the
+header and writes the rest empties the file on the success path. Falling
+back quietly would mean a team discovers their customised template is gone
+when their next story comes out in Procoder's shape instead of theirs.
+
+## `.procoder/lint/RULES.md`
+
+The lint domain reads rules the same way `docs` and `security` do: prose
+for the agent, with list sections a machine reads. A section that is
+present replaces the default; a section that is absent keeps it.
+
+```markdown
+## checks
+
+- `readability-*`
+- `bugprone-*`
+```
+
+That list replaces Procoder's curated clang-tidy families. Replace means
+replace — a family left out does not survive. A project `.clang-tidy`
+still wins over both: that is the tool's own configuration.

--- a/internal/backlog/items.go
+++ b/internal/backlog/items.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"procoder/internal/templates"
 	"procoder/internal/textutil"
 )
 
@@ -260,7 +261,15 @@ func Story(root, title, epic string, out func(string)) int {
 		slug = time.Now().UTC().Format("20060102") + "-" + slug
 	}
 	return printItem(root, KindStory, slug, title, func(now string) string {
-		return fmt.Sprintf(storyTemplate, title, now, epic)
+		body, _, problem := templates.Resolve(root, "story", storyTemplate)
+		if problem != nil {
+			// An emptied template is not a reason to print nothing, but it
+			// must not pass unsaid either: the repository gets procoder's
+			// shape and is told why, loudly enough to notice before every
+			// story afterwards is wrong too.
+			out(problem.Message)
+		}
+		return fmt.Sprintf(body, title, now, epic)
 	}, out)
 }
 

--- a/internal/lint/cfamily.go
+++ b/internal/lint/cfamily.go
@@ -64,8 +64,11 @@ func lintCFamily(root string, files []string, block bool) []gitx.Finding {
 		args := []string{"--quiet"}
 		// The project's own .clang-tidy wins wherever it has one; the
 		// curated set is only for a project that chose nothing.
+		// A project .clang-tidy wins outright — that is the tool's own
+		// config and D-OVERRIDE. Otherwise the repository's `## checks`
+		// list, if it wrote one, and procoder's curated families if not.
 		if hasAny(root, f, []string{".clang-tidy"}) == "" {
-			args = append(args, "--checks="+clangTidyBaseline)
+			args = append(args, "--checks="+checkSet(root))
 		}
 		args = append(args, f, "--", cFamilyStandard(f))
 		raw, err := execute(root, bin, args)

--- a/internal/lint/php_test.go
+++ b/internal/lint/php_test.go
@@ -216,3 +216,42 @@ func TestTheBaselineLevelIsTheMeasuredOne(t *testing.T) {
 		t.Error("the baseline must not pin paths — the files come from the command line")
 	}
 }
+
+// A `## checks` list in the repository's lint rules replaces procoder's
+// curated set; a rules file with no such section keeps it. Absent means
+// default, which is the rule the rest of .procoder/ lives by.
+// proved by: made checkSet join the repository's list onto the baseline
+// instead of replacing it — a repository that narrowed its checks still
+// gets every finding it excluded.
+func TestACheckListReplacesTheBaseline(t *testing.T) {
+	root := t.TempDir()
+	if got := checkSet(root); got != clangTidyBaseline {
+		t.Errorf("no rules file means the baseline, got %q", got)
+	}
+
+	dir := filepath.Join(root, ".procoder", "lint")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A rules file with prose but no checks section keeps the default: a
+	// missing section must not read as "no checks at all".
+	if err := os.WriteFile(filepath.Join(dir, "RULES.md"),
+		[]byte("# Lint rules\n\nSome prose.\n\n## something else\n\n- ignored\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := checkSet(root); got != clangTidyBaseline {
+		t.Errorf("a rules file without a checks section keeps the baseline, got %q", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "RULES.md"),
+		[]byte("# Lint rules\n\n## checks\n\n- `readability-*`\n- `bugprone-*`\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := checkSet(root)
+	if got != "readability-*,bugprone-*" {
+		t.Errorf("the repository's list must replace the baseline, got %q", got)
+	}
+	if strings.Contains(got, "cert-") {
+		t.Error("replace means replace — a family the repository left out must not survive")
+	}
+}

--- a/internal/lint/rules.go
+++ b/internal/lint/rules.go
@@ -1,0 +1,60 @@
+package lint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RulesPath is the lint domain's repo-overridable rules file, following
+// the pattern docs and security already use: prose for the agent, with
+// list sections a machine reads. A section that is present replaces the
+// default for that section; a section that is absent keeps it (D-OVERRIDE,
+// and the "absent means default" rule the rest of .procoder/ lives by).
+const RulesPath = ".procoder/lint/RULES.md"
+
+// Rules is what the repository's RULES.md dictates. The zero value means
+// "use procoder's defaults", so a repo with no file behaves exactly as it
+// did before the file existed.
+type Rules struct {
+	// Checks replaces the curated clang-tidy check set. Empty means the
+	// baseline stands.
+	Checks []string
+}
+
+// LoadRules reads the repository's lint rules.
+func LoadRules(root string) Rules {
+	var r Rules
+	data, err := os.ReadFile(filepath.Join(root, RulesPath))
+	if err != nil {
+		return r
+	}
+	section := ""
+	for _, line := range strings.Split(string(data), "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "## ") {
+			section = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(t, "## ")))
+			continue
+		}
+		if !strings.HasPrefix(t, "- ") {
+			continue
+		}
+		item := strings.TrimSpace(strings.Trim(strings.TrimPrefix(t, "- "), "`"))
+		if item == "" {
+			continue
+		}
+		if section == "checks" {
+			r.Checks = append(r.Checks, item)
+		}
+	}
+	return r
+}
+
+// checkSet is the clang-tidy --checks value: the repository's list when it
+// wrote one, procoder's curated families otherwise.
+func checkSet(root string) string {
+	if c := LoadRules(root).Checks; len(c) > 0 {
+		return strings.Join(c, ",")
+	}
+	return clangTidyBaseline
+}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,0 +1,49 @@
+// Package templates resolves an embedded template against the
+// repository's override.
+//
+// The five templates under .procoder/github/ have always been the
+// repository's to edit; the nine that drive the quality chain — spec,
+// plan, ADR, todo, milestone, epic, story, sprint, bug — were embedded
+// constants with no way in. A team whose stories carry an extra field, or
+// whose ADRs follow a house shape, had to choose between the domain and
+// their own format.
+package templates
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// Dir is where a repository puts its own versions.
+const Dir = ".procoder/templates"
+
+// Resolve returns the template body for name, and where it came from.
+//
+// Absent means default — the rule everywhere else in .procoder/. Only an
+// EMPTY file is an error, and it is a blocking one: `procoder format`
+// prints a single header line for an already-formatted file, so a
+// pipeline that strips the header and writes the rest empties the file on
+// the success path. That destroyed a documentation page in this
+// repository. Falling back to the default here would do the same thing to
+// a team's customised template, silently, and they would find out when
+// their next story came out in procoder's shape instead of theirs.
+func Resolve(root, name, embedded string) (body, source string, problem *gitx.Finding) {
+	path := filepath.Join(root, Dir, name+".md")
+	rel := filepath.ToSlash(filepath.Join(Dir, name+".md"))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return embedded, "default", nil
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return embedded, rel, &gitx.Finding{Blocking: true, File: path,
+			Message: fmt.Sprintf("this template is empty — procoder used its own instead. If it was emptied by accident, `git checkout <ref> -- %s` restores it; if it is meant to go, delete the file (templates)", rel)}
+	}
+	return string(data), rel, nil
+}
+
+// Names are the templates a repository may override.
+var Names = []string{"spec", "plan", "adr", "todo", "milestone", "epic", "story", "sprint", "bug", "changelog"}

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,0 +1,73 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func write(t *testing.T, root, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, Dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, Dir, name+".md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A repository's template replaces the embedded one, and a repository
+// without the file gets the embedded one unchanged — the "absent means
+// default" rule the rest of .procoder/ lives by.
+// proved by: made Resolve return the embedded body even when a file is
+// present — a team's house format is silently ignored and every story
+// comes out in procoder's shape.
+func TestTheRepositorysTemplateWinsAndAbsentMeansDefault(t *testing.T) {
+	root := t.TempDir()
+	if body, source, _ := Resolve(root, "story", "EMBEDDED"); body != "EMBEDDED" || source != "default" {
+		t.Errorf("no file means the default, got %q from %q", body, source)
+	}
+	write(t, root, "story", "HOUSE STYLE")
+	body, source, problem := Resolve(root, "story", "EMBEDDED")
+	if body != "HOUSE STYLE" {
+		t.Errorf("the repository's template must win, got %q", body)
+	}
+	if !strings.Contains(source, "story.md") {
+		t.Errorf("the source must name the file, got %q", source)
+	}
+	if problem != nil {
+		t.Errorf("a template that exists and has content is not a problem: %v", problem)
+	}
+}
+
+// An empty template BLOCKS rather than falling back quietly. Falling back
+// is the dangerous option: `procoder format` prints one header line for an
+// already-formatted file, so a pipeline that strips the header and writes
+// the rest empties the file on the success path — that destroyed a
+// documentation page in this repository. A team would find out their
+// customised template was gone when their next story came out in
+// procoder's shape instead of theirs.
+// proved by: treated whitespace-only as absent — the emptied template is
+// silently replaced by the default and nothing is reported.
+func TestAnEmptyTemplateBlocksInsteadOfFallingBackQuietly(t *testing.T) {
+	root := t.TempDir()
+	for _, body := range []string{"", "\n\n   \n"} {
+		write(t, root, "story", body)
+		got, _, problem := Resolve(root, "story", "EMBEDDED")
+		if problem == nil {
+			t.Fatalf("an emptied template must be reported (body %q)", body)
+		}
+		if !problem.Blocking {
+			t.Error("it must block — a silently reverted template is found weeks later")
+		}
+		if !strings.Contains(problem.Message, "git checkout") {
+			t.Errorf("the refusal must say how to restore it: %q", problem.Message)
+		}
+		// Procoder still prints something usable: refusing to emit a
+		// template at all would turn one bad file into a broken command.
+		if got != "EMBEDDED" {
+			t.Errorf("the embedded template is still used, got %q", got)
+		}
+	}
+}


### PR DESCRIPTION
The last three of sprint 010's twelve stories.

### `.procoder/templates/`

Nine templates drive the quality chain — spec, plan, ADR, todo, milestone, epic, story, sprint, bug — and were embedded constants with **no way in**. A team whose stories carry an extra field had to choose between the domain and their own format.

```
$ procoder backlog story "A thing" --epic e
# A thing

HOUSE STYLE          ← .procoder/templates/story.md
```

Absent still means default, as everywhere else under `.procoder/`.

### ⚠️ An empty template blocks rather than falling back

Not hypothetical. `procoder format` prints one header line for an already-formatted file, so a pipeline that strips the header and writes the rest empties the file **on the success path** — that destroyed `docs/commands.md` in this repository this morning.

Falling back quietly would mean a team discovers their customised template is gone when their next story comes out in Procoder's shape instead of theirs, weeks later, with no way to date it. Procoder still prints a usable template for that run: one bad file must not become a broken command.

The empty-doc guard added earlier today already blocks the file at gate time too, so it fails from both directions.

### `.procoder/lint/RULES.md`

The lint domain gains the rules file `docs` and `security` already had:

```markdown
## checks

- `readability-*`
- `bugprone-*`
```

Verified end to end — the default baseline reports a garbage-value analyser finding; the list above replaces it and reports an identifier-length finding instead. **Replace means replace**: a family left out does not survive. A rules file with prose but *no* `## checks` section keeps the default, because a missing section must never read as "no checks at all". A project `.clang-tidy` still wins over both.

All four new tests verified against their named mutations — including two retries, because the first attempt at each mutated the code into something that would not compile, which proves nothing.