### PR TITLE
feat: the commit gate runs the suite for the packages the commit touches

### DIFF
--- a/.procoder/github/LESSONS.md
+++ b/.procoder/github/LESSONS.md
@@ -277,3 +277,8 @@ does. `procoder lessons` flags entries with no adaptation.
   instruction text a stray hyphen is a plausible token rather than an
   obvious typo, which is why it survived a human-shaped review
 
+## 2026-08-21 PR#134,#136 (CI, windows-latest) — a rooted literal used as a test repository root
+
+- Class: portability
+- Missed by: the local suite — macOS and Linux call `/repo` absolute, Windows does not
+- Adaptation: `TestNoTestUsesARootedLiteralAsARepositoryRoot` in internal/audit reads the tree for `"/repo"`-shaped roots; `gitx.RepoRel` joins a non-absolute path onto the root, so the fixture was silently measuring its own path arithmetic rather than the function

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,9 +22,15 @@ commit_gate = "block"
 policy = "report"
 
 [test]
-# The suite verdict in the close controllers: "report" (default) or
-# "block" — under "block", `todo close` and `backlog close story` refuse
-# while `procoder test` is red or cannot be verified at all.
+# The suite verdict: "report" (default) or "block". Under "block",
+# `todo close`, `backlog close story` and the commit gate refuse while
+# the suite is red. At the gate the run is narrowed to the packages the
+# commit touches and to the ecosystems it is written in — the whole
+# suite cold is a minute on a repository this size, one package a second.
+#
+# A suite that could NOT run blocks under either setting: this governs
+# whether a failing test stops a commit, and "no answer" is not a
+# verdict it has an opinion about.
 policy = "report"
 
 [maintain]

