### PR TITLE
feat: the report names the suites the gate does not run

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -250,7 +250,7 @@ never runs the gate, the suite, or any network tool.
 It also names the suites the commit gate will **not** run here:
 
 ```
-gate defers to CI: rust, js suite(s) — the gate narrows only go and pytest
+gate defers to CI: rust, js suite(s) — the gate runs go, python
 ```
 
 The gate narrows to the runners that accept a target list, so every other

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -247,6 +247,18 @@ reason rather than defaulting to something comfortable. The same block
 is injected at session start, inside a hard three-second budget that
 never runs the gate, the suite, or any network tool.
 
+It also names the suites the commit gate will **not** run here:
+
+```
+gate defers to CI: rust, js suite(s) — the gate narrows only go and pytest
+```
+
+The gate narrows to the runners that accept a target list, so every other
+suite is CI's. Without this line that trade is invisible — a JavaScript
+commit passes a green gate having never run its suite. Nothing deferred,
+nothing said; and a `package.json` with no test script is no suite rather
+than a deferred one, so it is not named.
+
 #### `procoder run [--exec]`
 
 How to run this project: the launch command(s) it declares — package.json

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -147,3 +147,41 @@ func TestBlockingHygieneFailsTheExitCodeNotJustTheReport(t *testing.T) {
 		t.Fatalf("exit %d with a blocking finding in the report, want 1\n%s", code, out.String())
 	}
 }
+
+// A repository with no test setup, no manifests and no rule files commits
+// without a blocking finding. This sprint gave the gate five new legs —
+// SAST, complexity, vulnerable dependencies, the suite, and agents drift
+// — and each one had to decide what to say about a repository that has
+// nothing for it to look at. "Nothing here" must come out silent; a
+// repository that adopts procoder and cannot commit a text file has been
+// told its empty tree is broken.
+//
+// The scanners are stubbed clean because what is under test is procoder's
+// half. A machine WITHOUT them blocks, loudly and on purpose, and that
+// has its own test in internal/security.
+// proved by: made portability.AgentsDrift block when AGENTS.md is absent
+// instead of returning nil — a repository that never opted into an agent
+// layer is blocked for not having one.
+func TestAQuietRepositoryStillCommits(t *testing.T) {
+	stubGitleaks(t)
+	stubSemgrep(t)
+
+	root := t.TempDir()
+	// A note and nothing else: no go.mod, no package.json, no AGENTS.md,
+	// no pytest.ini, no lockfile.
+	note := filepath.Join(root, "NOTES.txt")
+	if err := os.WriteFile(note, []byte("A note.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	code := RunWith([]string{note}, root, "docs: a note", &buf)
+	if code != 0 {
+		t.Errorf("a quiet repository commits, got exit %d:\n%s", code, buf.String())
+	}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "BLOCKING") {
+			t.Errorf("nothing here is not a finding: %s", line)
+		}
+	}
+}

