### PR TITLE
feat: CI runs the whole-tree pass, and maintain stops passing when it did not run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,19 @@ jobs:
         run: procoder docs --external
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: the whole-tree pass — maintain, debt, deps
+        # The gate answers about the change; these answer about the
+        # repository. Dependency freshness, the debt ledger and complexity
+        # across a codebase are properties of the tree, and asking them of
+        # every commit would either report the same finding forever or
+        # rescan everything each time somebody edits a line.
+        #
+        # Until now they ran nowhere unless a person typed them, which
+        # meant they protected whoever already knew they existed.
+        run: |
+          procoder maintain
+          procoder debt
+          procoder deps
 
   release:
     # A tag is the release. Twenty-seven tags were pushed before this job

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -277,6 +277,12 @@ repository.
 
 #### `procoder maintain`
 
+`maintain` is report-only about its findings: complexity and dead code are
+judgement calls and nothing blocks on them. A check that could not run is
+not a finding, though — a missing golangci-lint exits non-zero, because a
+report that never read the code must not look like a clean one. CI runs
+this over the whole tree.
+
 Dead-code candidates from the index's precise tier, cyclomatic complexity
 and function length from isolated linter runs. Nothing blocks; thresholds
 are the repo's to set (`[maintain]` in config.toml).

--- a/internal/maintain/maintain.go
+++ b/internal/maintain/maintain.go
@@ -52,23 +52,41 @@ func Run(root string, out func(string)) int {
 	count += unusedLines
 
 	cfg := config.Load(root)
+	// notChecked counts the legs that could NOT run — a missing tool, not
+	// a judgement about the code. The findings here are all judgement
+	// calls and none of them block, but "the complexity checker was not
+	// installed" is not a finding at all: it is the absence of one, and
+	// reporting it while exiting 0 is how a repository can run `maintain`
+	// forever and be told nothing is wrong by a check that never ran.
+	notChecked := 0
 	if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
-		count += complexityGo(root, cfg, out)
+		n, missed := complexityGo(root, cfg, out)
+		count += n
+		notChecked += missed
 	}
 	if hasFiles(root, ".py") {
-		count += complexityPy(root, out)
+		n, missed := complexityPy(root, out)
+		count += n
+		notChecked += missed
 	}
 	out(fmt.Sprintf("procoder maintain: %d line(s) of findings — all judgment calls, none blocking", count))
+	if notChecked > 0 {
+		out(fmt.Sprintf("%d check(s) did NOT run — run `procoder init` and try again", notChecked))
+		return 1
+	}
 	return 0
 }
 
 // complexityGo runs golangci-lint with ONLY the complexity rules, isolated
 // from the repo's config so nothing is required or overridden.
