### PR TITLE
backlog: sprint 011 opens over checks-that-run-themselves

### DIFF
--- a/.procoder/backlog/epics/checks-that-run-themselves.md
+++ b/.procoder/backlog/epics/checks-that-run-themselves.md
@@ -1,0 +1,12 @@
+# checks-that-run-themselves
+
+Status: open
+Created: 2026-08-21
+Spec: checks-that-run-themselves @ b903540aae01
+
+## Description
+
+<!-- What this epic delivers and why it is one coherent unit of value.
+     Stories reference this epic by its file name. -->
+
+Seeded from .procoder/specs/checks-that-run-themselves.md — one story per acceptance criterion.

--- a/.procoder/backlog/sprints/011-checks-that-run-themselves-the-gate-for-the-change-ci-for.md
+++ b/.procoder/backlog/sprints/011-checks-that-run-themselves-the-gate-for-the-change-ci-for.md
@@ -1,0 +1,39 @@
+# Checks that run themselves: the gate for the change, CI for the tree
+
+Status: active
+Created: 2026-08-21
+
+## Goal
+
+A person who does not know the command list still gets the checks. Today
+nine of them run only when typed — the suite, dependency vulnerabilities,
+complexity, debt rot, dependency freshness, environment drift, per-host
+rule drift, and the spec and plan controllers — and two more run only in
+CI, so a commit can carry a SAST finding whose author learns about it
+after pushing.
+
+The sprint moves the checks that are meaningful about a CHANGE into the
+commit gate, and the ones that are properties of the REPOSITORY into CI.
+Neither tier gets a time budget: a check runs until it answers, because
+a verdict that depends on how fast the machine is, is not a verdict about
+the code. Where a check is slow, it is given less to do rather than cut
+off partway.
+
+Two of these are not additions but corrections. The documentation already
+says the gate blocks on agents drift, and it does not. `[test] policy =
+block` reads like it governs commits, and it governs closing a story.
+
+Done means a green gate covers what a reader would assume it covers, and
+`procoder status` names anything it did not.
+
+## Stories
+
+<!-- pulled below -->
+
+## Retro
+
+<!-- What slowed us down this sprint. -->
+
+<!-- What we change next sprint because of it. -->
+
+<!-- One adaptation from this sprint worth keeping. -->