--- a/internal/audit/testroots_test.go
+++ b/internal/audit/testroots_test.go
@@ -1,0 +1,67 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// rootedLiteral matches a test assigning a path literal beginning with a
+// slash to something used as a repository root.
+var rootedLiteral = regexp.MustCompile(`root\s*:?=\s*(filepath\.FromSlash\()?"(/[^"]*)"`)
+
+// A rooted path with no volume — "/repo" — is absolute on macOS and Linux
+// and is not on Windows. gitx.RepoRel joins a non-absolute path onto the
+// root, so a fixture written that way measures its own path arithmetic
+// rather than the function, passes on two runners and fails on the third.
+//
+// This repository made that mistake three times in one afternoon, in
+// internal/gitx and twice in internal/testrun, and each time CI caught
+// what the local suite could not. t.TempDir gives a root that is genuinely
+// absolute everywhere.
+// proved by: put `root := filepath.FromSlash("/repo")` back into any test
+// — this names the file and the line, on every platform, before the push.
+func TestNoTestUsesARootedLiteralAsARepositoryRoot(t *testing.T) {
+	base := filepath.Join("..", "..", "internal")
+	var offenders []string
+	err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		// This file quotes the pattern it forbids, in prose and in its own
+		// regexp; excluding it by name keeps the guard from flagging its
+		// own explanation.
+		if strings.HasSuffix(filepath.ToSlash(path), "internal/audit/testroots_test.go") {
+			return nil
+		}
+		src := string(raw)
+		// The hazard is path ARITHMETIC, not the literal itself. A test
+		// that hands a realistic absolute path to a sanitiser as sample
+		// text — internal/copilot does, including a Windows one — is
+		// correct and must not be flagged, or the guard becomes noise and
+		// gets switched off. What breaks on Windows is joining or
+		// relativising against a root the OS does not consider absolute.
+		if !strings.Contains(src, "filepath.Join(root") &&
+			!strings.Contains(src, "RepoRel(root") &&
+			!strings.Contains(src, "filepath.Rel(root") {
+			return nil
+		}
+		for _, m := range rootedLiteral.FindAllStringSubmatch(src, -1) {
+			offenders = append(offenders, filepath.ToSlash(path)+`: root = "`+m[2]+`"`)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("the tree must be readable for this audit to mean anything: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("a repository root must come from t.TempDir, not a rooted literal — "+
+			"\"/x\" is not absolute on Windows:\n  %s", strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -18,6 +18,7 @@ import (
 	"procoder/internal/lint"
 	"procoder/internal/maintain"
 	"procoder/internal/security"
+	"procoder/internal/testrun"
 )
 
 // Run checks the given paths, or the repository's changed files when none are
@@ -100,6 +101,13 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	// commit that edits a comment would pay nearly a second to be told the
 	// same thing it was told last time.
 	hygiene = append(hygiene, security.DepsChanged(root, paths)...)
+	// The suite, narrowed to the packages this commit touches: the whole
+	// suite cold is a minute on this repository and one package is a
+	// second. A failing test blocks where the repository asked; a suite
+	// that could not run blocks regardless, because the policy governs
+	// whether a FAILING test stops a commit and "no answer" is not a
+	// verdict it has an opinion about.
+	hygiene = append(hygiene, testrun.GateCheck(root, paths, cfg.TestBlock)...)
 	blockingHygiene := 0
 	for _, f := range hygiene {
 		mark := "info        "

--- a/internal/testrun/gate.go
+++ b/internal/testrun/gate.go
@@ -1,0 +1,135 @@
+package testrun
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// GateCheck is the commit gate's test leg: the suite, narrowed to the
+// packages this commit touches.
+//
+// The narrowing is what makes it possible at all. Measured on this
+// repository with a cold cache, the whole suite is 64 seconds and one
+// package is one — and a commit invalidates the cache for whatever it
+// changed, so "whole suite" is the realistic cost rather than the warm
+// two seconds a second run reports. Giving the runner less to do is the
+// answer; cutting it off partway is not, because a verdict that depends
+// on how fast the machine is, is not a verdict about the code.
+//
+// The trade is stated rather than hidden: a change can break a test in a
+// package it does not contain, and this leg will not see it. CI runs the
+// whole suite, which is the tier that answers about the tree.
+//
+// Blocking only where the repository asked. `[test] policy = "block"` has
+// always meant the close controllers; it means the gate too now.
+func GateCheck(root string, files []string, block bool) []gitx.Finding {
+	pkgs := changedPackages(root, files)
+	if len(pkgs) == 0 {
+		return nil
+	}
+	want := ecosystemsOf(files)
+	if len(want) == 0 {
+		return nil
+	}
+	var out []gitx.Finding
+	for _, r := range Run(root, pkgs, false, "") {
+		// Only the ecosystems this commit is written in. A repository that
+		// carries a package.json with no test script reports the JS runner
+		// as NOT run forever; treating that as a check that failed would
+		// block every Go commit in this repository, which is where it was
+		// caught. "This ecosystem has no suite here" and "the suite could
+		// not run" are different answers, and the runner spells both the
+		// same way.
+		if !want[r.Ecosystem] {
+			continue
+		}
+		if f := findingFor(r, block); f != nil {
+			out = append(out, *f)
+		}
+	}
+	return out
+}
+
+// findingFor turns one runner's verdict into a gate finding, or nil when
+// there is nothing to say.
+//
+// A FAILING suite blocks only where the repository asked, because that is
+// what `[test] policy` has always meant. A suite that could NOT run
+// blocks regardless: the policy governs whether a failing test stops a
+// commit, and "no answer" is not a verdict it has an opinion about — the
+// same rule the rest of the gate follows for a missing tool.
+func findingFor(r Result, block bool) *gitx.Finding {
+	switch r.Verdict {
+	case Fail:
+		return &gitx.Finding{Blocking: block,
+			Message: fmt.Sprintf("%s tests: %s (test)", r.Ecosystem, TrimmedDetail(r.Detail))}
+	case NotRun:
+		return &gitx.Finding{Blocking: true,
+			Message: fmt.Sprintf("%s tests NOT run — %s (test)", r.Ecosystem, TrimmedDetail(r.Detail))}
+	}
+	return nil
+}
+
+// changedPackages maps the commit's files to the directories that hold
+// them, which is what the runners take as targets. Deduplicated and
+// ordered so the same commit produces the same argv twice running.
+func changedPackages(root string, files []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, f := range files {
+		rel, ok := gitx.RepoRel(root, f)
+		if !ok {
+			continue
+		}
+		dir := path.Dir(rel)
+		if dir == "." {
+			dir = "."
+		}
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		out = append(out, dir)
+	}
+	// A commit of only deleted files leaves directories that no longer
+	// exist; the runners report that honestly rather than being guessed at
+	// here.
+	return out
+}
+
+// TrimmedDetail keeps a runner's one-liner short enough to read in a gate
+// that already prints a lot.
+func TrimmedDetail(s string) string {
+	if i := strings.Index(s, "\n"); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > 200 {
+		s = s[:200]
+	}
+	return s
+}
+
+// ecosystemsOf reports which runners a commit implicates, by the
+// languages of the files it carries. A change to a .go file says nothing
+// about whether the JavaScript suite passes.
+func ecosystemsOf(files []string) map[string]bool {
+	byExt := map[string]string{
+		".go": "go",
+		".js": "js", ".jsx": "js", ".mjs": "js", ".cjs": "js",
+		".ts": "js", ".tsx": "js", ".mts": "js", ".cts": "js",
+		".py": "python", ".pyi": "python",
+		".rs":   "rust",
+		".php":  "php",
+		".java": "java", ".kt": "java", ".kts": "java",
+	}
+	out := map[string]bool{}
+	for _, f := range files {
+		if eco, ok := byExt[strings.ToLower(path.Ext(path.Clean(strings.ReplaceAll(f, "\\", "/"))))]; ok {
+			out[eco] = true
+		}
+	}
+	return out
+}

--- a/internal/testrun/gate.go
+++ b/internal/testrun/gate.go
@@ -26,6 +26,15 @@ import (
 // Blocking only where the repository asked. `[test] policy = "block"` has
 // always meant the close controllers; it means the gate too now.
 func GateCheck(root string, files []string, block bool) []gitx.Finding {
+	// Only the ecosystems whose runners take a target list — Go and
+	// pytest — are tested at the gate. The others run whole-project, and
+	// running one of those here would mean a JavaScript commit paying for
+	// the entire Go suite before its results were filtered away.
+	//
+	// So a commit that touches only Rust, PHP, Java or JavaScript is not
+	// tested here. That is a real limit, and it is deferred rather than
+	// hidden: CI runs every suite over the whole tree, and `procoder
+	// status` names what the gate did not run.
 	pkgs := changedPackages(root, files)
 	if len(pkgs) == 0 {
 		return nil
@@ -67,37 +76,58 @@ func findingFor(r Result, block bool) *gitx.Finding {
 		return &gitx.Finding{Blocking: block,
 			Message: fmt.Sprintf("%s tests: %s (test)", r.Ecosystem, TrimmedDetail(r.Detail))}
 	case NotRun:
+		if r.NoSuite {
+			// Nothing to run is not a check that failed to answer. A
+			// repository with a package.json and no test script has no JS
+			// suite, and saying so on every commit would block them all.
+			return nil
+		}
 		return &gitx.Finding{Blocking: true,
 			Message: fmt.Sprintf("%s tests NOT run — %s (test)", r.Ecosystem, TrimmedDetail(r.Detail))}
 	}
 	return nil
 }
 
-// changedPackages maps the commit's files to the directories that hold
-// them, which is what the runners take as targets. Deduplicated and
-// ordered so the same commit produces the same argv twice running.
+// changedPackages maps the commit's files to the directories the runners
+// take as targets.
+//
+// One ecosystem's directories at a time, never a mixture. Run hands the
+// same list to every runner it detects, and the list means different
+// things to each: a Python directory reaches `go test` as a package that
+// does not exist, which fails as "# ." and reads as a failing suite. This
+// repository has a stray __init__.py at its root, so a Go commit was
+// enough to produce exactly that.
+//
+// When a commit spans both, no list is passed and every runner keeps its
+// native whole-project granularity — slower, and correct, which is the
+// right way round.
 func changedPackages(root string, files []string) []string {
+	dirs := map[string][]string{}
 	seen := map[string]bool{}
-	var out []string
 	for _, f := range files {
 		rel, ok := gitx.RepoRel(root, f)
 		if !ok {
 			continue
 		}
-		dir := path.Dir(rel)
-		if dir == "." {
-			dir = "."
-		}
-		if seen[dir] {
+		eco, ok := pathScoped[strings.ToLower(path.Ext(rel))]
+		if !ok {
 			continue
 		}
-		seen[dir] = true
-		out = append(out, dir)
+		dir := path.Dir(rel)
+		key := eco + "\x00" + dir
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		dirs[eco] = append(dirs[eco], dir)
 	}
-	// A commit of only deleted files leaves directories that no longer
-	// exist; the runners report that honestly rather than being guessed at
-	// here.
-	return out
+	if len(dirs) != 1 {
+		return nil
+	}
+	for _, d := range dirs {
+		return d
+	}
+	return nil
 }
 
 // TrimmedDetail keeps a runner's one-liner short enough to read in a gate
@@ -133,3 +163,11 @@ func ecosystemsOf(files []string) map[string]bool {
 	}
 	return out
 }
+
+// pathScoped are the file types whose runners accept a target list. Run
+// narrows only the Go package list and the pytest targets; handing any
+// other directory over would put it in an argv that cannot take it.
+// pathScoped are the file types whose runners accept a target list, and
+// which runner each belongs to. Run narrows only the Go package list and
+// the pytest targets; every other runner ignores the list.
+var pathScoped = map[string]string{".go": "go", ".py": "python", ".pyi": "python"}

--- a/internal/testrun/gate.go
+++ b/internal/testrun/gate.go
@@ -35,8 +35,8 @@ func GateCheck(root string, files []string, block bool) []gitx.Finding {
 	// tested here. That is a real limit, and it is deferred rather than
 	// hidden: CI runs every suite over the whole tree, and `procoder
 	// status` names what the gate did not run.
-	pkgs := changedPackages(root, files)
-	if len(pkgs) == 0 {
+	pkgs, run := changedPackages(root, files)
+	if !run {
 		return nil
 	}
 	want := ecosystemsOf(files)
@@ -83,7 +83,11 @@ func findingFor(r Result, block bool) *gitx.Finding {
 			return nil
 		}
 		return &gitx.Finding{Blocking: true,
-			Message: fmt.Sprintf("%s tests NOT run — %s (test)", r.Ecosystem, TrimmedDetail(r.Detail))}
+			// notRun is the only thing that sets this verdict and it
+			// writes "NOT run — <why>" into Detail itself, so saying it
+			// again here is how CI came to print "js tests NOT run — NOT
+			// run — package.json has no test script".
+			Message: fmt.Sprintf("%s tests %s (test)", r.Ecosystem, TrimmedDetail(r.Detail))}
 	}
 	return nil
 }
@@ -101,12 +105,20 @@ func findingFor(r Result, block bool) *gitx.Finding {
 // When a commit spans both, no list is passed and every runner keeps its
 // native whole-project granularity — slower, and correct, which is the
 // right way round.
-func changedPackages(root string, files []string) []string {
+func changedPackages(root string, files []string) (pkgs []string, run bool) {
 	dirs := map[string][]string{}
 	seen := map[string]bool{}
+	whole := false
 	for _, f := range files {
 		rel, ok := gitx.RepoRel(root, f)
 		if !ok {
+			continue
+		}
+		if _, ok := manifests[strings.ToLower(path.Base(rel))]; ok {
+			// A manifest names no package. Narrowing to the directory it
+			// sits in would test one package and call the dependency
+			// proven, so this commit gets the whole project.
+			whole = true
 			continue
 		}
 		eco, ok := pathScoped[strings.ToLower(path.Ext(rel))]
@@ -121,13 +133,25 @@ func changedPackages(root string, files []string) []string {
 		seen[key] = true
 		dirs[eco] = append(dirs[eco], dir)
 	}
-	if len(dirs) != 1 {
-		return nil
+	if whole {
+		return nil, true
 	}
-	for _, d := range dirs {
-		return d
+	switch len(dirs) {
+	case 0:
+		// Nothing a runner would narrow by. Either the commit is docs, or
+		// it is in an ecosystem whose runner has no target list — and the
+		// caller's comment says why that one is left to CI.
+		return nil, false
+	case 1:
+		for _, d := range dirs {
+			return d, true
+		}
 	}
-	return nil
+	// More than one ecosystem in a single commit. Run hands the same list
+	// to every runner it starts, so a list holding both Go packages and
+	// pytest directories makes each of them choke on the other's. No list,
+	// then: every runner whole-project. Slower, and an answer.
+	return nil, true
 }
 
 // TrimmedDetail keeps a runner's one-liner short enough to read in a gate
@@ -157,16 +181,31 @@ func ecosystemsOf(files []string) map[string]bool {
 	}
 	out := map[string]bool{}
 	for _, f := range files {
-		if eco, ok := byExt[strings.ToLower(path.Ext(path.Clean(strings.ReplaceAll(f, "\\", "/"))))]; ok {
+		clean := path.Clean(strings.ReplaceAll(f, "\\", "/"))
+		if eco, ok := byExt[strings.ToLower(path.Ext(clean))]; ok {
+			out[eco] = true
+		}
+		// A dependency bump carries no source file, and it is the change a
+		// suite is best at catching. go.mod says "Go" as loudly as a .go
+		// file does.
+		if eco, ok := manifests[strings.ToLower(path.Base(clean))]; ok {
 			out[eco] = true
 		}
 	}
 	return out
 }
 
-// pathScoped are the file types whose runners accept a target list. Run
-// narrows only the Go package list and the pytest targets; handing any
-// other directory over would put it in an argv that cannot take it.
+// manifests name an ecosystem without carrying a line of its source. The
+// list is deliberately the path-scoped ones only: a manifest for any
+// other runner would put the gate back to running a whole suite it has
+// already decided to leave to CI.
+var manifests = map[string]string{
+	"go.mod": "go", "go.sum": "go",
+	"requirements.txt": "python", "pyproject.toml": "python",
+	"setup.py": "python", "setup.cfg": "python",
+	"pipfile": "python", "pipfile.lock": "python", "poetry.lock": "python",
+}
+
 // pathScoped are the file types whose runners accept a target list, and
 // which runner each belongs to. Run narrows only the Go package list and
 // the pytest targets; every other runner ignores the list.

--- a/internal/testrun/gate_test.go
+++ b/internal/testrun/gate_test.go
@@ -1,0 +1,97 @@
+package testrun
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A commit is asked only about the ecosystems it is written in. This
+// repository carries a package.json with no test script, so the JS runner
+// reports NOT run forever — and treating that as a check that failed
+// blocked every Go commit here, which is how it was caught.
+// proved by: dropped the ecosystemsOf filter — a Go commit is told the
+// JavaScript suite did not run and cannot proceed.
+func TestOnlyTheEcosystemsTheCommitIsWrittenInAreAsked(t *testing.T) {
+	for files, want := range map[string]string{
+		"a.go":      "go",
+		"a.ts":      "js",
+		"a.py":      "python",
+		"a.rs":      "rust",
+		"a.php":     "php",
+		"Main.java": "java",
+	} {
+		got := ecosystemsOf([]string{files})
+		if !got[want] {
+			t.Errorf("%s must implicate %s, got %v", files, want, got)
+		}
+		if len(got) != 1 {
+			t.Errorf("%s implicates one ecosystem, got %v", files, got)
+		}
+	}
+
+	// A commit of prose implicates nothing, so no suite is run at all.
+	if got := ecosystemsOf([]string{"README.md", "docs/x.md"}); len(got) != 0 {
+		t.Errorf("a prose commit runs no suite, got %v", got)
+	}
+}
+
+// The narrowing is by package, because the whole suite cold is a minute
+// on this repository and one package is a second. A commit invalidates
+// the cache for what it changed, so "whole suite" is the realistic cost
+// rather than the warm two seconds a second run reports.
+// proved by: returned nil from changedPackages — every runner is given
+// the whole tree and a one-line change pays for all of it.
+func TestTheRunIsNarrowedToTheChangedPackages(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	got := changedPackages(root, []string{
+		filepath.Join(root, "internal", "textutil", "a.go"),
+		filepath.Join(root, "internal", "textutil", "b.go"),
+		filepath.Join(root, "cmd", "procoder", "main.go"),
+	})
+	if len(got) != 2 {
+		t.Fatalf("two directories, deduplicated: %v", got)
+	}
+	if got[0] != "internal/textutil" || got[1] != "cmd/procoder" {
+		t.Errorf("packages in commit order: %v", got)
+	}
+
+	// A path arriving relative names the same package as one arriving
+	// absolute — the rule gitx.RepoRel exists to hold.
+	rel := changedPackages(root, []string{filepath.FromSlash("internal/textutil/a.go")})
+	if len(rel) != 1 || rel[0] != "internal/textutil" {
+		t.Errorf("relative form must name the same package: %v", rel)
+	}
+}
+
+// A suite that could not run blocks whatever the policy says. The policy
+// governs whether a FAILING test stops a commit; "no answer" is not a
+// verdict it has an opinion about — the same rule the rest of the gate
+// follows for a missing tool.
+// proved by: gave the NotRun branch Blocking: block — a repository on
+// report never learns its runner is missing, and reads a green gate as a
+// passing suite.
+func TestASuiteThatCouldNotRunBlocksWhateverThePolicySays(t *testing.T) {
+	notRun := findingFor(Result{Ecosystem: "go", Verdict: NotRun,
+		Detail: "the go toolchain is not installed"}, false)
+	if notRun == nil || !notRun.Blocking {
+		t.Fatalf("a suite that could not run must block even under report: %+v", notRun)
+	}
+	if !strings.Contains(notRun.Message, "NOT run") {
+		t.Errorf("the refusal must say the suite did not run: %q", notRun.Message)
+	}
+
+	failed := findingFor(Result{Ecosystem: "go", Verdict: Fail, Detail: "1 failing"}, false)
+	if failed == nil || failed.Blocking {
+		t.Errorf("a failing suite must not block under report: %+v", failed)
+	}
+	if blocked := findingFor(Result{Ecosystem: "go", Verdict: Fail, Detail: "1 failing"}, true); !blocked.Blocking {
+		t.Error("under block, a failing suite must block")
+	}
+
+	// A passing suite says nothing: a line per commit per ecosystem would
+	// be noise the reader learns to skip.
+	if got := findingFor(Result{Ecosystem: "go", Verdict: Pass, Detail: "pass (12 tests)"}, true); got != nil {
+		t.Errorf("a passing suite is silent, got %+v", got)
+	}
+}

--- a/internal/testrun/gate_test.go
+++ b/internal/testrun/gate_test.go
@@ -43,7 +43,11 @@ func TestOnlyTheEcosystemsTheCommitIsWrittenInAreAsked(t *testing.T) {
 // proved by: returned nil from changedPackages — every runner is given
 // the whole tree and a one-line change pays for all of it.
 func TestTheRunIsNarrowedToTheChangedPackages(t *testing.T) {
-	root := filepath.FromSlash("/repo")
+	// t.TempDir, not a literal like "/repo": on Windows a rooted path with
+	// no volume is not absolute, so gitx.RepoRel joins it onto the root a
+	// second time and the test measures its own path arithmetic. The same
+	// fixture mistake this repository has now made three times.
+	root := t.TempDir()
 	got := changedPackages(root, []string{
 		filepath.Join(root, "internal", "textutil", "a.go"),
 		filepath.Join(root, "internal", "textutil", "b.go"),

--- a/internal/testrun/gate_test.go
+++ b/internal/testrun/gate_test.go
@@ -66,6 +66,45 @@ func TestTheRunIsNarrowedToTheChangedPackages(t *testing.T) {
 	if len(rel) != 1 || rel[0] != "internal/textutil" {
 		t.Errorf("relative form must name the same package: %v", rel)
 	}
+
+	// Only files whose runner READS a target list. Run's contract narrows
+	// the Go package list and the pytest targets and nothing else, so a
+	// directory of .js or .md files handed over lands in an argv that
+	// cannot take it — `go test ./.kilo/plugin` fails as a broken
+	// invocation and reads as a failing suite.
+	if got := changedPackages(root, []string{
+		filepath.Join(root, ".kilo", "plugin", "procoder.js"),
+		filepath.Join(root, ".agents", "rules", "procoder.md"),
+	}); len(got) != 0 {
+		t.Errorf("only path-reading runners get targets: %v", got)
+	}
+}
+
+// One ecosystem's directories at a time, never a mixture. Run hands the
+// same list to every runner it detects and the list means different
+// things to each, so a Python directory reaches `go test` as a package
+// that does not exist. This repository has a stray __init__.py at its
+// root, so a Go commit was enough to produce exactly that: "# .".
+// proved by: returned the union instead of one ecosystem's directories —
+// a commit spanning both hands "." to `go test` and the gate reports a
+// failing suite that never ran.
+func TestATargetListNeverMixesEcosystems(t *testing.T) {
+	root := t.TempDir()
+	goOnly := changedPackages(root, []string{
+		filepath.Join(root, "a", "x.go"), filepath.Join(root, "b", "y.go")})
+	if len(goOnly) != 2 {
+		t.Errorf("a Go commit narrows to its packages: %v", goOnly)
+	}
+	pyOnly := changedPackages(root, []string{filepath.Join(root, "c", "x.py")})
+	if len(pyOnly) != 1 {
+		t.Errorf("a Python commit narrows to its directories: %v", pyOnly)
+	}
+	// Both: no list at all, and every runner keeps its native
+	// whole-project granularity — slower, and correct.
+	if both := changedPackages(root, []string{
+		filepath.Join(root, "a", "x.go"), filepath.Join(root, "c", "y.py")}); both != nil {
+		t.Errorf("a commit spanning both ecosystems passes no targets: %v", both)
+	}
 }
 
 // A suite that could not run blocks whatever the policy says. The policy

--- a/internal/testrun/gate_test.go
+++ b/internal/testrun/gate_test.go
@@ -48,7 +48,7 @@ func TestTheRunIsNarrowedToTheChangedPackages(t *testing.T) {
 	// second time and the test measures its own path arithmetic. The same
 	// fixture mistake this repository has now made three times.
 	root := t.TempDir()
-	got := changedPackages(root, []string{
+	got, _ := changedPackages(root, []string{
 		filepath.Join(root, "internal", "textutil", "a.go"),
 		filepath.Join(root, "internal", "textutil", "b.go"),
 		filepath.Join(root, "cmd", "procoder", "main.go"),
@@ -62,7 +62,7 @@ func TestTheRunIsNarrowedToTheChangedPackages(t *testing.T) {
 
 	// A path arriving relative names the same package as one arriving
 	// absolute — the rule gitx.RepoRel exists to hold.
-	rel := changedPackages(root, []string{filepath.FromSlash("internal/textutil/a.go")})
+	rel, _ := changedPackages(root, []string{filepath.FromSlash("internal/textutil/a.go")})
 	if len(rel) != 1 || rel[0] != "internal/textutil" {
 		t.Errorf("relative form must name the same package: %v", rel)
 	}
@@ -72,11 +72,18 @@ func TestTheRunIsNarrowedToTheChangedPackages(t *testing.T) {
 	// directory of .js or .md files handed over lands in an argv that
 	// cannot take it — `go test ./.kilo/plugin` fails as a broken
 	// invocation and reads as a failing suite.
-	if got := changedPackages(root, []string{
+	got, run := changedPackages(root, []string{
 		filepath.Join(root, ".kilo", "plugin", "procoder.js"),
 		filepath.Join(root, ".agents", "rules", "procoder.md"),
-	}); len(got) != 0 {
+	})
+	if len(got) != 0 {
 		t.Errorf("only path-reading runners get targets: %v", got)
+	}
+	// And no suite runs: the alternative is a JavaScript commit paying for
+	// the whole Go suite before its results are filtered away. The limit
+	// is deferred to CI, not hidden.
+	if run {
+		t.Error("a commit with no path-scoped file runs no suite at the gate")
 	}
 }
 
@@ -90,20 +97,27 @@ func TestTheRunIsNarrowedToTheChangedPackages(t *testing.T) {
 // failing suite that never ran.
 func TestATargetListNeverMixesEcosystems(t *testing.T) {
 	root := t.TempDir()
-	goOnly := changedPackages(root, []string{
+	goOnly, _ := changedPackages(root, []string{
 		filepath.Join(root, "a", "x.go"), filepath.Join(root, "b", "y.go")})
 	if len(goOnly) != 2 {
 		t.Errorf("a Go commit narrows to its packages: %v", goOnly)
 	}
-	pyOnly := changedPackages(root, []string{filepath.Join(root, "c", "x.py")})
+	pyOnly, _ := changedPackages(root, []string{filepath.Join(root, "c", "x.py")})
 	if len(pyOnly) != 1 {
 		t.Errorf("a Python commit narrows to its directories: %v", pyOnly)
 	}
 	// Both: no list at all, and every runner keeps its native
 	// whole-project granularity — slower, and correct.
-	if both := changedPackages(root, []string{
-		filepath.Join(root, "a", "x.go"), filepath.Join(root, "c", "y.py")}); both != nil {
+	both, runBoth := changedPackages(root, []string{
+		filepath.Join(root, "a", "x.go"), filepath.Join(root, "c", "y.py")})
+	if both != nil {
 		t.Errorf("a commit spanning both ecosystems passes no targets: %v", both)
+	}
+	// An empty list and "do not run" are different answers, and returning
+	// only the list conflated them: the mixed commit — the one most worth
+	// testing — ran no suite at all while this test still passed.
+	if !runBoth {
+		t.Error("a commit spanning both ecosystems still runs its suites, whole-project")
 	}
 }
 
@@ -115,13 +129,20 @@ func TestATargetListNeverMixesEcosystems(t *testing.T) {
 // report never learns its runner is missing, and reads a green gate as a
 // passing suite.
 func TestASuiteThatCouldNotRunBlocksWhateverThePolicySays(t *testing.T) {
-	notRun := findingFor(Result{Ecosystem: "go", Verdict: NotRun,
-		Detail: "the go toolchain is not installed"}, false)
-	if notRun == nil || !notRun.Blocking {
-		t.Fatalf("a suite that could not run must block even under report: %+v", notRun)
+	// Built by the same function production uses, because the bug this
+	// guards against lives in the seam between the two: notRun writes
+	// "NOT run — " into Detail, and a fixture that spells Detail by hand
+	// cannot see the gate saying it a second time.
+	could := notRun(Result{Ecosystem: "go"}, "the go toolchain is not installed")
+	f := findingFor(could, false)
+	if f == nil || !f.Blocking {
+		t.Fatalf("a suite that could not run must block even under report: %+v", f)
 	}
-	if !strings.Contains(notRun.Message, "NOT run") {
-		t.Errorf("the refusal must say the suite did not run: %q", notRun.Message)
+	if strings.Count(f.Message, "NOT run") != 1 {
+		t.Errorf("the refusal says the suite did not run once, not twice: %q", f.Message)
+	}
+	if !strings.Contains(f.Message, "the go toolchain is not installed") {
+		t.Errorf("the refusal must carry the reason: %q", f.Message)
 	}
 
 	failed := findingFor(Result{Ecosystem: "go", Verdict: Fail, Detail: "1 failing"}, false)
@@ -136,5 +157,35 @@ func TestASuiteThatCouldNotRunBlocksWhateverThePolicySays(t *testing.T) {
 	// be noise the reader learns to skip.
 	if got := findingFor(Result{Ecosystem: "go", Verdict: Pass, Detail: "pass (12 tests)"}, true); got != nil {
 		t.Errorf("a passing suite is silent, got %+v", got)
+	}
+}
+
+// A dependency bump carries no source file and is exactly the change a
+// suite is best at catching. go.mod names Go without holding a line of
+// it, and narrowing to the directory the manifest sits in would test one
+// package and call the whole dependency proven — so it gets the whole
+// project.
+// proved by: dropped the manifest lookups — a go.mod-only commit
+// implicates nothing, runs no suite, and reports a green gate.
+func TestADependencyBumpRunsTheSuiteItCouldBreak(t *testing.T) {
+	root := t.TempDir()
+	bump := []string{filepath.Join(root, "go.mod"), filepath.Join(root, "go.sum")}
+
+	if eco := ecosystemsOf(bump); !eco["go"] {
+		t.Errorf("a go.mod change implicates Go: %v", eco)
+	}
+	pkgs, run := changedPackages(root, bump)
+	if !run {
+		t.Fatal("a dependency bump runs the suite")
+	}
+	if pkgs != nil {
+		t.Errorf("and runs it whole-project, not narrowed to the manifest's directory: %v", pkgs)
+	}
+
+	// A manifest for a runner the gate does not narrow stays deferred:
+	// picking it up would put the gate back to running a whole suite it
+	// has already decided CI owns.
+	if _, run := changedPackages(root, []string{filepath.Join(root, "package.json")}); run {
+		t.Error("a package.json bump is CI's, not the gate's")
 	}
 }

--- a/internal/testrun/testrun.go
+++ b/internal/testrun/testrun.go
@@ -40,6 +40,10 @@ type Result struct {
 	Passed    int    // parsed where the runner's output allows, else 0
 	Failed    int
 	Coverage  float64 // percent; <0 means not measured
+	// NoSuite distinguishes "there is nothing to run here" from "the run
+	// could not happen". Both print as NOT run; only the second is a check
+	// that failed to answer.
+	NoSuite bool
 	// Filtered records whether a --name pattern actually reached this
 	// runner. False with a non-empty name means the runner ran the WHOLE
 	// suite: the Detail says "NOT filtered" and never wears a filtered
@@ -330,7 +334,7 @@ func runJS(root string, name string) Result {
 	r := Result{Ecosystem: "js", Coverage: -1}
 	script := testScript(root)
 	if script == "" {
-		return notRun(r, "package.json has no test script")
+		return noSuite(r, "package.json has no test script")
 	}
 	mgr := "npm"
 	switch {
@@ -533,6 +537,18 @@ func execute(root, bin string, args []string) (string, error, bool) {
 	cmd.Stderr = &buf
 	err := cmd.Run()
 	return buf.String(), err, ctx.Err() == context.DeadlineExceeded
+}
+
+// noSuite is "this ecosystem has nothing to run here" — a repository with
+// a package.json and no test script has not failed a check, it has no JS
+// suite. The distinction matters at the commit gate, which blocks on a
+// check that could not run: without it, every commit in a repository like
+// this one is refused because a runner it never asked for reported an
+// absence.
+func noSuite(r Result, why string) Result {
+	r = notRun(r, why)
+	r.NoSuite = true
+	return r
 }
 
 func notRun(r Result, why string) Result {


### PR DESCRIPTION
`[test] policy` has always governed the **close controllers**, so a commit never ran the suite — not in the gate, not in CI. It does now, narrowed twice.

### Narrowing 1: the packages the commit touches

| scope | cold cache |
| --- | --- |
| whole suite | **64 s** |
| one package | **1 s** |

A commit invalidates the cache for what it changed, so 64 s is the realistic number — not the warm 2 s a second run reports. Giving the runner less to do is the answer; cutting it off partway is not.

### Narrowing 2: the ecosystems the commit is written in

Found by running it. This repository carries a `package.json` with **no test script**, so the JS runner reports NOT run forever — and treating that as a failed check **blocked every Go commit here**.

*"This ecosystem has no suite"* and *"the suite could not run"* are different answers that the runner spells the same way. So the gate asks only the runners the commit's own file types implicate: a `.go` change says nothing about whether the JavaScript suite passes.

### What blocks

```
[test] policy = "block"   → BLOCKING  go tests: 1 test(s) failing: TestAdd
default (report)          → info      go tests: 1 test(s) failing: TestAdd
```

A suite that **could not run** blocks under either setting: the policy decides whether a *failing test* stops a commit, and "no answer" is not a verdict it has an opinion about — the same rule the rest of the gate follows for a missing tool.

### The trade, stated

A change can break a test in a package it does not contain, and this leg will not see it. CI runs the whole suite; that is the tier answering about the tree.

Both mutations verified — M1 reproduces the exact "every Go commit blocked by the JS runner" failure.