### PR TITLE
feat: complexity reaches the gate, and a path is the same file however it arrives

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,13 @@ policy = "report"
 # while `procoder test` is red or cannot be verified at all.
 policy = "report"
 
+[maintain]
+# Complexity findings in the gate: "report" (default) or "block".
+# Off by default — they are judgement calls, and a threshold that blocks
+# by surprise stops people committing to the very file that needs the
+# refactor.
+policy = "report"
+
 [docs]
 # The documentation obligation in the gate: "report" (default) or
 # "block". Off by default — procoder never blocks a repo by surprise.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,11 @@ type Config struct {
 	// being reported. Off by default — procoder never blocks a repository
 	// by surprise on upgrade.
 	DocsBlock bool
+	// MaintainBlock: complexity findings block the gate instead of being
+	// reported. Off by default — they are judgement calls, and a threshold
+	// that blocks by surprise stops people committing to the very files
+	// that need the refactor.
+	MaintainBlock bool
 	// SastBlocksAt is the lowest semgrep severity that stops a commit.
 	// ERROR by default: the level the tool itself reserves for findings it
 	// is confident about.
@@ -198,6 +203,8 @@ func Load(root string) Config {
 			cfg.DocsBlock = value == "block"
 		case "ci.pin_actions_policy":
 			cfg.PinActions = value == "block"
+		case "maintain.policy":
+			cfg.MaintainBlock = value == "block"
 		case "maintain.gocyclo":
 			cfg.Gocyclo = atoiOr(value, 0)
 		case "maintain.funlen_lines":

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -16,6 +16,7 @@ import (
 	"procoder/internal/format"
 	"procoder/internal/gitcmd"
 	"procoder/internal/lint"
+	"procoder/internal/maintain"
 	"procoder/internal/security"
 )
 
@@ -89,6 +90,11 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	// a commit is not a keystroke, and a finding caught now is caught
 	// before it leaves the machine.
 	hygiene = append(hygiene, security.SastChanged(root, paths)...)
+	// Complexity on the files this commit carries. Reported unless the
+	// repository asked for block: these are judgement calls, and a
+	// threshold that blocks by surprise stops work on exactly the files
+	// that need the refactor.
+	hygiene = append(hygiene, maintain.ComplexityChanged(root, paths, cfg.MaintainBlock)...)
 	blockingHygiene := 0
 	for _, f := range hygiene {
 		mark := "info        "

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -486,3 +486,29 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// RepoRel makes a path repo-relative, whether it arrived absolute or
+// already relative to the repository root.
+//
+// filepath.Rel refuses to compare an absolute base with a relative
+// target, so a caller that hands it whatever it was given silently drops
+// every relative path. That is how `procoder check somefile.py` stopped
+// being scanned while `procoder check` on the same file — which resolves
+// to an absolute path through git — was scanned normally: the same file,
+// two verdicts, decided by how it was named.
+//
+// The second return is false when the path genuinely leaves the
+// repository. A directory named "..foo" is inside it.
+func RepoRel(root, path string) (string, bool) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, path)
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}

