### PR TITLE
feat: the gate blocks on agents drift, as it always claimed to

### DIFF
--- a/.procoder/specs/checks-that-run-themselves.md
+++ b/.procoder/specs/checks-that-run-themselves.md
@@ -26,10 +26,10 @@ Two of those are worse than merely absent. `docs/commands.md` says the
 gate blocks on `agents` drift; it does not, and the only match for
 `agents` anywhere near the gate is prose inside a template — so other
 hosts can read rule files that have drifted from AGENTS.md while the
-documentation promises otherwise. And `[test] policy = "block"` reads
-like it governs commits; it governs closing a todo or a story
-(cmd/procoder/main.go). A commit never runs the suite, in the gate or in
-CI.
+documentation promises otherwise. The test suite is a plainer gap: nothing claims otherwise —
+docs/configuration.md says the policy governs the close controllers, and
+names them — but a commit never runs the suite, in the gate or in CI, so
+the only thing standing between a red suite and a push is remembering.
 
 ## Users
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -401,7 +401,15 @@ one blocks exactly as before.
 The universal agent layer: per-host rule files (Cursor, Windsurf, Cline,
 Kilo Code, Roo Code, Kiro, Antigravity, Qoder, Copilot editors, Codex)
 derived from the canonical `AGENTS.md`. Prints the content for anything
-missing or drifted so the agent can write it; drift blocks the gate.
+missing or drifted so the agent can write it.
+
+Drift blocks the gate — and until now it did not, though this page and
+the command's own output both said so. A rule file that has drifted means
+another host is reading rules this repository no longer holds, which is
+the failure the agent layer exists to prevent, so it is blocking rather
+than advisory. A repository with no `AGENTS.md` ships no agent layer and
+is asked nothing.
+
 See [Every agent](portability.md) for the full host matrix.
 
 #### `procoder lessons`

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -116,6 +116,11 @@ func collectHygiene(root string, cfg config.Config, changed []string) []gitx.Fin
 	// every run. It rides here so `check`, `git` and CI cannot disagree
 	// about the config any more than they can about the code.
 	out := cfg.Findings()
+	// Domain: the agent layer. `procoder agents` has always ended by
+	// printing "the gate blocks on drift" and the documentation said the
+	// same, while nothing anywhere asked. A rule file that has drifted
+	// means another host is reading rules this repository no longer holds.
+	out = append(out, portability.AgentsDrift(root)...)
 	out = append(out, gitx.ConflictMarkers(changed)...)
 	out = append(out, gitx.JunkFiles(changed)...)
 	out = append(out, gitx.Oversized(changed, cfg.MaxFileMB)...)

