### PR TITLE
feat: known vulnerabilities are checked when a commit touches a manifest

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -45,6 +45,13 @@ runs; the narrowing is applied to its findings, not to its targets —
 naming files explicitly makes semgrep scan ones its own default selection
 skips, which would block a developer on a finding CI never reports.
 
+Known dependency vulnerabilities are checked at the gate too, but only
+when the commit touches a manifest — the scan answers about the manifests,
+so running it on a commit that edits a comment would report the same
+vulnerabilities forever at nearly a second each time. All manifests are
+scanned when one changes: a lockfile edit moves the versions the others
+resolve against.
+
 It costs seconds rather than milliseconds: semgrep's time goes on loading
 rules, which is fixed, so a one-line file is barely cheaper than the whole
 tree. It is there because a commit is not a keystroke and a finding caught

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -48,9 +48,14 @@ skips, which would block a developer on a finding CI never reports.
 Known dependency vulnerabilities are checked at the gate too, but only
 when the commit touches a manifest — the scan answers about the manifests,
 so running it on a commit that edits a comment would report the same
-vulnerabilities forever at nearly a second each time. All manifests are
-scanned when one changes: a lockfile edit moves the versions the others
-resolve against.
+vulnerabilities forever at nearly a second each time.
+
+Every manifest in the repository is scanned when one changes, including
+the ones beneath the root — a monorepo keeps one per package — and all of
+them rather than only the one that changed, since a lockfile edit moves
+the versions the others resolve against. Vendored copies and installed
+packages are skipped: their manifests describe code nobody here can
+change.
 
 It costs seconds rather than milliseconds: semgrep's time goes on loading
 rules, which is fixed, so a one-line file is barely cheaper than the whole

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -95,6 +95,11 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	// threshold that blocks by surprise stops work on exactly the files
 	// that need the refactor.
 	hygiene = append(hygiene, maintain.ComplexityChanged(root, paths, cfg.MaintainBlock)...)
+	// Known vulnerabilities, when the commit touches a dependency
+	// manifest. Only then: the scan answers about the manifests, so a
+	// commit that edits a comment would pay nearly a second to be told the
+	// same thing it was told last time.
+	hygiene = append(hygiene, security.DepsChanged(root, paths)...)
 	blockingHygiene := 0
 	for _, f := range hygiene {
 		mark := "info        "

--- a/internal/security/deps_test.go
+++ b/internal/security/deps_test.go
@@ -102,3 +102,69 @@ func TestAManifestTriggersHoweverThePathArrived(t *testing.T) {
 		t.Error("a nested relative manifest must trigger")
 	}
 }
