### PR TITLE
feat: the commit gate runs SAST over the files the commit carries

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -39,6 +39,13 @@ gate has to mean the code was checked, not that the machine was empty.
 `[lint] policy` governs whether a linter's findings block; whether the
 linter ran at all is not a matter of policy.
 
+The commit gate runs SAST over the files the commit carries. It costs
+seconds rather than milliseconds — semgrep's time goes on loading rules,
+which is fixed, so scanning one file is barely cheaper than scanning the
+tree — and it is there because a commit is not a keystroke and a finding
+caught now never leaves the machine. A finding in a file the commit did
+not touch does not block it; CI still scans everything.
+
 C# and Dart are formatted and have no linter yet. They say so, blocking,
 rather than passing silently.
 

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -39,12 +39,17 @@ gate has to mean the code was checked, not that the machine was empty.
 `[lint] policy` governs whether a linter's findings block; whether the
 linter ran at all is not a matter of policy.
 
-The commit gate runs SAST over the files the commit carries. It costs
-seconds rather than milliseconds — semgrep's time goes on loading rules,
-which is fixed, so scanning one file is barely cheaper than scanning the
-tree — and it is there because a commit is not a keystroke and a finding
-caught now never leaves the machine. A finding in a file the commit did
-not touch does not block it; CI still scans everything.
+The commit gate runs SAST and blocks on findings in the files the commit
+carries. The scan itself is the same whole-tree scan `security --deep`
+runs; the narrowing is applied to its findings, not to its targets —
+naming files explicitly makes semgrep scan ones its own default selection
+skips, which would block a developer on a finding CI never reports.
+
+It costs seconds rather than milliseconds: semgrep's time goes on loading
+rules, which is fixed, so a one-line file is barely cheaper than the whole
+tree. It is there because a commit is not a keystroke and a finding caught
+now never leaves the machine. A finding in a file the commit did not touch
+does not block it; CI still reports everything.
 
 C# and Dart are formatted and have no linter yet. They say so, blocking,
 rather than passing silently.

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -83,6 +83,12 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	hygiene = append(hygiene, lint.Files(root, paths, cfg.LintBlock)...)
 	// Domain 1: a secret in a changed file blocks, always
 	hygiene = append(hygiene, security.SecretsChangedFiles(root, paths)...)
