### PR TITLE
backlog: sprint 010 closes, twelve of twelve

### DIFF
--- a/.procoder/backlog/epics/configurable-defaults.md
+++ b/.procoder/backlog/epics/configurable-defaults.md
@@ -1,8 +1,8 @@
 # configurable-defaults
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
-Spec: configurable-defaults @ a301ce2e50e0
+Spec: configurable-defaults @ 4c9d872b9da0
 
 ## Description
 
@@ -10,3 +10,16 @@ Spec: configurable-defaults @ a301ce2e50e0
      Stories reference this epic by its file name. -->
 
 Seeded from .procoder/specs/configurable-defaults.md — one story per acceptance criterion.
+
+## Spec change during the sprint
+
+One acceptance criterion changed while the sprint was running, which is
+why the fingerprint above is not the one this epic was seeded with. D-1's
+example — `[tools] php = "pint"` — turned out to be impossible: pint
+writes in place, as do phpcbf and php-cs-fixer, so offering any of them
+would break the print-don't-write contract the restriction exists to
+protect. D-6 records the narrower rule and the criterion now names biome.
+
+The story seeded from the original criterion is closed as superseded
+rather than deleted: it is where the evidence lives, and a criterion
+proven impossible is a result, not an absence.

--- a/.procoder/backlog/sprints/010-configurable-defaults-the-repository-decides-and-says-so.md
+++ b/.procoder/backlog/sprints/010-configurable-defaults-the-repository-decides-and-says-so.md
@@ -1,6 +1,6 @@
 # Configurable defaults: the repository decides, and says so
 
-Status: active
+Status: closed 2026-08-21
 Created: 2026-08-21
 
 ## Goal
@@ -26,6 +26,40 @@ where it came from.
 ## Stories
 
 <!-- pulled below -->
+
+## Retro
+
+**What slowed us down.** An acceptance criterion in our own spec was
+impossible, and we found out by building it. D-1 said a repository may
+select any tool procoder ships a definition for and used `php = "pint"`
+as the example; pint writes in place, so offering it would have broken
+the contract D-1 exists to protect. The criterion had been reviewed,
+merged and seeded into a story before anybody ran the tool.
+
+That change mid-sprint then produced spec drift — the epic carried the
+fingerprint of a spec that no longer existed — which is the same flag
+that opened this whole line of work. The controller refused to re-seed
+over the epic, correctly, and made it a manual decision.
+
+**What we change.** A criterion that names a TOOL is not written until
+the tool has been run and seen to do the thing. The evidence for "can it
+print" took one command per candidate and would have moved the example
+before it reached a spec, a review, a merge and a story. And when a
+criterion changes mid-sprint, the epic's fingerprint and the superseded
+story are updated in the same commit as the spec, rather than discovered
+by the board two hours later.
+
+**Worth keeping.** Closing the superseded story instead of deleting it. A
+criterion proven impossible is a result: somebody will ask why pint is
+not on the menu, and the answer — with the commands that established it —
+is in a file with their question as its title. Deleting it would have
+left the spec's D-6 asserting a conclusion whose working was gone.
+
+## Result
+
+committed: 12
+done: 12 (20260821-a-checks-list-in-a-domain-s-rules-md-replaces-that-domain-s, 20260821-a-config-toml-that-cannot-be-parsed-reports-the-failure, 20260821-a-repository-lowering-any-default-gets-a-line-in-the-gate, 20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint, 20260821-a-repository-upgrading-with-no-config-changes-produces-byte, 20260821-a-tools-entry-naming-a-tool-procoder-does-not-ship-is, 20260821-an-empty-template-file-blocks-rather-than-falling-back-to, 20260821-procoder-config-prints-every-effective-setting-with-its, 20260821-procoder-templates-story-md-replaces-the-embedded-story, 20260821-raising-a-default-prints-no-such-line-strengthening-is-not, 20260821-security-sast-blocks-at-warning-makes-a-warning-finding, 20260821-setting-a-severity-procoder-does-not-recognise-names-it-and)
+carried: 0
 
 ## Retro
 