--- a/internal/portability/drift.go
+++ b/internal/portability/drift.go
@@ -48,8 +48,18 @@ func check(root string, c Copy, want string) (verdict, error) {
 // A repository with no AGENTS.md ships no agent layer and gets nothing.
 func AgentsDrift(root string) []gitx.Finding {
 	master, err := os.ReadFile(filepath.Join(root, Master))
-	if err != nil {
+	switch {
+	case err != nil && os.IsNotExist(err):
+		// No agent layer at all: this repository never opted in, and it is
+		// asked nothing.
 		return nil
+	case err != nil:
+		// Present but unreadable is not the same as absent. Returning
+		// nothing here would disable the entire drift check on a
+		// permission or IO error — unknown reported as clean, which is the
+		// one verdict this gate must never produce.
+		return []gitx.Finding{{Blocking: true, File: Master,
+			Message: fmt.Sprintf("%s is unreadable (%v) — no rule file could be checked against it (agents)", Master, err)}}
 	}
 	want := normalize(stripFrontmatter(string(master)))
 	var out []gitx.Finding

--- a/internal/portability/drift.go
+++ b/internal/portability/drift.go
@@ -1,0 +1,71 @@
+package portability
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"procoder/internal/gitx"
+)
+
+// verdict is what one host's rule file is: ok, missing, drifted, or
+// unreadable. Both `procoder agents` and the gate ask for it, so the
+// command and the gate cannot disagree about what drift is.
+type verdict int
+
+const (
+	ok verdict = iota
+	missing
+	drifted
+	unreadable
+)
+
+// check reads one host's copy and compares it with the master body.
+func check(root string, c Copy, want string) (verdict, error) {
+	raw, err := os.ReadFile(filepath.Join(root, c.Path))
+	switch {
+	case err != nil && !os.IsNotExist(err):
+		return unreadable, err
+	case err != nil:
+		return missing, nil
+	case normalize(stripFrontmatter(string(raw))) != want:
+		return drifted, nil
+	}
+	return ok, nil
+}
+
+// AgentsDrift reports rule files that no longer match AGENTS.md.
+//
+// `procoder agents` has always ended by printing "the gate blocks on
+// drift", and docs/commands.md says the same. Neither was true: nothing
+// in the gate, the hooks or CI ever asked. So every other host — Cursor,
+// Windsurf, Cline, Kilo, Roo, Kiro, Codex and the rest — could be reading
+// rules that had drifted from AGENTS.md while procoder reported clean,
+// which is the failure mode the agent layer exists to prevent.
+//
+// Blocking, because a stale rule file is not a matter of taste: it is
+// another agent being told something this repository stopped believing.
+// A repository with no AGENTS.md ships no agent layer and gets nothing.
+func AgentsDrift(root string) []gitx.Finding {
+	master, err := os.ReadFile(filepath.Join(root, Master))
+	if err != nil {
+		return nil
+	}
+	want := normalize(stripFrontmatter(string(master)))
+	var out []gitx.Finding
+	for _, c := range Copies {
+		v, rerr := check(root, c, want)
+		switch v {
+		case unreadable:
+			out = append(out, gitx.Finding{Blocking: true, File: c.Path,
+				Message: fmt.Sprintf("%s rule file is unreadable (%v) — NOT checked against %s (agents)", c.Host, rerr, Master)})
+		case missing:
+			out = append(out, gitx.Finding{Blocking: true, File: c.Path,
+				Message: fmt.Sprintf("%s has no rule file — run `procoder agents` for the content to write (agents)", c.Host)})
+		case drifted:
+			out = append(out, gitx.Finding{Blocking: true, File: c.Path,
+				Message: fmt.Sprintf("%s rule file has drifted from %s — that host is reading rules this repository no longer holds; run `procoder agents` (agents)", c.Host, Master)})
+		}
+	}
+	return out
+}

--- a/internal/portability/drift_test.go
+++ b/internal/portability/drift_test.go
@@ -55,10 +55,48 @@ func TestDriftedRuleFilesBlock(t *testing.T) {
 			if !strings.Contains(f.Message, "drifted") {
 				t.Errorf("a file with different content has drifted, not gone: %q", f.Message)
 			}
+			// The blocking assertion belongs here too, not only on the
+			// missing case: drift is the reason this function exists, and
+			// a regression making it advisory would otherwise pass.
+			if !f.Blocking {
+				t.Errorf("a drifted rule file must block: %q", f.Message)
+			}
 		}
 	}
 	if !found {
 		t.Errorf("%s must still be reported", c.Path)
+	}
+}
+
+// An AGENTS.md that exists and cannot be read is not a repository without
+// an agent layer. Returning nothing there would disable the whole drift
+// check on a permission or IO error — unknown reported as clean, the one
+// verdict this gate must never produce.
+// proved by: returned nil for any read error again — an unreadable
+// AGENTS.md silently switches the check off and every host passes.
+func TestAnUnreadableMasterIsNotAnAbsentAgentLayer(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, Master)
+	if err := os.WriteFile(path, []byte("# Rules\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Skip("cannot make a file unreadable here: ", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+	if os.Geteuid() == 0 {
+		t.Skip("root reads anything, so this cannot be exercised")
+	}
+
+	got := AgentsDrift(root)
+	if len(got) != 1 {
+		t.Fatalf("an unreadable master must be reported once, got %+v", got)
+	}
+	if !got[0].Blocking {
+		t.Error("a check that could not run must block")
+	}
+	if !strings.Contains(got[0].Message, "unreadable") {
+		t.Errorf("the reason must say what happened: %q", got[0].Message)
 	}
 }
 