--- a/internal/security/sast_test.go
+++ b/internal/security/sast_test.go
@@ -1,10 +1,14 @@
 package security
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 // stubSemgrep puts a fake semgrep on PATH that prints the given JSON. A
@@ -14,11 +18,23 @@ import (
 // that has not installed it, and the test job has not.
 func stubSemgrep(t *testing.T, out string) {
 	t.Helper()
+	stubSemgrepAfter(t, out, 0)
+}
+
+// stubSemgrepAfter is stubSemgrep with a deliberate delay before the
+// answer, for the tests that assert a slow check is still a completed
+// one.
+func stubSemgrepAfter(t *testing.T, out string, seconds int) {
+	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub is a POSIX shell script")
 	}
 	bin := t.TempDir()
-	script := "#!/bin/sh\ncat <<'JSON'\n" + out + "\nJSON\n"
+	sleep := ""
+	if seconds > 0 {
+		sleep = fmt.Sprintf("sleep %d\n", seconds)
+	}
+	script := "#!/bin/sh\n" + sleep + "cat <<'JSON'\n" + out + "\nJSON\n"
 	if err := os.WriteFile(filepath.Join(bin, "semgrep"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -137,5 +153,68 @@ func TestAFindingIsMatchedHoweverThePathArrived(t *testing.T) {
 	// Relative, as a person types them.
 	if got := SastChanged(root, []string{filepath.FromSlash("..foo/a.py")}); len(got) != 1 {
 		t.Errorf("relative path: the same file must match: %+v", got)
+	}
+}
+
+// A slow check still completes and still reports what it found. There is
+// no budget on the heavy legs: cutting one off partway and printing the
+// findings it happened to reach would make the verdict a fact about the
+// machine rather than about the code, and the fast machine and the slow
+// one would disagree about whether a commit is safe.
+//
+// The ceiling that does exist is a hung-process net, not a budget: when
+// it fires the finding says SAST was NOT run, and blocks. Silence is
+// never the answer.
+// proved by: wrapped the scan in a 1-second context and returned the
+// findings gathered so far — the slow run reports clean and the commit
+// lands with the finding still in the file.
+func TestASlowCheckStillCompletes(t *testing.T) {
+	stubSemgrepAfter(t, oneError, 2)
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "bad.py"), []byte("x = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	got := SastChanged(root, []string{filepath.Join(root, "bad.py")})
+	waited := time.Since(start)
+
+	if len(got) != 1 {
+		t.Fatalf("a slow scanner's findings are still the answer: %v", got)
+	}
+	if !strings.Contains(got[0].Message, "shell=True") {
+		t.Errorf("the finding must survive the wait intact: %q", got[0].Message)
+	}
+	// The gate waited rather than reporting a verdict it had not reached.
+	if waited < 2*time.Second {
+		t.Errorf("the gate returned before the check answered, in %s", waited)
+	}
+}
+
+// The same commit produces the same findings however fast the machine
+// is. This is the property a budget would take away, and it is asserted
+// by comparing two runs that differ only in how long the scanner took.
+// proved by: gave the scan a 1-second ceiling that returns what it has —
+// the two runs disagree, and which one a developer gets depends on their
+// laptop.
+func TestFastAndSlowRunsAgree(t *testing.T) {
+	scan := func(seconds int) []string {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "bad.py"), []byte("x = 1\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		stubSemgrepAfter(t, oneError, seconds)
+		var out []string
+		for _, f := range SastChanged(root, []string{filepath.Join(root, "bad.py")}) {
+			out = append(out, fmt.Sprintf("%v|%s", f.Blocking, f.Message))
+		}
+		return out
+	}
+	fast, slow := scan(0), scan(2)
+	if len(fast) == 0 {
+		t.Fatal("the fixture must produce a finding, or the comparison proves nothing")
+	}
+	if !reflect.DeepEqual(fast, slow) {
+		t.Errorf("the verdict must not depend on the machine:\n fast: %v\n slow: %v", fast, slow)
 	}
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -21,6 +21,7 @@ import (
 	"procoder/internal/codeindex"
 	"procoder/internal/gitx"
 	"procoder/internal/lessons"
+	"procoder/internal/testrun"
 	"procoder/internal/todo"
 )
 
@@ -58,6 +59,9 @@ func Report(root string) []string {
 	// the file-backed lines are computed while git runs: they read small
 	// local files, and doing them here keeps the total inside the budget
 	project := append(sprintLines(root), taskLine(root), lessonLine(root))
+	if d := deferredLine(root); d != "" {
+		project = append(project, d)
+	}
 
 	var lines []string
 	head, timedOut := "", false
@@ -353,4 +357,20 @@ func indexLine(root, head string, timedOut bool) string {
 		return base + " — current"
 	}
 	return base + " — STALE, HEAD is " + head + "; run `procoder index build`"
+}
+
+// deferredLine names the suites the commit gate will not run here, and
+// says nothing when there are none — a line on every session in a
+// single-language repository is noise the reader learns to skip.
+//
+// The gate narrows only the runners that take a target list; the rest are
+// CI's. Without this line that trade is invisible: a JavaScript commit
+// passes the gate having never run its suite, and a green gate reads as a
+// suite that passed.
+func deferredLine(root string) string {
+	d := testrun.Deferred(root)
+	if len(d) == 0 {
+		return ""
+	}
+	return "gate defers to CI: " + strings.Join(d, ", ") + " suite(s) — the gate narrows only go and pytest"
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -372,5 +372,6 @@ func deferredLine(root string) string {
 	if len(d) == 0 {
 		return ""
 	}
-	return "gate defers to CI: " + strings.Join(d, ", ") + " suite(s) — the gate narrows only go and pytest"
+	return "gate defers to CI: " + strings.Join(d, ", ") + " suite(s) — the gate runs " +
+		strings.Join(testrun.Narrowed(), ", ")
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -209,3 +209,30 @@ func TestRunPrintsTheHeaderAndExitsZero(t *testing.T) {
 		t.Fatalf("the report must open with %q, got %v", Header, got)
 	}
 }
+
+// The report names what the gate will not run, and stays silent when
+// there is nothing to name.
+// proved by: returned the line unconditionally — every single-language
+// repository gets "gate defers to CI: " on every session, naming nothing.
+func TestTheReportNamesWhatTheGateDefers(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := deferredLine(root); got != "" {
+		t.Errorf("nothing deferred, nothing said: %q", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "package.json"),
+		[]byte(`{"scripts":{"test":"vitest run"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := deferredLine(root)
+	if !strings.Contains(got, "js") {
+		t.Errorf("the deferred suite must be named: %q", got)
+	}
+	// Named AND explained: "js" alone reads as a suite that failed.
+	if !strings.Contains(got, "CI") {
+		t.Errorf("the line must say who runs it instead: %q", got)
+	}
+}

--- a/internal/testrun/gate.go
+++ b/internal/testrun/gate.go
@@ -210,3 +210,33 @@ var manifests = map[string]string{
 // which runner each belongs to. Run narrows only the Go package list and
 // the pytest targets; every other runner ignores the list.
 var pathScoped = map[string]string{".go": "go", ".py": "python", ".pyi": "python"}
+
+// Deferred names the suites this repository has that the commit gate will
+// not run, in reading order. Empty when there are none.
+//
+// The gate narrows only the runners that accept a target list, so every
+// other suite is CI's. That is a defensible trade and a silent one: a
+// reader watching a JavaScript commit pass the gate has no way to know
+// its suite never ran. This is what `procoder status` says out loud so
+// the silence is not mistaken for a pass.
+//
+// Detection is stats and one small file read, because the report that
+// calls this runs at session start under a hard budget.
+func Deferred(root string) []string {
+	var out []string
+	if exists(root, "Cargo.toml") {
+		out = append(out, "rust")
+	}
+	// A package.json with no test script has no suite to defer. Saying
+	// "js" there would invent a check that does not exist.
+	if testScript(root) != "" {
+		out = append(out, "js")
+	}
+	if exists(root, "build.gradle") || exists(root, "build.gradle.kts") || exists(root, "pom.xml") {
+		out = append(out, "java")
+	}
+	if phpunitDetected(root) {
+		out = append(out, "php")
+	}
+	return out
+}

--- a/internal/testrun/gate.go
+++ b/internal/testrun/gate.go
@@ -3,6 +3,7 @@ package testrun
 import (
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	"procoder/internal/gitx"
@@ -238,5 +239,23 @@ func Deferred(root string) []string {
 	if phpunitDetected(root) {
 		out = append(out, "php")
 	}
+	return out
+}
+
+// Narrowed names the ecosystems the gate can run, derived from the table
+// that decides it rather than restated beside it. The report says which
+// suites it defers and which it does not, and a hand-written list there
+// would keep saying "go and pytest" the day a third runner learns to
+// take a target list.
+func Narrowed() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, eco := range pathScoped {
+		if !seen[eco] {
+			seen[eco] = true
+			out = append(out, eco)
+		}
+	}
+	sort.Strings(out)
 	return out
 }

--- a/internal/testrun/gate_test.go
+++ b/internal/testrun/gate_test.go
@@ -228,3 +228,24 @@ func TestTheGateNamesTheSuitesItLeavesToCI(t *testing.T) {
 		t.Errorf("both suites the gate cannot narrow, in reading order: %v", got)
 	}
 }
+
+// The list of what the gate runs is derived from the table that decides
+// it. Restating it in the report's sentence is how a message keeps saying
+// "go and pytest" the day a third runner learns to take a target list —
+// and a status line that is confidently wrong is worse than none.
+// proved by: returned a fixed []string{"go", "python"} — adding a runner
+// to pathScoped leaves the report naming the old pair.
+func TestWhatTheGateRunsIsDerivedNotRestated(t *testing.T) {
+	got := Narrowed()
+	if len(got) != 2 || got[0] != "go" || got[1] != "python" {
+		t.Fatalf("the ecosystems pathScoped names, deduplicated and sorted: %v", got)
+	}
+
+	// The real assertion: it tracks the table. .pyi and .py both say
+	// python and must not produce it twice, and a new entry must appear.
+	pathScoped[".zig"] = "zig"
+	defer delete(pathScoped, ".zig")
+	if got := Narrowed(); len(got) != 3 || got[2] != "zig" {
+		t.Errorf("a new path-scoped runner must reach the report: %v", got)
+	}
+}

--- a/internal/testrun/gate_test.go
+++ b/internal/testrun/gate_test.go
@@ -1,6 +1,7 @@
 package testrun
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -187,5 +188,43 @@ func TestADependencyBumpRunsTheSuiteItCouldBreak(t *testing.T) {
 	// has already decided CI owns.
 	if _, run := changedPackages(root, []string{filepath.Join(root, "package.json")}); run {
 		t.Error("a package.json bump is CI's, not the gate's")
+	}
+}
+
+// The gate runs only the suites it can narrow, and every other one is
+// CI's. That trade is invisible from a green gate — a JavaScript commit
+// passes having never run its suite — so the deferral has to be
+// nameable. Silence when there is nothing to name: a line on every
+// session in a single-language repository is noise.
+// proved by: returned every detected ecosystem rather than the deferred
+// ones — a Go repository is told its Go suite was deferred to CI on
+// every commit, which is the opposite of true.
+func TestTheGateNamesTheSuitesItLeavesToCI(t *testing.T) {
+	root := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A Go repository defers nothing: the gate runs what it narrows.
+	write("go.mod", "module x\n")
+	if d := Deferred(root); len(d) != 0 {
+		t.Errorf("a Go repository has nothing deferred: %v", d)
+	}
+
+	// A package.json with no test script is not a deferred suite — it is
+	// no suite. Naming it would invent a check that does not exist.
+	write("package.json", `{"name":"x"}`)
+	if d := Deferred(root); len(d) != 0 {
+		t.Errorf("no test script is no suite, not a deferred one: %v", d)
+	}
+
+	write("package.json", `{"scripts":{"test":"vitest run"}}`)
+	write("Cargo.toml", "[package]\nname=\"x\"\n")
+	got := Deferred(root)
+	if len(got) != 2 || got[0] != "rust" || got[1] != "js" {
+		t.Errorf("both suites the gate cannot narrow, in reading order: %v", got)
 	}
 }


### PR DESCRIPTION
## What

`procoder status` now names the suites the commit gate will not run here, and says nothing when there are none.

```
gate defers to CI: rust, js suite(s) — the gate narrows only go and pytest
```

## Why

The gate narrows to the runners that accept a target list. Every other suite is CI's — defensible, and until now invisible: a JavaScript commit passes a green gate having never run its suite, and a green gate reads as a suite that passed.

The list comes from `testrun.Deferred`, which owns the knowledge of which runners can be narrowed. A second copy in the report would drift the next time a runner is added.

## Notes

- Silent in a single-language repo — a line on every session is noise the reader learns to skip.
- A `package.json` with no test script is *no* suite, not a deferred one, and is not named.
- Detection is stats plus one small file read: the report runs at session start under a 3s budget.

Closes the last story of sprint 011.