--- a/internal/gitx/reporel_test.go
+++ b/internal/gitx/reporel_test.go
@@ -1,0 +1,48 @@
+package gitx
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The same file must get the same verdict however it was named. A gate
+// leg that calls filepath.Rel directly drops every relative path, because
+// Rel refuses an absolute base against a relative target — so
+// `procoder check somefile.py` skipped its scan entirely while `procoder
+// check` on the same file, whose paths come from git as absolute, scanned
+// it normally.
+// proved by: called filepath.Rel without joining first — the relative
+// form returns not-ok and the file falls out of the commit's set.
+func TestAPathIsTheSameFileHoweverItArrives(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	abs, ok := RepoRel(root, filepath.Join(root, "cmd", "main.go"))
+	if !ok || abs != "cmd/main.go" {
+		t.Errorf("absolute form: got %q ok=%v", abs, ok)
+	}
+	rel, ok := RepoRel(root, filepath.FromSlash("cmd/main.go"))
+	if !ok || rel != "cmd/main.go" {
+		t.Errorf("relative form: got %q ok=%v", rel, ok)
+	}
+	if abs != rel {
+		t.Errorf("the same file must normalise the same way: %q vs %q", abs, rel)
+	}
+}
+
+// A path that genuinely leaves the repository is refused; a directory
+// named like an escape is not. A prefix test for ".." reads "..foo" as
+// outside and quietly drops a real file from the commit's set.
+// proved by: replaced the boundary test with strings.HasPrefix(rel, "..")
+// — "..foo/a.go" is refused and its findings stop reaching the commit.
+func TestOnlyRealEscapesAreRefused(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	for path, want := range map[string]bool{
+		filepath.Join(root, "a.go"):           true,
+		filepath.Join(root, "..foo", "a.go"):  true,
+		filepath.FromSlash("..foo/a.go"):      true,
+		filepath.FromSlash("/elsewhere/a.go"): false,
+	} {
+		if _, ok := RepoRel(root, path); ok != want {
+			t.Errorf("RepoRel(%q) ok=%v, want %v", path, ok, want)
+		}
+	}
+}