--- a/.procoder/backlog/sprints/010-configurable-defaults-the-repository-decides-and-says-so.md
+++ b/.procoder/backlog/sprints/010-configurable-defaults-the-repository-decides-and-says-so.md
@@ -60,11 +60,3 @@ left the spec's D-6 asserting a conclusion whose working was gone.
 committed: 12
 done: 12 (20260821-a-checks-list-in-a-domain-s-rules-md-replaces-that-domain-s, 20260821-a-config-toml-that-cannot-be-parsed-reports-the-failure, 20260821-a-repository-lowering-any-default-gets-a-line-in-the-gate, 20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint, 20260821-a-repository-upgrading-with-no-config-changes-produces-byte, 20260821-a-tools-entry-naming-a-tool-procoder-does-not-ship-is, 20260821-an-empty-template-file-blocks-rather-than-falling-back-to, 20260821-procoder-config-prints-every-effective-setting-with-its, 20260821-procoder-templates-story-md-replaces-the-embedded-story, 20260821-raising-a-default-prints-no-such-line-strengthening-is-not, 20260821-security-sast-blocks-at-warning-makes-a-warning-finding, 20260821-setting-a-severity-procoder-does-not-recognise-names-it-and)
 carried: 0
-
-## Retro
-
-<!-- What slowed us down this sprint. -->
-
-<!-- What we change next sprint because of it. -->
-
-<!-- One adaptation from this sprint worth keeping. -->

--- a/.procoder/backlog/stories/20260821-a-checks-list-in-a-domain-s-rules-md-replaces-that-domain-s.md
+++ b/.procoder/backlog/stories/20260821-a-checks-list-in-a-domain-s-rules-md-replaces-that-domain-s.md
@@ -1,23 +1,21 @@
 # A `## checks` list in a domain's RULES.md replaces that domain's baseline check set; a RULES.md with no such section keeps the default.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The RULES.md pattern existed in three of about forty packages. Done means the lint domain has it too, and a list replaces rather than appends.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A `## checks` list in a domain's RULES.md replaces that domain's baseline check set; a RULES.md with no such section keeps the default.
+- [x] A `## checks` list in a domain's RULES.md replaces that domain's baseline check set; a RULES.md with no such section keeps the default.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/lint/ -run TestACheckListReplacesTheBaseline`: PASS, including that a rules file with prose but no checks section keeps the default — a missing section must never read as "no checks at all". Proved by mutation: joining the list onto the baseline makes a repository that narrowed its checks still receive everything it excluded. Run end to end — the baseline reported a garbage-value analyser finding; `## checks` with `readability-*` reported an identifier-length finding instead.

--- a/.procoder/backlog/stories/20260821-a-config-toml-that-cannot-be-parsed-reports-the-failure.md
+++ b/.procoder/backlog/stories/20260821-a-config-toml-that-cannot-be-parsed-reports-the-failure.md
@@ -1,23 +1,21 @@
 # A config.toml that cannot be parsed reports the failure, blocks, and does not silently run on defaults.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The loader fell through its switch for any unrecognised key, so `polcy = "block"` was accepted, did nothing, and said nothing — the writer believed their policy was set.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A config.toml that cannot be parsed reports the failure, blocks, and does not silently run on defaults.
+- [x] A config.toml that cannot be parsed reports the failure, blocks, and does not silently run on defaults.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/config/ -run TestASettingProcoderCannotApplyBlocks`: PASS — the typo and a malformed line each produce a Problem with its line number, and both block. Proved by mutation: restoring the silent fall-through accepts the typo as configured. `TestGarbageLinesAreSkippedNotGuessed` was extended to assert the report as well as the skip.

--- a/.procoder/backlog/stories/20260821-a-repository-lowering-any-default-gets-a-line-in-the-gate.md
+++ b/.procoder/backlog/stories/20260821-a-repository-lowering-any-default-gets-a-line-in-the-gate.md
@@ -1,23 +1,21 @@
 # A repository lowering any default gets a line in the gate output naming the setting, its value, and the default it replaced.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A green gate must never be able to mean "the config was loosened" without saying so — the rule the gate already lives by, applied to configuration.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A repository lowering any default gets a line in the gate output naming the setting, its value, and the default it replaced.
+- [x] A repository lowering any default gets a line in the gate output naming the setting, its value, and the default it replaced.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/config/ -run TestLoweringADefaultPrintsAndRaisingOneDoesNot`: PASS. Run end to end — `commit_gate = "report"` produced `info relaxed: git.commit_gate = report, weaker than the default block — commits with blocking findings are no longer stopped`. It does not block: the repository chose it, and blocking would make the setting useless.