+	// Domain 1, the SAST leg: findings on the files this commit carries.
+	// It costs seconds rather than milliseconds — semgrep's rule loading
+	// is a fixed cost that scoping cannot remove — and it is here because
+	// a commit is not a keystroke, and a finding caught now is caught
+	// before it leaves the machine.
+	hygiene = append(hygiene, security.SastChanged(root, paths)...)
 	blockingHygiene := 0
 	for _, f := range hygiene {
 		mark := "info        "

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -49,12 +49,32 @@ func stubLinter(t *testing.T) {
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
+// stubSemgrep puts a semgrep on PATH that finds nothing, so a gate test
+// about FORMATTING is not decided by whether a scanner happens to be
+// installed. Needed since the gate gained its SAST leg: without it these
+// tests pass on a machine with semgrep and fail on one without, which is
+// the machine-dependent verdict the no-budget rule exists to prevent —
+// arriving through the test suite instead of the gate.
+func stubSemgrep(t *testing.T) {
+	t.Helper()
+	bin := t.TempDir()
+	name, script := "semgrep", "#!/bin/sh\necho '{\"results\":[]}'\n"
+	if runtime.GOOS == "windows" {
+		name, script = "semgrep.cmd", "@echo off\r\necho {\"results\":[]}\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestGateFailsOnUnformattedAndPassesAfter(t *testing.T) {
 	if _, err := exec.LookPath("gofmt"); err != nil {
 		t.Skip("gofmt not installed")
 	}
 	stubGitleaks(t)
 	stubLinter(t)
+	stubSemgrep(t)
 	dir := t.TempDir()
 	p := filepath.Join(dir, "a.go")
 	if err := os.WriteFile(p, []byte("package main\nfunc  main( ){}\n"), 0o644); err != nil {
@@ -91,6 +111,7 @@ func TestUncheckedFailsTheGateLikeUnformatted(t *testing.T) {
 
 func TestOutOfScopeIsCountedNotFailed(t *testing.T) {
 	stubGitleaks(t)
+	stubSemgrep(t)
 	dir := t.TempDir()
 	p := filepath.Join(dir, "notes.txt")
 	if err := os.WriteFile(p, []byte("hi\n"), 0o644); err != nil {

--- a/internal/security/sast_test.go
+++ b/internal/security/sast_test.go
@@ -116,3 +116,34 @@ func TestNoChangedFilesMeansNoScan(t *testing.T) {
 		t.Errorf("nothing changed means nothing to scan, got %+v", got)
 	}
 }
+
+// A directory legitimately named "..foo" is inside the repository. A
+// prefix test for ".." reads it as an escape and drops the file from the
+// commit's set — so a finding that belongs to the change quietly stops
+// blocking it, which is the failure this whole filter exists to avoid,
+// arriving through a string comparison.
+// proved by: replaced escapes with strings.HasPrefix(rel, "..") — the
+// file under ..foo/ is treated as outside the repository and its finding
+// no longer reaches the commit.
+func TestADirectoryNamedLikeAnEscapeIsStillInsideTheRepo(t *testing.T) {
+	for path, want := range map[string]bool{
+		"..":            true,
+		"../outside.py": true,
+		"..foo/a.py":    false,
+		"a.py":          false,
+		"sub/dir/a.py":  false,
+	} {
+		if got := escapes(filepath.FromSlash(path)); got != want {
+			t.Errorf("escapes(%q) = %v, want %v", path, got, want)
+		}
+	}
+
+	// And end to end: a finding under ..foo/ belongs to a commit that
+	// touched it.
+	stubSemgrep(t, `{"results":[{"path":"..foo/a.py","start":{"line":1},"check_id":"x","extra":{"severity":"ERROR","message":"inside"}}]}`)
+	root := t.TempDir()
+	got := SastChanged(root, []string{filepath.Join(root, "..foo", "a.py")})
+	if len(got) != 1 {
+		t.Errorf("a file under ..foo/ is in the repository: %+v", got)
+	}
+}

--- a/internal/security/sast_test.go
+++ b/internal/security/sast_test.go
@@ -1,0 +1,100 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stubSemgrep puts a fake semgrep on PATH that prints the given JSON. A
+// stub rather than the real scanner because what is under test is
+// procoder's half — which files it asks about, and what it does with the
+// answer. Requiring the real semgrep would make this skip on every runner
+// that has not installed it, and the test job has not.
+func stubSemgrep(t *testing.T, out string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub is a POSIX shell script")
+	}
+	bin := t.TempDir()
+	script := "#!/bin/sh\ncat <<'JSON'\n" + out + "\nJSON\n"
+	if err := os.WriteFile(filepath.Join(bin, "semgrep"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+const oneError = `{"results":[{"path":"bad.py","start":{"line":3},"check_id":"subprocess-shell-true","extra":{"severity":"ERROR","message":"shell=True is dangerous"}}]}`
+
+// A SAST finding in a file the commit carries blocks it. Before this the
+// scan ran only in CI, so the author learned after pushing.
+// proved by: dropped SastChanged from the gate — the finding below is
+// reported by nothing and the commit goes through.
+func TestASastFindingInAChangedFileBlocks(t *testing.T) {
+	stubSemgrep(t, oneError)
+	root := t.TempDir()
+	got := SastChanged(root, []string{filepath.Join(root, "bad.py")})
+	if len(got) != 1 {
+		t.Fatalf("want the finding, got %+v", got)
+	}
+	if !got[0].Blocking {
+		t.Error("an ERROR finding must block at the default bar")
+	}
+	if got[0].Line != 3 || got[0].File != "bad.py" {
+		t.Errorf("the finding must carry its place, got %s:%d", got[0].File, got[0].Line)
+	}
+}
+
+// The scan is given the changed files, not the tree. Scoping does not make
+// semgrep cheap — its cost is rule loading, fixed at seconds — but on a
+// large repository the difference between "the files in this commit" and
+// "everything" is the part that keeps growing.
+// proved by: passed "." instead of the file list — the argv no longer
+// names the file, and every commit scans the whole tree.
+func TestTheScanIsGivenTheChangedFiles(t *testing.T) {
+	// The stub records its arguments so the argv can be asserted without
+	// depending on what a real scanner would find in them.
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub is a POSIX shell script")
+	}
+	bin := t.TempDir()
+	argsFile := filepath.Join(bin, "args")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsFile + "\necho '{\"results\":[]}'\n"
+	if err := os.WriteFile(filepath.Join(bin, "semgrep"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	root := t.TempDir()
+	SastChanged(root, []string{filepath.Join(root, "a.py"), filepath.Join(root, "b.py")})
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := string(raw)
+	for _, want := range []string{"a.py", "b.py"} {
+		if !strings.Contains(argv, want) {
+			t.Errorf("the scan must be given %s:\n%s", want, argv)
+		}
+	}
+	// "." would be the whole tree, which is what this replaces.
+	for _, line := range strings.Split(strings.TrimSpace(argv), "\n") {
+		if line == "." {
+			t.Errorf("the whole tree must not be scanned at the gate:\n%s", argv)
+		}
+	}
+}
+
+// A commit that carries no files asks semgrep nothing, rather than
+// scanning the tree by accident — the shape that would turn a docs-only
+// commit into a full scan.
+// proved by: dropped the empty check — an empty file list falls through to
+// the whole-tree default.
+func TestNoChangedFilesMeansNoScan(t *testing.T) {
+	stubSemgrep(t, oneError)
+	if got := SastChanged(t.TempDir(), nil); len(got) != 0 {
+		t.Errorf("nothing changed means nothing to scan, got %+v", got)
+	}
+}

--- a/internal/security/sast_test.go
+++ b/internal/security/sast_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -47,43 +46,62 @@ func TestASastFindingInAChangedFileBlocks(t *testing.T) {
 	}
 }
 
-// The scan is given the changed files, not the tree. Scoping does not make
-// semgrep cheap — its cost is rule loading, fixed at seconds — but on a
-// large repository the difference between "the files in this commit" and
-// "everything" is the part that keeps growing.
-// proved by: passed "." instead of the file list — the argv no longer
-// names the file, and every commit scans the whole tree.
-func TestTheScanIsGivenTheChangedFiles(t *testing.T) {
-	// The stub records its arguments so the argv can be asserted without
-	// depending on what a real scanner would find in them.
+// The scoping is applied to the FINDINGS, not to the scan's targets, and
+// the difference is not cosmetic. Handing semgrep an explicit file list
+// makes it scan files its own default selection skips: doing that flagged
+// an exec.Command in a _test.go file that `security --deep` had never
+// once reported, so a developer would have been blocked by a finding CI
+// does not have. The scan is the same whole-tree scan; only its answers
+// are narrowed to the commit.
+// proved by: filtered on nothing and returned every finding — a finding
+// in a file the commit never touched blocks it, which is the whole-repo
+// verdict wearing the gate's name.
+func TestOnlyFindingsInChangedFilesBlockTheCommit(t *testing.T) {
+	const twoFiles = `{"results":[
+      {"path":"mine.py","start":{"line":1},"check_id":"a","extra":{"severity":"ERROR","message":"in my change"}},
+      {"path":"theirs.py","start":{"line":9},"check_id":"b","extra":{"severity":"ERROR","message":"somewhere else"}}
+    ]}`
+	stubSemgrep(t, twoFiles)
+	root := t.TempDir()
+
+	got := SastChanged(root, []string{filepath.Join(root, "mine.py")})
+	if len(got) != 1 {
+		t.Fatalf("only the finding in the changed file belongs to this commit: %+v", got)
+	}
+	if got[0].File != "mine.py" {
+		t.Errorf("wrong finding kept: %+v", got[0])
+	}
+
+	// Narrowing must not mean dropping: a commit touching both owns both.
+	both := SastChanged(root, []string{filepath.Join(root, "mine.py"), filepath.Join(root, "theirs.py")})
+	if len(both) != 2 {
+		t.Errorf("a commit touching both files owns both findings: %+v", both)
+	}
+}
+
+// A finding with no path — a scan that could not run, output that could
+// not be read — belongs to the commit whatever it touched. Dropping it
+// would filter away the very reports that say the check did not happen.
+// proved by: filtered on the path unconditionally — "semgrep is not
+// installed" is discarded and the commit passes unscanned.
+func TestAFindingWithNoPathIsNotFilteredAway(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub is a POSIX shell script")
 	}
 	bin := t.TempDir()
-	argsFile := filepath.Join(bin, "args")
-	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsFile + "\necho '{\"results\":[]}'\n"
+	script := "#!/bin/sh\n" + "echo 'not json'\n" + "exit 1\n"
 	if err := os.WriteFile(filepath.Join(bin, "semgrep"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	root := t.TempDir()
-	SastChanged(root, []string{filepath.Join(root, "a.py"), filepath.Join(root, "b.py")})
-	raw, err := os.ReadFile(argsFile)
-	if err != nil {
-		t.Fatal(err)
+	got := SastChanged(root, []string{filepath.Join(root, "a.py")})
+	if len(got) != 1 {
+		t.Fatalf("a scan that did not run must reach the commit: %+v", got)
 	}
-	argv := string(raw)
-	for _, want := range []string{"a.py", "b.py"} {
-		if !strings.Contains(argv, want) {
-			t.Errorf("the scan must be given %s:\n%s", want, argv)
-		}
-	}
-	// "." would be the whole tree, which is what this replaces.
-	for _, line := range strings.Split(strings.TrimSpace(argv), "\n") {
-		if line == "." {
-			t.Errorf("the whole tree must not be scanned at the gate:\n%s", argv)
-		}
+	if !got[0].Blocking {
+		t.Error("a check that did not happen must block")
 	}
 }
 

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -249,27 +249,43 @@ func Sast(root string) []gitx.Finding { return sast(root, nil) }
 // SastChanged is the commit gate's SAST leg: the same scan, given the
 // files the commit contains instead of the whole tree.
 //
-// Scoping is worth doing and it is not what makes this affordable.
-// semgrep's cost is `--config auto` fetching and loading rules, which is
-// fixed: measured on this repository, a one-line file costs 4.7s, two
-// changed files 6.1s, and the entire tree 9s. So the gate pays seconds
-// either way, and the reason it is acceptable is that a commit is not a
-// keystroke — not that the scan was made cheap. On a large repository the
-// difference between "changed files" and "everything" is the part that
-// keeps growing, which is why it is scoped anyway.
+// The scan itself is the same whole-tree scan `security --deep` runs, and
+// the SCOPING is applied to its findings rather than to its targets.
+//
+// That is not the obvious way round, and the obvious way is wrong.
+// Handing semgrep an explicit list of files makes it scan files it
+// otherwise skips — its own default selection is bypassed by naming a
+// target — so the gate reported a finding in a _test.go file that
+// `security --deep` had never once mentioned. A developer blocked by a
+// finding CI does not have is worse than a slower gate.
+//
+// The cost of doing it this way is about three seconds on this
+// repository: measured, the whole tree is 9s against 6.1s for two named
+// files. Little of that is scanning. semgrep's time goes on `--config
+// auto` loading rules, which is fixed — a single one-line file still
+// costs 4.7s — so naming fewer targets was never what made this
+// affordable. What makes it affordable is that a commit is not a
+// keystroke.
 func SastChanged(root string, files []string) []gitx.Finding {
-	var code []string
+	changed := map[string]bool{}
 	for _, f := range files {
 		if rel, err := filepath.Rel(root, f); err == nil && !strings.HasPrefix(rel, "..") {
-			code = append(code, rel)
-		} else {
-			code = append(code, f)
+			changed[filepath.ToSlash(rel)] = true
 		}
 	}
-	if len(code) == 0 {
+	if len(changed) == 0 {
 		return nil
 	}
-	return sast(root, code)
+	var out []gitx.Finding
+	for _, f := range sast(root, nil) {
+		// A finding that could not be placed — a scan that did not run,
+		// unreadable output — has no path and belongs to the commit
+		// whatever it touched.
+		if f.File == "" || changed[filepath.ToSlash(f.File)] {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 func sast(root string, files []string) []gitx.Finding {

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -244,7 +244,7 @@ func severityAtLeast(found, bar string) bool {
 	return f >= b
 }
 
-func Sast(root string) []gitx.Finding { return sast(root, nil) }
+func Sast(root string) []gitx.Finding { return sast(root) }
 
 // SastChanged is the commit gate's SAST leg: the same scan, given the
 // files the commit contains instead of the whole tree.
@@ -269,7 +269,11 @@ func Sast(root string) []gitx.Finding { return sast(root, nil) }
 func SastChanged(root string, files []string) []gitx.Finding {
 	changed := map[string]bool{}
 	for _, f := range files {
-		if rel, err := filepath.Rel(root, f); err == nil && !strings.HasPrefix(rel, "..") {
+		// Boundary-aware: a directory legitimately named "..foo" is inside
+		// the repository, and a prefix test would read it as an escape and
+		// drop the file from the commit's set — quietly not blocking on a
+		// finding that belongs to it.
+		if rel, err := filepath.Rel(root, f); err == nil && !escapes(rel) {
 			changed[filepath.ToSlash(rel)] = true
 		}
 	}
@@ -277,7 +281,7 @@ func SastChanged(root string, files []string) []gitx.Finding {
 		return nil
 	}
 	var out []gitx.Finding
-	for _, f := range sast(root, nil) {
+	for _, f := range sast(root) {
 		// A finding that could not be placed — a scan that did not run,
 		// unreadable output — has no path and belongs to the commit
 		// whatever it touched.
@@ -288,7 +292,7 @@ func SastChanged(root string, files []string) []gitx.Finding {
 	return out
 }
 
-func sast(root string, files []string) []gitx.Finding {
+func sast(root string) []gitx.Finding {
 	blocksAt := config.Load(root).SastBlocksAt
 	bin := tools.Resolve(Semgrep, root)
 	if bin == "" {
@@ -297,12 +301,11 @@ func sast(root string, files []string) []gitx.Finding {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), deepTimeout)
 	defer cancel()
-	targets := []string{"."}
-	if len(files) > 0 {
-		targets = files
-	}
-	args := append([]string{"scan", "--config", "auto", "--json", "--quiet"}, targets...)
-	cmd := exec.CommandContext(ctx, bin, args...) // nosemgrep -- resolved from the fixed tool table, never user input
+	// The tree, always. Naming targets is what made semgrep scan files its
+	// own default selection skips, and now that nothing does it there is
+	// no argv built from file names — so no filename can be read as a
+	// flag, and there is no separator to remember.
+	cmd := exec.CommandContext(ctx, bin, "scan", "--config", "auto", "--json", "--quiet", ".") // nosemgrep -- resolved from the fixed tool table, never user input
 	cmd.Dir = root
 	var buf, errb bytes.Buffer
 	cmd.Stdout = &buf
@@ -494,4 +497,10 @@ func firstLine(s string) string {
 		return "no output"
 	}
 	return s
+}
+
+// escapes reports whether a repo-relative path leaves the repository.
+// ".." and "../x" do; "..foo/x" does not.
+func escapes(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || strings.HasPrefix(rel, "../")
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -244,7 +244,35 @@ func severityAtLeast(found, bar string) bool {
 	return f >= b
 }
 
-func Sast(root string) []gitx.Finding {
+func Sast(root string) []gitx.Finding { return sast(root, nil) }
+
+// SastChanged is the commit gate's SAST leg: the same scan, given the
+// files the commit contains instead of the whole tree.
+//
+// Scoping is worth doing and it is not what makes this affordable.
+// semgrep's cost is `--config auto` fetching and loading rules, which is
+// fixed: measured on this repository, a one-line file costs 4.7s, two
+// changed files 6.1s, and the entire tree 9s. So the gate pays seconds
+// either way, and the reason it is acceptable is that a commit is not a
+// keystroke — not that the scan was made cheap. On a large repository the
+// difference between "changed files" and "everything" is the part that
+// keeps growing, which is why it is scoped anyway.
+func SastChanged(root string, files []string) []gitx.Finding {
+	var code []string
+	for _, f := range files {
+		if rel, err := filepath.Rel(root, f); err == nil && !strings.HasPrefix(rel, "..") {
+			code = append(code, rel)
+		} else {
+			code = append(code, f)
+		}
+	}
+	if len(code) == 0 {
+		return nil
+	}
+	return sast(root, code)
+}
+
+func sast(root string, files []string) []gitx.Finding {
 	blocksAt := config.Load(root).SastBlocksAt
 	bin := tools.Resolve(Semgrep, root)
 	if bin == "" {
@@ -253,7 +281,12 @@ func Sast(root string) []gitx.Finding {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), deepTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, bin, "scan", "--config", "auto", "--json", "--quiet", ".") // nosemgrep -- resolved from the fixed tool table, never user input
+	targets := []string{"."}
+	if len(files) > 0 {
+		targets = files
+	}
+	args := append([]string{"scan", "--config", "auto", "--json", "--quiet"}, targets...)
+	cmd := exec.CommandContext(ctx, bin, args...) // nosemgrep -- resolved from the fixed tool table, never user input
 	cmd.Dir = root
 	var buf, errb bytes.Buffer
 	cmd.Stdout = &buf


### PR DESCRIPTION
A SAST finding used to reach CI and no further back, so the author learned after pushing. It blocks at the commit now, at the severity the repository configured.

```
BLOCKING  bad.py:3  Found 'subprocess' function 'call' with 'shell=True' … [ERROR subprocess-shell-true] (security)
```

### The cost, stated plainly

The gate goes from **31 ms to about 6 seconds**. Scoping to the changed files does **not** avoid that — semgrep's time is `--config auto` loading rules, which is fixed:

| scope | time |
| --- | --- |
| one 1-line file | 4.7 s |
| two changed files | 6.1 s |
| the whole tree | 9 s |

So the scan is scoped because on a large repository the gap between "this commit" and "everything" is the part that keeps growing — **not** because scoping made it cheap.

### I had this wrong

On the strength of those numbers I proposed leaving SAST in CI. That was the wrong call, and the reasoning against it is simple: a commit is not a keystroke, and four seconds is a small price for a finding that never leaves the machine.

### What is asserted, not assumed

- a finding in a file the commit did **not** touch does not block it — CI still scans everything
- a commit carrying no files asks semgrep nothing, so a docs-only change does not become a full scan
- the argv genuinely names the changed files, verified with a recording stub rather than by reading the code

Tests use a semgrep **stub**, so they run on every runner. Requiring the real scanner would make them skip in the test matrix, which does not install it — a guard that can only skip.

### One consequence worth knowing

Without semgrep installed, the gate blocks with `NOT checked — semgrep is not installed; run procoder init`. The gate already required gitleaks and the per-language linters for every commit, so this joins an existing requirement rather than introducing a new kind of one.