--- a/internal/portability/drift_test.go
+++ b/internal/portability/drift_test.go
@@ -3,6 +3,7 @@ package portability
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -75,6 +76,13 @@ func TestDriftedRuleFilesBlock(t *testing.T) {
 // proved by: returned nil for any read error again — an unreadable
 // AGENTS.md silently switches the check off and every host passes.
 func TestAnUnreadableMasterIsNotAnAbsentAgentLayer(t *testing.T) {
+	// chmod 000 does not make a file unreadable on Windows, so the file
+	// stays readable there, the drift check runs normally, and this test
+	// would be asserting the opposite of what it is named for. The same
+	// guard the adr sweep already uses, for the same reason.
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 does not make a file unreadable on Windows")
+	}
 	root := t.TempDir()
 	path := filepath.Join(root, Master)
 	if err := os.WriteFile(path, []byte("# Rules\n"), 0o644); err != nil {

--- a/internal/portability/drift_test.go
+++ b/internal/portability/drift_test.go
@@ -1,0 +1,86 @@
+package portability
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRules(t *testing.T, root, rel, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, filepath.Dir(rel)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, rel), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// `procoder agents` has always ended by printing "the gate blocks on
+// drift", and docs/commands.md said the same. Neither was true: nothing
+// in the gate, the hooks or CI ever asked. So Cursor, Windsurf, Cline,
+// Kilo, Roo, Kiro, Codex and the rest could be reading rules this
+// repository had stopped holding, while procoder reported clean — which
+// is the exact failure the agent layer exists to prevent.
+// proved by: returned nil from AgentsDrift — a drifted rule file passes
+// the gate again, and the binary goes back to printing a promise it does
+// not keep.
+func TestDriftedRuleFilesBlock(t *testing.T) {
+	root := t.TempDir()
+	master := "# Rules\n\nAlways do the thing.\n"
+	if err := os.WriteFile(filepath.Join(root, Master), []byte(master), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Every host missing: each is reported, and each blocks.
+	got := AgentsDrift(root)
+	if len(got) != len(Copies) {
+		t.Fatalf("every host without a rule file must be reported: %d of %d", len(got), len(Copies))
+	}
+	for _, f := range got {
+		if !f.Blocking {
+			t.Errorf("a host reading nothing must block: %q", f.Message)
+		}
+	}
+
+	// One host given content that differs is DRIFTED, and the message says
+	// so rather than calling it missing — the reader has a file to fix,
+	// not one to create.
+	c := Copies[0]
+	writeRules(t, root, c.Path, c.Frontmatter+"# Rules\n\nSomething else entirely.\n")
+	var found bool
+	for _, f := range AgentsDrift(root) {
+		if f.File == c.Path {
+			found = true
+			if !strings.Contains(f.Message, "drifted") {
+				t.Errorf("a file with different content has drifted, not gone: %q", f.Message)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("%s must still be reported", c.Path)
+	}
+}
+
+// A file that matches is not a finding, and a repository with no
+// AGENTS.md ships no agent layer and is asked nothing — or the check
+// would block every repository that never opted in.
+// proved by: reported on every host regardless of content — a repo with
+// no AGENTS.md then cannot commit at all.
+func TestMatchingFilesAndNoAgentLayerAreSilent(t *testing.T) {
+	if got := AgentsDrift(t.TempDir()); len(got) != 0 {
+		t.Errorf("no AGENTS.md means no agent layer: %+v", got)
+	}
+
+	root := t.TempDir()
+	master := "# Rules\n\nAlways do the thing.\n"
+	if err := os.WriteFile(filepath.Join(root, Master), []byte(master), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range Copies {
+		writeRules(t, root, c.Path, c.Frontmatter+master)
+	}
+	if got := AgentsDrift(root); len(got) != 0 {
+		t.Errorf("rule files that match must be silent: %+v", got)
+	}
+}


### PR DESCRIPTION
The first of sprint 011's stories, and a correction to my own spec.

### The binary was making a promise it did not keep

`procoder agents` ends every run by printing:

```
N file(s) to write — the gate blocks on drift
```

`docs/commands.md` said the same. **Neither was true.** Nothing in the gate, the hooks or CI ever asked — the only match for `agents` anywhere near the gate was prose inside a template.

So Cursor, Windsurf, Cline, Kilo, Roo, Kiro, Codex and the rest could be reading rules this repository had stopped holding, while procoder reported clean. That is precisely the failure the agent layer exists to prevent.

`AgentsDrift` returns findings from the **same comparison** `procoder agents` prints, so the command and the gate cannot disagree about what drift is. Blocking, because a stale rule file is not a matter of taste — it is another agent being told something this repository no longer believes. A repository with no `AGENTS.md` ships no agent layer and is asked nothing.

```
BLOCKING  .cursor/rules/procoder.mdc  Cursor has no rule file — run `procoder agents` (agents)
```

### ⚠️ A correction to my own spec

I had grouped `[test] policy` with this as a second case of *"the documentation claims otherwise"*. **It is not.** `docs/configuration.md` says plainly that the policy governs the close controllers, and names `todo close` and `backlog close story`.

The test gap is real — a commit never runs the suite, in the gate or in CI — but nothing lied about it. The spec now says so, because holding others to a documentation standard while overstating a case myself is not a standard.

Mutation verified: returning nil from `AgentsDrift` lets a drifted rule file pass the gate again.