--- a/.procoder/backlog/stories/20260821-a-check-that-is-slow-still-completes-and-still-reports-its.md
+++ b/.procoder/backlog/stories/20260821-a-check-that-is-slow-still-completes-and-still-reports-its.md
@@ -1,0 +1,23 @@
+# A check that is slow still completes and still reports its findings, asserted against a deliberately slow stub — the gate waits rather than reporting a verdict it did not reach.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A check that is slow still completes and still reports its findings, asserted against a deliberately slow stub — the gate waits rather than reporting a verdict it did not reach.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-commit-adding-a-function-past-the-complexity-limit-is.md
+++ b/.procoder/backlog/stories/20260821-a-commit-adding-a-function-past-the-complexity-limit-is.md
@@ -1,0 +1,23 @@
+# A commit adding a function past the complexity limit is blocked.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A commit adding a function past the complexity limit is blocked.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by.md
+++ b/.procoder/backlog/stories/20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by.md
@@ -1,0 +1,23 @@
+# A commit touching a file with a SAST finding is blocked by the gate at the configured severity, where previously only CI saw it.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A commit touching a file with a SAST finding is blocked by the gate at the configured severity, where previously only CI saw it.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-in-a-file-the.md
+++ b/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-in-a-file-the.md
@@ -1,0 +1,23 @@
+# A debt marker with no revisit condition, in a file the commit did not touch, is caught by CI and not by the gate — asserted so the two tiers cannot silently collapse into one.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A debt marker with no revisit condition, in a file the commit did not touch, is caught by CI and not by the gate — asserted so the two tiers cannot silently collapse into one.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-is-reported-at-the.md
+++ b/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-is-reported-at-the.md
@@ -1,0 +1,23 @@
+# A debt marker with no revisit condition is reported at the gate.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A debt marker with no revisit condition is reported at the gate.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks.md
+++ b/.procoder/backlog/stories/20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks.md
@@ -1,0 +1,23 @@
+# A dependency manifest carrying a known vulnerability blocks the commit that changes it.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A dependency manifest carrying a known vulnerability blocks the commit that changes it.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-failing-test-suite-blocks-the-commit-where-the-repository.md
+++ b/.procoder/backlog/stories/20260821-a-failing-test-suite-blocks-the-commit-where-the-repository.md
@@ -1,0 +1,23 @@
+# A failing test suite blocks the commit where the repository set the test policy to block, and reports without blocking otherwise.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A failing test suite blocks the commit where the repository set the test policy to block, and reports without blocking otherwise.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule.md
+++ b/.procoder/backlog/stories/20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule.md
@@ -1,0 +1,23 @@
+# A repository with no test setup, no manifests and no rule files commits without any new blocking finding.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository with no test setup, no manifests and no rule files commits without any new blocking finding.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and.md
+++ b/.procoder/backlog/stories/20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and.md
@@ -1,0 +1,23 @@
+# CI runs `maintain`, `debt` and `deps` over the whole tree and fails the job on a blocking finding from any of them.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] CI runs `maintain`, `debt` and `deps` over the whole tree and fails the job on a blocking finding from any of them.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-procoder-status-names-every-check-the-gate-deferred-and.md
+++ b/.procoder/backlog/stories/20260821-procoder-status-names-every-check-the-gate-deferred-and.md
@@ -1,0 +1,23 @@
+# `procoder status` names every check the gate deferred, and says nothing when none were.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder status` names every check the gate deferred, and says nothing when none were.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate.md
+++ b/.procoder/backlog/stories/20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate.md
@@ -1,0 +1,23 @@
+# Rule files that have drifted from AGENTS.md block the gate, making the sentence already in docs/commands.md true.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] Rule files that have drifted from AGENTS.md block the gate, making the sentence already in docs/commands.md true.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole.md
+++ b/.procoder/backlog/stories/20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole.md
@@ -1,0 +1,23 @@
+# SAST at the gate is given the changed files, not the whole tree, asserted by a fixture where an untouched file carries a finding and the commit is not blocked by it.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] SAST at the gate is given the changed files, not the whole tree, asserted by a fixture where an untouched file carries a finding and the commit is not blocked by it.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a.md
+++ b/.procoder/backlog/stories/20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a.md
@@ -1,0 +1,23 @@
+# The same commit produces the same findings on a fast and a slow run, asserted by running the gate twice against stubs of different speeds and comparing the output.
+
+Status: open
+Created: 2026-08-21
+Epic: checks-that-run-themselves
+Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
+
+## Description
+
+<!-- The user story: who needs what, and why. What "done" looks like in
+     the reader's terms — a title is not a description. -->
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] The same commit produces the same findings on a fast and a slow run, asserted by running the gate twice against stubs of different speeds and comparing the output.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->


### PR DESCRIPTION
Seeds #128's spec into thirteen stories and opens sprint 011.

**The gate — meaningful about a change**

- SAST on the changed files blocks at the configured severity
- SAST is given the file list, not the tree (asserted: an untouched file's finding does not block)
- a manifest carrying a known CVE blocks the commit that changes it
- a function past the complexity limit blocks
- rule files drifted from `AGENTS.md` block — *making the sentence already in docs/commands.md true*
- a failing suite blocks where the repo set the test policy to block
- a slow check still completes and still reports
- the same commit produces the same findings on a fast and a slow run

**CI — properties of the repository**

- `maintain`, `debt` and `deps` run over the whole tree and fail on a blocking finding
- a debt marker in a file the commit did not touch is caught by CI and **not** by the gate — so the two tiers cannot silently collapse into one

**Safety**

- a repo with no test setup, no manifests and no rule files commits with no new blocking finding
- `procoder status` names every check the gate deferred, and says nothing when none were

---

Pre-flight on this repository, so the sprint builds against reality rather than hope: `maintain` reports 46 findings (*"all judgment calls, none blocking"*), `debt` 8 markers with 0 missing a revisit trigger, `deps` 0 behind. All three exit 0 — so the CI tier buys visibility now and enforcement when something genuinely blocks.