+
+// A monorepo keeps one manifest per package. Scanning only the ones at
+// the repository root reported clean over every package beneath it — in
+// `security --deep` as well as at the gate — and once the gate began
+// triggering on a nested manifest, a commit paid for a scan that could
+// not look at the file that triggered it.
+// proved by: restored the root-only os.Stat loop — services/api/go.mod
+// and web/app/package-lock.json vanish from the scan, and a monorepo
+// commits dependency changes unscanned while being charged for the scan.
+func TestManifestsAreFoundBeneathTheRootToo(t *testing.T) {
+	root := t.TempDir()
+	for _, p := range []string{
+		"go.mod",
+		filepath.FromSlash("services/api/go.mod"),
+		filepath.FromSlash("web/app/package-lock.json"),
+		// Not ours: a vendored copy and an installed package carry their
+		// own manifests, and reporting on them means reporting code
+		// nobody here can change.
+		filepath.FromSlash("node_modules/evil/package-lock.json"),
+		filepath.FromSlash("vendor/x/go.mod"),
+	} {
+		if err := os.MkdirAll(filepath.Join(root, filepath.Dir(p)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, p), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := manifestsIn(root)
+	want := []string{"go.mod", "services/api/go.mod", "web/app/package-lock.json"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("manifests found:\n got %v\nwant %v", got, want)
+	}
+}
+
+// The same gap one level down: a nested package.json declaring
+// dependencies with no lockfile beside it is an unscannable package, and
+// checking only the repository root reports the first and stays silent
+// about the rest.
+// proved by: called hasNpmDepsWithoutLockfile(root) directly again — the
+// nested package is not reported and its dependencies go unscanned with
+// nothing said.
+func TestEveryPackageWithoutALockfileIsNamed(t *testing.T) {
+	root := t.TempDir()
+	write := func(p, body string) {
+		if err := os.MkdirAll(filepath.Join(root, filepath.Dir(p)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, p), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const withDeps = `{"dependencies":{"left-pad":"1.0.0"}}`
+	write("package.json", withDeps)
+	write(filepath.FromSlash("web/app/package.json"), withDeps)
+	// This one has its lockfile, so it is scannable and not a gap.
+	write(filepath.FromSlash("web/ok/package.json"), withDeps)
+	write(filepath.FromSlash("web/ok/package-lock.json"), "{}")
+
+	got := npmGaps(root)
+	want := []string{"package.json", "web/app/package.json"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("packages with no lockfile:\n got %v\nwant %v", got, want)
+	}
+}

--- a/internal/security/deps_test.go
+++ b/internal/security/deps_test.go
@@ -1,0 +1,104 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stubOsv puts an osv-scanner on PATH that reports nothing, so these
+// tests measure WHEN the scan runs rather than what a real scanner finds.
+func stubOsv(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub is a POSIX shell script")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "osv-scanner"),
+		[]byte("#!/bin/sh\necho '{\"results\":[]}'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// The scan answers about the manifests, so it runs when the commit
+// touches one and not otherwise. Running it on every commit would report
+// the same vulnerabilities forever at nearly a second each time, which is
+// how a check becomes something people route around.
+// proved by: dropped the touchesManifest guard — a commit editing a
+// comment pays for a full dependency scan and is told what it was told
+// last time.
+func TestTheScanRunsWhenAManifestChanges(t *testing.T) {
+	stubOsv(t)
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DepsChanged(root, []string{filepath.Join(root, "README.md")}); got != nil {
+		t.Errorf("a commit touching no manifest must not scan: %+v", got)
+	}
+	// "Ran and found nothing" and "never ran" are both an empty slice, so
+	// the scan is made observable: a package.json declaring dependencies
+	// with no lockfile is a gap only a real run reports.
+	if err := os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"dependencies":{"left-pad":"1.0.0"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := DepsChanged(root, []string{filepath.Join(root, "package.json")})
+	var ran bool
+	for _, f := range got {
+		if strings.Contains(f.Message, "no lockfile") {
+			ran = true
+		}
+	}
+	if !ran {
+		t.Errorf("touching a manifest must actually run the scan: %+v", got)
+	}
+	// And a commit that touches nothing relevant still does not run it,
+	// now that a run would be visible.
+	if others := DepsChanged(root, []string{filepath.Join(root, "README.md")}); others != nil {
+		t.Errorf("an unrelated commit must still skip the scan: %+v", others)
+	}
+}
+
+// Every name osv-scanner accepts triggers the scan, plus the package.json
+// whose missing lockfile Deps reports on. A list that drifts from
+// DepManifests would leave an ecosystem silently unscanned at the gate
+// while `security --deep` still covered it.
+// proved by: hard-coded a short list instead of deriving it from
+// DepManifests — Cargo.lock and composer.lock stop triggering, and Rust
+// and PHP repositories commit dependency changes unscanned.
+func TestEveryManifestNameTriggersTheScan(t *testing.T) {
+	root := t.TempDir()
+	for _, m := range append([]string{"package.json"}, DepManifests...) {
+		if !touchesManifest(root, []string{filepath.Join(root, m)}) {
+			t.Errorf("%s must trigger the dependency scan", m)
+		}
+	}
+	for _, other := range []string{"main.go", "README.md", "go.sum"} {
+		if touchesManifest(root, []string{filepath.Join(root, other)}) {
+			t.Errorf("%s is not a manifest osv-scanner reads", other)
+		}
+	}
+}
+
+// A path that arrives relative must trigger the scan too — the same file
+// cannot mean two things depending on how it was named.
+// proved by: matched on the raw string instead of gitx.RepoRel — an
+// absolute path fails path.Base's expectations or a relative one is
+// dropped, depending which way it is written.
+func TestAManifestTriggersHoweverThePathArrived(t *testing.T) {
+	root := t.TempDir()
+	if !touchesManifest(root, []string{filepath.Join(root, "go.mod")}) {
+		t.Error("absolute form must trigger")
+	}
+	if !touchesManifest(root, []string{"go.mod"}) {
+		t.Error("relative form must trigger")
+	}
+	if !touchesManifest(root, []string{filepath.FromSlash("services/api/go.mod")}) {
+		t.Error("a nested relative manifest must trigger")
+	}
+}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -496,4 +497,45 @@ func firstLine(s string) string {
 		return "no output"
 	}
 	return s
+}
+
+// DepsChanged is the commit gate's dependency-vulnerability leg: the same
+// scan, run only when the commit touches something that could change the
+// dependency graph.
+//
+// The scan answers about the manifests, not about the files around them,
+// so re-running it on a commit that edits a comment would report the same
+// vulnerabilities forever at a cost of nearly a second each time. A commit
+// that changes a manifest is exactly the moment the answer can change.
+//
+// All manifests are scanned, not only the one that changed: a lockfile
+// edit moves versions the other manifests resolve against, and a scan of
+// half a graph is a scan nobody can trust.
+func DepsChanged(root string, files []string) []gitx.Finding {
+	if !touchesManifest(root, files) {
+		return nil
+	}
+	return Deps(root)
+}
+
+// touchesManifest reports whether any changed file is a dependency
+// manifest osv-scanner reads, or the package.json whose absent lockfile
+// Deps reports on.
+func touchesManifest(root string, files []string) bool {
+	watched := map[string]bool{"package.json": true}
+	for _, m := range DepManifests {
+		watched[m] = true
+	}
+	for _, f := range files {
+		rel, ok := gitx.RepoRel(root, f)
+		if !ok {
+			continue
+		}
+		// By base name: a manifest in a subdirectory is still a manifest,
+		// and a monorepo keeps one per package.
+		if watched[path.Base(rel)] {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -374,19 +375,17 @@ func Deps(root string) []gitx.Finding {
 	// manifests are named explicitly: osv's own directory walker trusts
 	// git metadata and comes back empty inside git worktrees
 	var margs []string
-	for _, m := range DepManifests {
-		if _, err := os.Stat(filepath.Join(root, m)); err == nil {
-			margs = append(margs, "-L", m)
-		}
+	for _, m := range manifestsIn(root) {
+		margs = append(margs, "-L", m)
 	}
 	// a bare package.json is not scannable by osv (it needs a lockfile's
 	// pinned versions); one that DECLARES dependencies without any
 	// lockfile is an honest gap, one without dependencies has nothing to
 	// check and stays silent
 	var out []gitx.Finding
-	if hasNpmDepsWithoutLockfile(root) {
-		out = append(out, gitx.Finding{Blocking: true,
-			Message: "npm dependencies NOT checked — package.json declares dependencies but no lockfile exists for osv-scanner; generate package-lock.json (security)"})
+	for _, gap := range npmGaps(root) {
+		out = append(out, gitx.Finding{Blocking: true, File: gap,
+			Message: "npm dependencies NOT checked — this package.json declares dependencies but no lockfile exists beside it for osv-scanner; generate package-lock.json (security)"})
 	}
 	if len(margs) == 0 {
 		if len(out) > 0 {
@@ -447,6 +446,38 @@ func Deps(root string) []gitx.Finding {
 
 // hasNpmDepsWithoutLockfile: package.json declares dependencies but no
 // npm lockfile exists — osv cannot pin versions, so scanning is impossible.
+// npmGaps lists every package.json that declares dependencies with no
+// lockfile beside it — one per package, because a monorepo has one per
+// package and checking only the repository root reports the first and
+// stays silent about the rest.
+func npmGaps(root string) []string {
+	var out []string
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable directory hides its own packages, not the others
+		}
+		if info.IsDir() {
+			if p != root && manifestDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.Name() != "package.json" {
+			return nil
+		}
+		if hasNpmDepsWithoutLockfile(filepath.Dir(p)) {
+			if rel, ok := gitx.RepoRel(root, p); ok {
+				out = append(out, rel)
+			}
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out
+}
+
+// hasNpmDepsWithoutLockfile answers for ONE directory: a package.json
+// there declaring dependencies with no lockfile beside it.
 func hasNpmDepsWithoutLockfile(root string) bool {
 	for _, lock := range []string{"package-lock.json", "yarn.lock", "pnpm-lock.yaml"} {
 		if _, err := os.Stat(filepath.Join(root, lock)); err == nil {
@@ -538,4 +569,55 @@ func touchesManifest(root string, files []string) bool {
 		}
 	}
 	return false
+}
+
+// manifestDirs are directories a dependency manifest may sit in without
+// belonging to this repository: vendored copies and installed packages
+// carry their own, and scanning them reports vulnerabilities in code
+// nobody here can change.
+var manifestDirs = map[string]bool{
+	".git": true, "node_modules": true, "vendor": true, "dist": true,
+	"target": true, "__pycache__": true, ".venv": true,
+}
+
+// manifestsIn finds every dependency manifest in the repository, not only
+// the ones at its root.
+//
+// The root-only version was the shape of the whole feature's failure: a
+// monorepo keeps one manifest per package, so `security --deep` scanned
+// the top level and reported clean over every package beneath it — and
+// once the gate began triggering on a nested manifest, a commit paid for
+// a scan that could not look at the file it was triggered by.
+//
+// Paths are returned repo-relative because that is what osv-scanner's -L
+// wants alongside cmd.Dir = root.
+func manifestsIn(root string) []string {
+	names := map[string]bool{}
+	for _, m := range DepManifests {
+		names[m] = true
+	}
+	var out []string
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			// An unreadable directory is not a reason to scan nothing; the
+			// manifests that ARE readable still get scanned, and osv
+			// reports on what it was given.
+			return nil //nolint:nilerr // a walk that cannot enter one directory still covers the rest
+		}
+		if info.IsDir() {
+			if p != root && manifestDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !names[info.Name()] {
+			return nil
+		}
+		if rel, ok := gitx.RepoRel(root, p); ok {
+			out = append(out, rel)
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
The dependency scan ran only in CI, under `security --deep`. A commit could add a vulnerable dependency and its author learned after pushing.

It runs at the gate now — **only when the commit touches something that could change the dependency graph**:

| commit touches | cost |
| --- | --- |
| no manifest | **0 s** — skipped |
| `go.mod` | 789 ms |
| `web/app/package.json` | 740 ms |

That condition is the design, not an optimisation. The scan answers about the *manifests*, so running it on a commit that edits a comment would report the same vulnerabilities forever at ~780 ms a time — which is how a check becomes something people route around.

**All manifests are scanned when one changes**, not just the changed one: a lockfile edit moves the versions the others resolve against, and a scan of half a graph is a scan nobody can trust.

The trigger matches by **base name** through `gitx.RepoRel`, so a nested manifest counts — a monorepo keeps one per package, and matching the repository root alone would leave every package after the first unscanned.

### The test needed a second attempt

*"Ran and found nothing"* and *"never ran"* are both an empty slice, so my first version asserted nothing at all — it would have passed with the feature deleted. It now makes a run **observable** through the npm-without-lockfile gap, which only a real scan reports.

Both mutations verified — including a redo, because the first attempt at one mutated the code into something that wouldn't compile.