-func complexityGo(root string, cfg config.Config, out func(string)) int {
+// complexityGo returns the number of findings and the number of checks
+// that could NOT run. The two are different answers and the caller needs
+// both: findings are judgement, an absent tool is silence.
+func complexityGo(root string, cfg config.Config, out func(string)) (findings, notChecked int) {
 	bin := tools.Resolve(lint.GolangciLint, root)
 	if bin == "" {
 		out("  complexity  NOT checked — golangci-lint is not installed; run `procoder init`")
-		return 1
+		return 0, 1
 	}
 	// an isolated config carries the thresholds: golangci's CLI cannot set
 	// linter settings, and the defaults (gocyclo 30) report almost nothing.
@@ -77,7 +95,7 @@ func complexityGo(root string, cfg config.Config, out func(string)) int {
 	cfgFile, err := os.CreateTemp("", "procoder-maintain-*.yml")
 	if err != nil {
 		out("  complexity  NOT checked — cannot write the isolated config")
-		return 1
+		return 0, 1
 	}
 	cfgPath := cfgFile.Name()
 	// a temp file that will not delete is nothing the report can act on
@@ -90,7 +108,7 @@ func complexityGo(root string, cfg config.Config, out func(string)) int {
 	}
 	if werr != nil {
 		out("  complexity  NOT checked — cannot write the isolated config")
-		return 1
+		return 0, 1
 	}
 	return runTool(root, bin, []string{"run", "--config", cfgPath,
 		"--output.text.path=stdout", "--show-stats=false", "./..."}, "complexity", out)
@@ -137,16 +155,18 @@ issues:
 }
 
 // complexityPy runs ruff with only the McCabe complexity rule.
-func complexityPy(root string, out func(string)) int {
+func complexityPy(root string, out func(string)) (findings, notChecked int) {
 	bin := tools.Resolve(lint.Ruff, root)
 	if bin == "" {
 		out("  complexity  NOT checked — ruff is not installed; run `procoder init`")
-		return 1
+		return 0, 1
 	}
 	return runTool(root, bin, []string{"check", "--select", "C901", "--output-format=concise", "."}, "complexity", out)
 }
 
-func runTool(root, bin string, args []string, label string, out func(string)) int {
+// runTool returns findings and, separately, whether the check ran at all.
+// A timeout is not zero findings; it is no answer.
+func runTool(root, bin string, args []string, label string, out func(string)) (findings, notChecked int) {
 	ctx, cancel := context.WithTimeout(context.Background(), maintainTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, args...) // nosemgrep -- resolved from the fixed tool table, never user input
@@ -158,7 +178,7 @@ func runTool(root, bin string, args []string, label string, out func(string)) in
 	runErr := cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		out(fmt.Sprintf("  %s  NOT checked — %s gave no answer in %s", label, filepath.Base(bin), maintainTimeout))
-		return 1
+		return 0, 1
 	}
 	count := 0
 	for _, line := range strings.Split(buf.String(), "\n") {
@@ -186,10 +206,10 @@ func runTool(root, bin string, args []string, label string, out func(string)) in
 		var exit *exec.ExitError
 		if !(errors.As(runErr, &exit) && exit.ExitCode() == 1 && buf.Len() > 0) {
 			out(fmt.Sprintf("  %s  NOT checked — %s failed: %s", label, filepath.Base(bin), textutil.FirstLine(buf.String()+runErr.Error())))
-			return 1
+			return 1, 0
 		}
 	}
-	return count
+	return count, 0
 }
 
 func hasFiles(root, ext string) bool {

--- a/internal/maintain/maintain_test.go
+++ b/internal/maintain/maintain_test.go
@@ -55,17 +55,34 @@ func TestComplexityIsReportedAndNothingBlocks(t *testing.T) {
 	}
 }
 
-func TestMissingToolsSayNotCheckedAndStillExitZero(t *testing.T) {
+// maintain is report-only about its FINDINGS: complexity and dead code are
+// judgement calls, nobody is blocked by them, and it exits 0 with a list.
+//
+// A check that could not run is not a finding. This test used to require
+// exit 0 there too, which meant a machine without golangci-lint ran
+// `procoder maintain`, printed "NOT checked", exited 0, and looked exactly
+// like a clean report — and once CI runs this command, that is a job that
+// passes because the tool was absent. Report-only describes the verdict on
+// the code, not the question of whether the code was read.
+// proved by: returned 0 from Run when a leg could not run — the missing
+// tool is still printed and the command still succeeds, which is the
+// silent green this whole rule exists to remove.
+func TestMissingToolsSayNotCheckedAndFail(t *testing.T) {
 	root := t.TempDir()
 	os.WriteFile(filepath.Join(root, "go.mod"), []byte("module demo\n"), 0o644)
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	var lines []string
-	if code := Run(root, func(s string) { lines = append(lines, s) }); code != 0 {
-		t.Fatalf("report-only command must exit 0: %v", lines)
-	}
-	if !strings.Contains(strings.Join(lines, "\n"), "NOT checked") {
+	code := Run(root, func(s string) { lines = append(lines, s) })
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "NOT checked") {
 		t.Fatalf("missing tool must be said: %v", lines)
+	}
+	if code == 0 {
+		t.Fatalf("a check that did not run must not exit 0:\n%s", joined)
+	}
+	if !strings.Contains(joined, "did NOT run") {
+		t.Errorf("the summary must name how many checks were skipped:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
`maintain`, `debt` and `deps` join the CI gate job — they ran nowhere unless somebody typed them, which meant they protected whoever already knew they existed.

**The gate answers about the change; these answer about the repository.** Dependency freshness, the debt ledger and codebase-wide complexity are properties of the tree; asking them per commit would either report the same finding forever or rescan everything on every edit.

### Wiring it up exposed a silent green inside `maintain`

`Run` always returned 0 — including when golangci-lint was absent:

```
  complexity  NOT checked — golangci-lint is not installed; run `procoder init`
procoder maintain: 1 line(s) of findings — all judgment calls, none blocking
exit 0
```

A test pinned that **deliberately**, named `...AndStillExitZero`, reasoning that maintain is report-only.

Report-only is right about the **findings** and wrong about a check that never ran. Complexity and dead code are judgement calls and nothing blocks on them. *"The complexity checker was not installed"* is not a judgement — it is the absence of one. Left alone, CI would run this on a machine without the tool, print NOT checked, and pass the job.

The legs now return findings and unrun checks separately, and `Run` exits non-zero only for the second:

```
procoder maintain: 1 line(s) of findings — all judgment calls, none blocking
1 check(s) did NOT run — run `procoder init` and try again
exit 1
```

The old test is **rewritten to assert both halves**, not deleted — the half it had right is still right, and `TestComplexityIsReportedAndNothingBlocks` still passes unchanged.

### Worth noting

This class was invisible to the cross-domain audit added earlier today. That test reads `gitx.Finding` literals; `maintain` reports through printed lines and an exit code, so it was never in scope. The audit closed one shape of the hole, not the shape.