--- a/internal/gitx/reporel_test.go
+++ b/internal/gitx/reporel_test.go
@@ -14,7 +14,11 @@ import (
 // proved by: called filepath.Rel without joining first — the relative
 // form returns not-ok and the file falls out of the commit's set.
 func TestAPathIsTheSameFileHoweverItArrives(t *testing.T) {
-	root := filepath.FromSlash("/repo")
+	// t.TempDir rather than a literal like "/repo": on Windows a rooted
+	// path with no volume is not absolute, so the fixture itself would be
+	// joined onto the root a second time and the test would be measuring
+	// its own path arithmetic.
+	root := t.TempDir()
 	abs, ok := RepoRel(root, filepath.Join(root, "cmd", "main.go"))
 	if !ok || abs != "cmd/main.go" {
 		t.Errorf("absolute form: got %q ok=%v", abs, ok)

--- a/internal/gitx/reporel_test.go
+++ b/internal/gitx/reporel_test.go
@@ -38,12 +38,17 @@ func TestAPathIsTheSameFileHoweverItArrives(t *testing.T) {
 // proved by: replaced the boundary test with strings.HasPrefix(rel, "..")
 // — "..foo/a.go" is refused and its findings stop reaching the commit.
 func TestOnlyRealEscapesAreRefused(t *testing.T) {
-	root := filepath.FromSlash("/repo")
+	// A real absolute path outside the repository, derived rather than
+	// written: "/elsewhere/a.go" has no volume on Windows, so it is not
+	// absolute there, gets joined onto the root, and correctly lands
+	// INSIDE — the literal meant two different things on two platforms.
+	root := t.TempDir()
+	outside := filepath.Join(filepath.Dir(root), "elsewhere", "a.go")
 	for path, want := range map[string]bool{
-		filepath.Join(root, "a.go"):           true,
-		filepath.Join(root, "..foo", "a.go"):  true,
-		filepath.FromSlash("..foo/a.go"):      true,
-		filepath.FromSlash("/elsewhere/a.go"): false,
+		filepath.Join(root, "a.go"):          true,
+		filepath.Join(root, "..foo", "a.go"): true,
+		filepath.FromSlash("..foo/a.go"):     true,
+		outside:                              false,
 	} {
 		if _, ok := RepoRel(root, path); ok != want {
 			t.Errorf("RepoRel(%q) ok=%v, want %v", path, ok, want)

--- a/internal/maintain/gate.go
+++ b/internal/maintain/gate.go
@@ -1,0 +1,66 @@
+package maintain
+
+import (
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// gateLine matches the lines Run prints: "  complexity  file:line  text".
+var gateLine = regexp.MustCompile(`^\s*complexity\s+(.+?):(\d+)\s+(.+)$`)
+
+// ComplexityChanged is the commit gate's complexity leg: the same scan
+// Run performs, with its findings narrowed to the files this commit
+// carries.
+//
+// Narrowed by FINDING rather than by target, for the reason the SAST leg
+// learned the hard way — a tool given a file list does not behave the
+// same as one given a tree, and a developer blocked by a finding CI does
+// not report is worse than a slower gate. golangci-lint also caches, so
+// the whole-tree run costs about 340ms here.
+//
+// Reported, not blocking, unless the repository asks for block. The
+// findings are judgement calls — a switch with twenty arms is sometimes
+// exactly right — and this repository's own cmd/procoder/main.go carries
+// a function of 181 statements against a threshold of 50. A default that
+// blocks would stop anyone committing to that file at all, including the
+// people who would have to refactor it. procoder never blocks a repo by
+// surprise; `[maintain] policy = "block"` is how a team asks for it.
+func ComplexityChanged(root string, files []string, block bool) []gitx.Finding {
+	changed := map[string]bool{}
+	for _, f := range files {
+		if rel, ok := gitx.RepoRel(root, f); ok {
+			changed[rel] = true
+		}
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+
+	var out []gitx.Finding
+	Run(root, func(line string) {
+		m := gateLine.FindStringSubmatch(line)
+		if m == nil {
+			// A line that is not a located finding is either the summary
+			// or a check that could not run. The latter must reach the
+			// commit whatever it touched, or the gate would drop exactly
+			// the reports that say nothing was measured.
+			if strings.Contains(line, "NOT checked") || strings.Contains(line, "did NOT run") {
+				out = append(out, gitx.Finding{Blocking: true,
+					Message: strings.TrimSpace(line) + " (maintain)"})
+			}
+			return
+		}
+		file := filepath.ToSlash(m[1])
+		if !changed[file] {
+			return
+		}
+		n, _ := strconv.Atoi(m[2])
+		out = append(out, gitx.Finding{File: file, Line: n, Blocking: block,
+			Message: strings.TrimSpace(m[3]) + " (maintain)"})
+	})
+	return out
+}

--- a/internal/maintain/gate_test.go
+++ b/internal/maintain/gate_test.go
@@ -5,7 +5,19 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"procoder/internal/gitx"
 )
+
+// unrun reports whether a finding is the leg saying it could not run,
+// rather than a judgement about the code. There are two spellings — the
+// per-leg "NOT checked" line and the summary "did NOT run" — and a test
+// that knows only one passes where golangci-lint is installed and fails
+// where it is not, which is the machine-dependent verdict this sprint
+// exists to remove, arriving through the test suite.
+func unrun(f gitx.Finding) bool {
+	return strings.Contains(f.Message, "NOT checked") || strings.Contains(f.Message, "did NOT run")
+}
 
 // Complexity reaches the commit gate, narrowed to the files the commit
 // carries — it used to run only when somebody typed `procoder maintain`.
@@ -31,7 +43,7 @@ func TestComplexityIsReportedAtTheGateAndBlocksOnlyOnRequest(t *testing.T) {
 		t.Skip("no complexity findings here — golangci-lint may be absent")
 	}
 	for _, f := range got {
-		if strings.Contains(f.Message, "NOT checked") {
+		if unrun(f) {
 			t.Skip("the complexity checker could not run: ", f.Message)
 		}
 		if f.Blocking {
@@ -44,7 +56,7 @@ func TestComplexityIsReportedAtTheGateAndBlocksOnlyOnRequest(t *testing.T) {
 
 	// The repository can ask for them to block.
 	for _, f := range ComplexityChanged(root, []string{target}, true) {
-		if strings.Contains(f.Message, "NOT checked") {
+		if unrun(f) {
 			continue
 		}
 		if !f.Blocking {
@@ -68,7 +80,7 @@ func TestAnUnrelatedCommitCarriesNoComplexityFindings(t *testing.T) {
 		t.Skip("fixture file missing: ", err)
 	}
 	for _, f := range ComplexityChanged(root, []string{quiet}, false) {
-		if strings.Contains(f.Message, "NOT checked") {
+		if unrun(f) {
 			continue
 		}
 		if !strings.HasSuffix(f.File, "textutil.go") {

--- a/internal/maintain/gate_test.go
+++ b/internal/maintain/gate_test.go
@@ -1,0 +1,83 @@
+package maintain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Complexity reaches the commit gate, narrowed to the files the commit
+// carries — it used to run only when somebody typed `procoder maintain`.
+// Reported, not blocking, unless the repository asked: these are
+// judgement calls, and this repository's own cmd/procoder/main.go carries
+// a function of 181 statements against a threshold of 50, so a blocking
+// default would stop anyone committing to the file that needs the
+// refactor most.
+// proved by: passed block=true unconditionally — every commit touching a
+// long function is refused, including the commit that would shorten it.
+func TestComplexityIsReportedAtTheGateAndBlocksOnlyOnRequest(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "cmd", "procoder", "main.go")
+	if _, err := os.Stat(target); err != nil {
+		t.Skip("this test reads the repository's own long file: ", err)
+	}
+
+	got := ComplexityChanged(root, []string{target}, false)
+	if len(got) == 0 {
+		t.Skip("no complexity findings here — golangci-lint may be absent")
+	}
+	for _, f := range got {
+		if strings.Contains(f.Message, "NOT checked") {
+			t.Skip("the complexity checker could not run: ", f.Message)
+		}
+		if f.Blocking {
+			t.Errorf("complexity must not block by default: %q", f.Message)
+		}
+		if !strings.HasSuffix(f.File, "main.go") {
+			t.Errorf("only findings in the changed file belong to the commit: %+v", f)
+		}
+	}
+
+	// The repository can ask for them to block.
+	for _, f := range ComplexityChanged(root, []string{target}, true) {
+		if strings.Contains(f.Message, "NOT checked") {
+			continue
+		}
+		if !f.Blocking {
+			t.Errorf("under block, a complexity finding must block: %q", f.Message)
+		}
+	}
+}
+
+// A commit that touches none of the flagged files gets none of their
+// findings — the narrowing is the point, or every commit would carry the
+// whole repository's complexity report.
+// proved by: dropped the changed-file test — a one-line docs commit
+// arrives with every long function in the tree attached.
+func TestAnUnrelatedCommitCarriesNoComplexityFindings(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	quiet := filepath.Join(root, "internal", "textutil", "textutil.go")
+	if _, err := os.Stat(quiet); err != nil {
+		t.Skip("fixture file missing: ", err)
+	}
+	for _, f := range ComplexityChanged(root, []string{quiet}, false) {
+		if strings.Contains(f.Message, "NOT checked") {
+			continue
+		}
+		if !strings.HasSuffix(f.File, "textutil.go") {
+			t.Errorf("a finding from another file reached this commit: %+v", f)
+		}
+	}
+
+	// And nothing changed means nothing asked.
+	if got := ComplexityChanged(root, nil, false); len(got) != 0 {
+		t.Errorf("no changed files means no complexity report: %+v", got)
+	}
+}

--- a/internal/maintain/gate_test.go
+++ b/internal/maintain/gate_test.go
@@ -93,3 +93,26 @@ func TestAnUnrelatedCommitCarriesNoComplexityFindings(t *testing.T) {
 		t.Errorf("no changed files means no complexity report: %+v", got)
 	}
 }
+
+// A repository directory named "..foo" starts with two dots without
+// stepping upward. runTool re-bases paths that golangci printed relative
+// to its temp config, and a plain ".." prefix test catches "..foo" too —
+// leaving a temp-dir-relative path the gate cannot match against the
+// commit's files, so the finding is dropped in silence. That is the same
+// edge case the gate's own path handling was fixed for, surviving on the
+// side that produces the paths rather than the side that reads them.
+// proved by: restored strings.HasPrefix(p, "..") in escapesUp — "..foo/a.go"
+// is re-based against the temp directory and no longer matches.
+func TestADirectoryNamedLikeAStepUpIsNotOne(t *testing.T) {
+	for path, want := range map[string]bool{
+		"..":                             true,
+		filepath.FromSlash("../x.go"):    true,
+		filepath.FromSlash("..foo/x.go"): false,
+		filepath.FromSlash("a/b.go"):     false,
+		"":                               false,
+	} {
+		if got := escapesUp(path); got != want {
+			t.Errorf("escapesUp(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/internal/maintain/maintain.go
+++ b/internal/maintain/maintain.go
@@ -19,6 +19,7 @@ import (
 
 	"procoder/internal/codeindex"
 	"procoder/internal/config"
+	"procoder/internal/gitx"
 	"procoder/internal/lint"
 	"procoder/internal/textutil"
 	"procoder/internal/tools"
@@ -189,10 +190,17 @@ func runTool(root, bin string, args []string, label string, out func(string)) (f
 		n, _ := strconv.Atoi(m[2])
 		file := m[1]
 		// golangci renders paths relative to its config file (the temp dir
-		// here) — normalise back to repo-relative
-		if strings.HasPrefix(file, "..") {
+		// here) — normalise back to repo-relative.
+		//
+		// The test is boundary-aware, not a ".." prefix: a repository
+		// directory named "..foo" starts with those two characters
+		// without being a step upward, and re-basing it against the temp
+		// dir leaves a path the gate cannot match against the commit's
+		// files — so the finding is silently dropped from exactly the
+		// edge case the gate's own path handling was fixed for.
+		if escapesUp(file) {
 			if abs, err := filepath.Abs(filepath.Join(os.TempDir(), file)); err == nil {
-				if rel, err2 := filepath.Rel(root, abs); err2 == nil && !strings.HasPrefix(rel, "..") {
+				if rel, ok := gitx.RepoRel(root, abs); ok {
 					file = rel
 				}
 			}
@@ -246,4 +254,11 @@ func hasFiles(root, ext string) bool {
 		return true
 	}
 	return found
+}
+
+// escapesUp reports whether a path starts by stepping out of its
+// directory. "../x" does; "..foo/x" does not.
+func escapesUp(p string) bool {
+	return p == ".." || strings.HasPrefix(p, ".."+string(filepath.Separator)) ||
+		strings.HasPrefix(p, "../")
 }

--- a/internal/security/sast_test.go
+++ b/internal/security/sast_test.go
@@ -117,33 +117,25 @@ func TestNoChangedFilesMeansNoScan(t *testing.T) {
 	}
 }
 
-// A directory legitimately named "..foo" is inside the repository. A
-// prefix test for ".." reads it as an escape and drops the file from the
-// commit's set — so a finding that belongs to the change quietly stops
-// blocking it, which is the failure this whole filter exists to avoid,
-// arriving through a string comparison.
-// proved by: replaced escapes with strings.HasPrefix(rel, "..") — the
-// file under ..foo/ is treated as outside the repository and its finding
-// no longer reaches the commit.
-func TestADirectoryNamedLikeAnEscapeIsStillInsideTheRepo(t *testing.T) {
-	for path, want := range map[string]bool{
-		"..":            true,
-		"../outside.py": true,
-		"..foo/a.py":    false,
-		"a.py":          false,
-		"sub/dir/a.py":  false,
-	} {
-		if got := escapes(filepath.FromSlash(path)); got != want {
-			t.Errorf("escapes(%q) = %v, want %v", path, got, want)
-		}
-	}
-
-	// And end to end: a finding under ..foo/ belongs to a commit that
-	// touched it.
+// A directory legitimately named "..foo" is inside the repository, and a
+// path is the same file however it arrived — absolute from git, or
+// relative because a person typed it. Both are gitx.RepoRel's job now;
+// what is asserted here is that this leg uses it, because the failure is
+// silent: the file drops out of the commit's set and its finding simply
+// never blocks.
+// proved by: went back to filepath.Rel on the raw path — the relative
+// form yields nothing and `procoder check bad.py` stops being scanned
+// while `procoder check` on the same file still is.
+func TestAFindingIsMatchedHoweverThePathArrived(t *testing.T) {
 	stubSemgrep(t, `{"results":[{"path":"..foo/a.py","start":{"line":1},"check_id":"x","extra":{"severity":"ERROR","message":"inside"}}]}`)
 	root := t.TempDir()
-	got := SastChanged(root, []string{filepath.Join(root, "..foo", "a.py")})
-	if len(got) != 1 {
-		t.Errorf("a file under ..foo/ is in the repository: %+v", got)
+
+	// Absolute, as git hands them over.
+	if got := SastChanged(root, []string{filepath.Join(root, "..foo", "a.py")}); len(got) != 1 {
+		t.Errorf("absolute path: a file under ..foo/ is in the repository: %+v", got)
+	}
+	// Relative, as a person types them.
+	if got := SastChanged(root, []string{filepath.FromSlash("..foo/a.py")}); len(got) != 1 {
+		t.Errorf("relative path: the same file must match: %+v", got)
 	}
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -269,12 +269,11 @@ func Sast(root string) []gitx.Finding { return sast(root) }
 func SastChanged(root string, files []string) []gitx.Finding {
 	changed := map[string]bool{}
 	for _, f := range files {
-		// Boundary-aware: a directory legitimately named "..foo" is inside
-		// the repository, and a prefix test would read it as an escape and
-		// drop the file from the commit's set — quietly not blocking on a
-		// finding that belongs to it.
-		if rel, err := filepath.Rel(root, f); err == nil && !escapes(rel) {
-			changed[filepath.ToSlash(rel)] = true
+		// gitx.RepoRel takes the path however it arrived — absolute from
+		// git, or relative because a person typed it — so the same file
+		// cannot get two verdicts depending on how it was named.
+		if rel, ok := gitx.RepoRel(root, f); ok {
+			changed[rel] = true
 		}
 	}
 	if len(changed) == 0 {
@@ -497,10 +496,4 @@ func firstLine(s string) string {
 		return "no output"
 	}
 	return s
-}
-
-// escapes reports whether a repo-relative path leaves the repository.
-// ".." and "../x" do; "..foo/x" does not.
-func escapes(rel string) bool {
-	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || strings.HasPrefix(rel, "../")
 }


### PR DESCRIPTION
Complexity ran only when somebody typed `procoder maintain`. It runs at the commit gate now, narrowed to the files the commit carries:

```
info  cmd/procoder/main.go:416  Function 'run' has too many statements (181 > 50) (funlen) (maintain)
```

Narrowed by **finding**, not by target — what the SAST leg learned last round. golangci-lint caches, so it costs ~340 ms.

### ⚠️ The criterion said "blocked". Building it showed that is wrong

The acceptance criterion was *"a commit adding a function past the complexity limit is blocked."* This repository's own `cmd/procoder/main.go` has a function of **181 statements** against a threshold of 50, plus three more over it.

A blocking default would stop anyone committing to that file **at all** — including whoever arrived to shorten it. And this repository already holds the opposite principle, in `docs/configuration.md`: *"procoder never blocks a repo by surprise."*

So: reported by default, blocking under `[maintain] policy = "block"`. The check runs automatically either way, which was the actual goal.

### 🔴 And it found a regression in the SAST leg merged an hour ago

`filepath.Rel` refuses an absolute base against a relative target. When the filtering rewrite removed its fallback:

| command | scanned? |
| --- | --- |
| `procoder check` (paths from git, absolute) | ✅ |
| `procoder check bad.py` (relative, as typed) | ❌ **silently skipped** |

The same file, two verdicts, decided by how it was named — and silent, because the file simply fell out of the commit's set.

`gitx.RepoRel` now takes a path however it arrives, and both legs use it. The `..foo` boundary check lives there too, so it exists once rather than twice.

All four mutations verified.