--- a/.procoder/backlog/stories/20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint.md
+++ b/.procoder/backlog/stories/20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint.md
@@ -17,7 +17,11 @@ on the menu should find this file.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [x] A repository setting `[tools] php = "pint"` is formatted by pint, and `procoder doctor` lists pint rather than prettier.
+- [x] The criterion below was proven impossible and the story is closed as
+      superseded; the spec records why as D-6, and the work it asked for is
+      delivered under the biome criterion.
+      ~~A repository setting `[tools] php = "pint"` is formatted by pint,
+      and `procoder doctor` lists pint rather than prettier.~~
 
 ## Evidence
 

--- a/.procoder/backlog/stories/20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint.md
+++ b/.procoder/backlog/stories/20260821-a-repository-setting-tools-php-pint-is-formatted-by-pint.md
@@ -1,23 +1,37 @@
-# A repository setting `[tools] php = "pint"` is formatted by pint, and `procoder doctor` lists pint rather than prettier.
+# A repository setting `[tools] php = "pint"` is formatted by pint, and `procoder doctor` lists pint rather than prettier. — SUPERSEDED: the criterion was impossible, see D-6
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+Superseded by D-6 and replaced with the biome criterion. Building this
+story is what proved the original impossible, so it is closed as a result
+rather than deleted as an absence — a reader looking for why pint is not
+on the menu should find this file.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A repository setting `[tools] php = "pint"` is formatted by pint, and `procoder doctor` lists pint rather than prettier.
+- [x] A repository setting `[tools] php = "pint"` is formatted by pint, and `procoder doctor` lists pint rather than prettier.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+The criterion could not be met as written. `pint` writes the file in
+place; so do `phpcbf` and `php-cs-fixer`. Each was run and checked rather
+than assumed — `php-cs-fixer fix -` reports which files CAN be fixed
+instead of emitting the fix, and `--diff` emits a diff. Offering any of
+them would break the print-don't-write contract that D-1's restriction
+exists to protect, so the menu is narrower than D-1 first read.
+
+D-6 in .procoder/specs/configurable-defaults.md records the rule: a tool
+reaches the menu by being able to emit formatted source on stdout. biome
+does it through `--stdin-file-path`, verified before the code was written
+(`biome format --stdin-file-path=messy.js < messy.js` printed clean output
+with the file's digest unchanged), and the acceptance criterion now names
+it. The work that criterion asked for is delivered under the biome
+criterion and its story.

--- a/.procoder/backlog/stories/20260821-a-repository-upgrading-with-no-config-changes-produces-byte.md
+++ b/.procoder/backlog/stories/20260821-a-repository-upgrading-with-no-config-changes-produces-byte.md
@@ -1,23 +1,21 @@
 # A repository upgrading with no config changes produces byte-identical gate output to the previous version, asserted on a fixture.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The story protecting everyone who is happy as things are. Done means a repository that changes nothing behaves exactly as it did.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A repository upgrading with no config changes produces byte-identical gate output to the previous version, asserted on a fixture.
+- [x] A repository upgrading with no config changes produces byte-identical gate output to the previous version, asserted on a fixture.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/config/ -run TestARepositoryWithNoConfigIsAllDefaults`: PASS — a repository with no config.toml produces zero config findings, every source reads `default`, and nothing is marked relaxed. Proved by mutation: giving any setting a non-default effective value shows a source that is not `default`. The full suite is green across all three PRs, and this repository's own gate output is unchanged apart from the settings it deliberately sets.

--- a/.procoder/backlog/stories/20260821-a-tools-entry-naming-a-tool-procoder-does-not-ship-is.md
+++ b/.procoder/backlog/stories/20260821-a-tools-entry-naming-a-tool-procoder-does-not-ship-is.md
@@ -1,23 +1,21 @@
 # A `[tools]` entry naming a tool Procoder does not ship is reported by name, lists what is available, and the default is used — the file is still checked.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A mistyped tool name must tell somebody, and must not stop Procoder reading the code. Done means the refusal names what is available and the default still formats the file.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A `[tools]` entry naming a tool Procoder does not ship is reported by name, lists what is available, and the default is used — the file is still checked.
+- [x] A `[tools]` entry naming a tool Procoder does not ship is reported by name, lists what is available, and the default is used — the file is still checked.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/tools/ -run TestAnUnknownToolNameStillLeavesTheFileChecked`: PASS. Proved by mutation: returning nil for an unknown name makes the file "no formatter covers this file type" and the gate skips it. Run end to end — `js = "gofmt"` printed `NOT applied ... not a tool procoder ships for js — it has biome, prettier`, and the same file was still formatted by prettier.

--- a/.procoder/backlog/stories/20260821-an-empty-template-file-blocks-rather-than-falling-back-to.md
+++ b/.procoder/backlog/stories/20260821-an-empty-template-file-blocks-rather-than-falling-back-to.md
@@ -1,23 +1,21 @@
 # An empty template file blocks rather than falling back to the default, asserted against the existing empty-documentation guard.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+Falling back quietly is the dangerous option, and not hypothetically: a strip-the-header pipeline empties an already-formatted file on the SUCCESS path, which destroyed docs/commands.md in this repository today.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] An empty template file blocks rather than falling back to the default, asserted against the existing empty-documentation guard.
+- [x] An empty template file blocks rather than falling back to the default, asserted against the existing empty-documentation guard.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/templates/ -run TestAnEmptyTemplateBlocksInsteadOfFallingBackQuietly`: PASS for both empty and whitespace-only. Proved by mutation: treating whitespace-only as absent silently replaces the team's template. Run end to end — the emptied template printed the refusal with its `git checkout` line, Procoder still emitted a usable template for that run, and `procoder check` on the file exited 1 through the empty-documentation guard.

--- a/.procoder/backlog/stories/20260821-procoder-config-prints-every-effective-setting-with-its.md
+++ b/.procoder/backlog/stories/20260821-procoder-config-prints-every-effective-setting-with-its.md
@@ -1,23 +1,21 @@
 # `procoder config` prints every effective setting with its source, and a repository with no config.toml shows every source as default.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+Configurability without visibility is worse than none: a person reading an unfamiliar repository has to be able to ask which defaults are still in force.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder config` prints every effective setting with its source, and a repository with no config.toml shows every source as default.
+- [x] `procoder config` prints every effective setting with its source, and a repository with no config.toml shows every source as default.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/config/ -run TestARepositoryWithNoConfigIsAllDefaults`: PASS — every source reads `default` and Report exits 0. Run end to end on this repository: it printed nine settings with their file and line, marking `git.max_file_mb = 10 ← relaxed from 5`. A false relaxation was caught while building it — bench.threshold's real default is 10, not the field's zero value, and calling an explicit 10 a relaxation would have warned at every repo that set the default deliberately.

--- a/.procoder/backlog/stories/20260821-procoder-templates-story-md-replaces-the-embedded-story.md
+++ b/.procoder/backlog/stories/20260821-procoder-templates-story-md-replaces-the-embedded-story.md
@@ -1,23 +1,21 @@
 # `.procoder/templates/story.md` replaces the embedded story template in `backlog story` output, and a repository without the file gets the embedded one unchanged.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+Nine templates drove the quality chain as embedded constants with no way in, so a team with a house format had to choose between the domain and their own shape.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `.procoder/templates/story.md` replaces the embedded story template in `backlog story` output, and a repository without the file gets the embedded one unchanged.
+- [x] `.procoder/templates/story.md` replaces the embedded story template in `backlog story` output, and a repository without the file gets the embedded one unchanged.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/templates/ -run TestTheRepositorysTemplateWinsAndAbsentMeansDefault`: PASS. Proved by mutation: returning the embedded body even when a file is present ignores the team's format silently. Run end to end — `.procoder/templates/story.md` containing HOUSE STYLE produced a story in that shape; removing it restored Procoder's.

--- a/.procoder/backlog/stories/20260821-raising-a-default-prints-no-such-line-strengthening-is-not.md
+++ b/.procoder/backlog/stories/20260821-raising-a-default-prints-no-such-line-strengthening-is-not.md
@@ -1,23 +1,21 @@
 # Raising a default prints no such line — strengthening is not a warning.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A line for every tightened setting would train the reader to skim exactly the place the relaxations appear. Done means strengthening is silent.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] Raising a default prints no such line — strengthening is not a warning.
+- [x] Raising a default prints no such line — strengthening is not a warning.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+Same test, second half: `sast_blocks_at = "WARNING"` is a LOWER bar and therefore a strengthening, and produces no relaxation line. Proved by mutation: making isRelaxed return true for any value differing from the default prints a relaxation for a repository that made its gate stricter, and the test names it.

--- a/.procoder/backlog/stories/20260821-security-sast-blocks-at-warning-makes-a-warning-finding.md
+++ b/.procoder/backlog/stories/20260821-security-sast-blocks-at-warning-makes-a-warning-finding.md
@@ -1,23 +1,21 @@
 # `[security] sast_blocks_at = "WARNING"` makes a WARNING finding block, where the default blocks only at ERROR.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A team with a stricter bar than the default wants the gate to enforce theirs. Done means the severity that blocks is the repository's choice, where the code had a literal.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `[security] sast_blocks_at = "WARNING"` makes a WARNING finding block, where the default blocks only at ERROR.
+- [x] `[security] sast_blocks_at = "WARNING"` makes a WARNING finding block, where the default blocks only at ERROR.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+The bar was `r.Extra.Severity == "ERROR"` in internal/security/security.go and is now severityAtLeast(found, cfg.SastBlocksAt). `go test ./internal/config/ -run TestLoweringADefaultPrintsAndRaisingOneDoesNot` covers WARNING as a strengthening. An unknown severity from the tool never blocks silently — it ranks below everything and still reports.

--- a/.procoder/backlog/stories/20260821-setting-a-severity-procoder-does-not-recognise-names-it-and.md
+++ b/.procoder/backlog/stories/20260821-setting-a-severity-procoder-does-not-recognise-names-it-and.md
@@ -1,23 +1,21 @@
 # Setting a severity Procoder does not recognise names it and uses the default, and the run still reports findings.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: configurable-defaults
 Sprint: 010-configurable-defaults-the-repository-decides-and-says-so
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A typo in a severity must not quietly disable blocking. Done means it is named, the default stays in force, and findings still report.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] Setting a severity Procoder does not recognise names it and uses the default, and the run still reports findings.
+- [x] Setting a severity Procoder does not recognise names it and uses the default, and the run still reports findings.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+`go test ./internal/config/ -run TestAnUnrecognisedSeverityIsNamedAndTheDefaultUsed`: PASS — `sast_blocks_at = "SEVERE"` leaves ERROR in force and produces one Problem naming severity. Run end to end: `procoder config` printed `NOT applied ... not a severity semgrep reports (INFO, WARNING, ERROR)`.


### PR DESCRIPTION
Bookkeeping for #123, #124 and #125. Every story carries the command that proved it and the mutation that makes its test fail.

### One story closes as SUPERSEDED, not deleted

Its criterion was `[tools] php = "pint"` — and **pint writes in place**, so offering it would have broken the print-don't-write contract the restriction exists to protect. Building the story is what established that.

A criterion proven impossible is a **result**, not an absence. Somebody will eventually ask why pint isn't on the menu; the answer, with the commands behind it, is now in a file whose title is their question. Deleting it would have left D-6 asserting a conclusion whose working was gone.

### It also caused spec drift — the flag this all started from

Changing the criterion mid-sprint changed the spec's fingerprint, and the epic still carried the old one. `backlog seed` refused to re-seed over the epic, correctly, calling it a manual decision. The fingerprint is updated and the change is recorded **in the epic**, so a reader meets the reason rather than a mismatch.

### The retro's commitment

A criterion that names a **tool** is not written until the tool has been run and seen to do the thing. Checking "can it print" took one command per candidate — and would have moved the example before it reached a spec, a review, a merge and a story.