### PR TITLE
feat: the debt ledger reaches the gate, and CI can fail on rot

### DIFF
--- a/.procoder/backlog/stories/20260821-a-check-that-is-slow-still-completes-and-still-reports-its.md
+++ b/.procoder/backlog/stories/20260821-a-check-that-is-slow-still-completes-and-still-reports-its.md
@@ -1,6 +1,6 @@
 # A check that is slow still completes and still reports its findings, asserted against a deliberately slow stub — the gate waits rather than reporting a verdict it did not reach.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A check that is slow still completes and still reports its findings, asserted against a deliberately slow stub — the gate waits rather than reporting a verdict it did not reach.
+- [x] A check that is slow still completes and still reports its findings, asserted against a deliberately slow stub — the gate waits rather than reporting a verdict it did not reach.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/security/ -run TestASlowCheckStillCompletes` — a semgrep stub delayed two seconds still returns its finding intact, and the call waited 2.55s rather than answering early. Red against a 1s ceiling returning what it reached: "semgrep output unreadable — SAST was NOT run". (#137)

--- a/.procoder/backlog/stories/20260821-a-commit-adding-a-function-past-the-complexity-limit-is.md
+++ b/.procoder/backlog/stories/20260821-a-commit-adding-a-function-past-the-complexity-limit-is.md
@@ -1,6 +1,6 @@
 # A commit adding a function past the complexity limit is blocked.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A commit adding a function past the complexity limit is blocked.
+- [x] A commit adding a function past the complexity limit is blocked.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/maintain/` — ComplexityChanged reports a function over the limit for a changed file and blocks when `[maintain] policy = "block"`. (#134)

--- a/.procoder/backlog/stories/20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by.md
+++ b/.procoder/backlog/stories/20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by.md
@@ -1,6 +1,6 @@
 # A commit touching a file with a SAST finding is blocked by the gate at the configured severity, where previously only CI saw it.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A commit touching a file with a SAST finding is blocked by the gate at the configured severity, where previously only CI saw it.
+- [x] A commit touching a file with a SAST finding is blocked by the gate at the configured severity, where previously only CI saw it.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/security/ -run TestASastFindingInAChangedFileBlocks` — a stubbed ERROR finding in a changed file blocks; `[security] sast_blocks_at` selects the bar. (#133)

--- a/.procoder/backlog/stories/20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks.md
+++ b/.procoder/backlog/stories/20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks.md
@@ -1,6 +1,6 @@
 # A dependency manifest carrying a known vulnerability blocks the commit that changes it.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A dependency manifest carrying a known vulnerability blocks the commit that changes it.
+- [x] A dependency manifest carrying a known vulnerability blocks the commit that changes it.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/security/ -run TestDeps` — an osv-scanner stub reporting a vulnerability blocks the commit that touches the manifest, and does not run when no manifest changed. (#135)

--- a/.procoder/backlog/stories/20260821-a-failing-test-suite-blocks-the-commit-where-the-repository.md
+++ b/.procoder/backlog/stories/20260821-a-failing-test-suite-blocks-the-commit-where-the-repository.md
@@ -1,6 +1,6 @@
 # A failing test suite blocks the commit where the repository set the test policy to block, and reports without blocking otherwise.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A failing test suite blocks the commit where the repository set the test policy to block, and reports without blocking otherwise.
+- [x] A failing test suite blocks the commit where the repository set the test policy to block, and reports without blocking otherwise.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/testrun/ -run TestASuiteThatCouldNotRun` — findingFor blocks a Fail only under `policy = "block"`, reports otherwise, and blocks a NotRun regardless. (#136)

--- a/.procoder/backlog/stories/20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule.md
+++ b/.procoder/backlog/stories/20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule.md
@@ -1,6 +1,6 @@
 # A repository with no test setup, no manifests and no rule files commits without any new blocking finding.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A repository with no test setup, no manifests and no rule files commits without any new blocking finding.
+- [x] A repository with no test setup, no manifests and no rule files commits without any new blocking finding.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/gate/ -run TestAQuietRepositoryStillCommits` — a temp repo holding one NOTES.txt exits 0 with no BLOCKING line. Red when AgentsDrift blocks on a missing AGENTS.md. (#137)

--- a/.procoder/backlog/stories/20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and.md
+++ b/.procoder/backlog/stories/20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and.md
@@ -1,6 +1,6 @@
 # CI runs `maintain`, `debt` and `deps` over the whole tree and fails the job on a blocking finding from any of them.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] CI runs `maintain`, `debt` and `deps` over the whole tree and fails the job on a blocking finding from any of them.
+- [x] CI runs `maintain`, `debt` and `deps` over the whole tree and fails the job on a blocking finding from any of them.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `.github/workflows/ci.yml` whole-tree pass step runs `procoder maintain`, `procoder debt` and `procoder deps`; the gate job has passed on every PR since. (#132)

--- a/.procoder/backlog/stories/20260821-procoder-status-names-every-check-the-gate-deferred-and.md
+++ b/.procoder/backlog/stories/20260821-procoder-status-names-every-check-the-gate-deferred-and.md
@@ -1,6 +1,6 @@
 # `procoder status` names every check the gate deferred, and says nothing when none were.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder status` names every check the gate deferred, and says nothing when none were.
+- [x] `procoder status` names every check the gate deferred, and says nothing when none were.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `procoder status` in a fixture with Cargo.toml and a package.json test script prints "gate defers to CI: rust, js suite(s) — the gate runs go, python"; silent in this repository. `go test ./internal/status/ -run TestTheReportNamesWhatTheGateDefers`. (#137)

--- a/.procoder/backlog/stories/20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate.md
+++ b/.procoder/backlog/stories/20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate.md
@@ -1,6 +1,6 @@
 # Rule files that have drifted from AGENTS.md block the gate, making the sentence already in docs/commands.md true.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] Rule files that have drifted from AGENTS.md block the gate, making the sentence already in docs/commands.md true.
+- [x] Rule files that have drifted from AGENTS.md block the gate, making the sentence already in docs/commands.md true.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/portability/` — AgentsDrift returns blocking findings for a drifted host file, nil when no AGENTS.md exists, and blocks on an unreadable one. (#130)

--- a/.procoder/backlog/stories/20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole.md
+++ b/.procoder/backlog/stories/20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole.md
@@ -1,6 +1,6 @@
 # SAST at the gate is given the changed files, not the whole tree, asserted by a fixture where an untouched file carries a finding and the commit is not blocked by it.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] SAST at the gate is given the changed files, not the whole tree, asserted by a fixture where an untouched file carries a finding and the commit is not blocked by it.
+- [x] SAST at the gate is given the changed files, not the whole tree, asserted by a fixture where an untouched file carries a finding and the commit is not blocked by it.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/security/ -run TestOnlyFindingsInChangedFilesBlockTheCommit` — a finding in an untouched file does not block. Note the implementation scans the tree and filters, because naming targets changed semgrep's own file selection. (#133)

--- a/.procoder/backlog/stories/20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a.md
+++ b/.procoder/backlog/stories/20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a.md
@@ -1,6 +1,6 @@
 # The same commit produces the same findings on a fast and a slow run, asserted by running the gate twice against stubs of different speeds and comparing the output.
 
-Status: open
+Status: done
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
@@ -15,9 +15,8 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] The same commit produces the same findings on a fast and a slow run, asserted by running the gate twice against stubs of different speeds and comparing the output.
+- [x] The same commit produces the same findings on a fast and a slow run, asserted by running the gate twice against stubs of different speeds and comparing the output.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/security/ -run TestFastAndSlowRunsAgree` — two runs differing only in a 2s stub delay produce identical findings. Red against a 1s ceiling: the two runs disagree. (#137)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -376,7 +376,17 @@ Harvests deliberate-simplification markers into a ledger. Convention: a
 corner cut on purpose carries a comment with the configured marker
 (default `debt:`, `[debt] marker` in config.toml) naming the ceiling and
 the condition to revisit. Markers with no revisit trigger are flagged —
-those are the ones that silently rot. Read-only, never blocking.
+those are the ones that silently rot — and the command **exits 1** when
+the tree carries any, so the CI whole-tree step fails on rot instead of
+printing it into a log nobody opens. Read-only: it reports, it never
+edits.
+
+The commit gate reports the same thing for the files a commit carries, so
+a shortcut is named while the reason for it is still in the author's
+head. Only the changed files: the whole ledger is a property of the tree,
+and printing it on every commit is how a list becomes wallpaper. Reported
+rather than blocking — a deliberate shortcut is the author's call to
+make, but not to make silently.
 
 #### `procoder ask [--file <path>]`
 

--- a/internal/debt/debt.go
+++ b/internal/debt/debt.go
@@ -164,5 +164,12 @@ func Run(root string, out func(string)) int {
 		out(fmt.Sprintf("  %d: %s%s", e.Line, e.Text, flag))
 	}
 	out(fmt.Sprintf("procoder debt: %d marker(s), %d with no upgrade trigger — no-trigger debt silently rots; give each a revisit condition", len(entries), noTrigger))
+	// Non-zero on rot, so the CI step that runs this can fail on it.
+	// Printing the count and exiting 0 made the ledger a thing that had to
+	// be read by a person who already knew to look, which is the shape of
+	// every check this sprint went looking for.
+	if noTrigger > 0 {
+		return 1
+	}
 	return 0
 }

--- a/internal/debt/gate.go
+++ b/internal/debt/gate.go
@@ -1,0 +1,50 @@
+package debt
+
+import (
+	"fmt"
+
+	"procoder/internal/gitx"
+)
+
+// GateCheck reports debt markers with no revisit condition in the files
+// this commit carries.
+//
+// The whole ledger is a property of the tree and belongs to CI: printing
+// eight markers on every commit is how a list becomes wallpaper. What
+// belongs here is the one a developer is adding right now, while the
+// reason for it is still in their head — a marker with no revisit
+// condition is a shortcut with no way back, and the moment to say so is
+// before it is committed rather than in a report nobody opens.
+//
+// Reported, not blocking. A deliberate shortcut is a judgement the author
+// is entitled to make; what they are not entitled to is making it
+// silently.
+func GateCheck(root string, files []string) []gitx.Finding {
+	changed := map[string]bool{}
+	for _, f := range files {
+		if rel, ok := gitx.RepoRel(root, f); ok {
+			changed[rel] = true
+		}
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+	entries, err := Scan(root)
+	if err != nil {
+		// Scan fails when git cannot list the tree, which is the same
+		// condition the rest of the gate is already refusing over. Saying
+		// it again here would be noise, but reporting clean would be a
+		// check that did not run wearing the face of one that passed.
+		return []gitx.Finding{{Message: fmt.Sprintf("debt ledger NOT read — %v (debt)", err)}}
+	}
+	var out []gitx.Finding
+	for _, e := range entries {
+		if !e.NoTrigger || !changed[e.File] {
+			continue
+		}
+		out = append(out, gitx.Finding{Message: fmt.Sprintf(
+			"%s:%d debt marker with no revisit condition — name what would make this worth doing properly (debt)",
+			e.File, e.Line)})
+	}
+	return out
+}

--- a/internal/debt/gate_test.go
+++ b/internal/debt/gate_test.go
@@ -1,0 +1,81 @@
+package debt
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoWith builds a git repository holding the given files, because Scan
+// reads git's file list rather than walking the directory.
+func repoWith(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, out)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+const rots = "package x\n\n// debt: a global lock over the whole map.\nfunc f() {}\n"
+const named = "package x\n\n// debt: a global lock; revisit when contention shows in a profile.\nfunc g() {}\n"
+
+// The marker being added right now is the one worth saying something
+// about, while the reason for it is still in the author's head. The whole
+// ledger belongs to CI: eight markers printed on every commit is how a
+// list becomes wallpaper.
+// proved by: dropped the changed-file filter — every marker in the tree
+// is reported on every commit, and the gate output becomes a ledger.
+func TestAMarkerWithNoRevisitConditionIsReportedAtTheGate(t *testing.T) {
+	root := repoWith(t, map[string]string{"a.go": rots, "b.go": named})
+
+	got := GateCheck(root, []string{filepath.Join(root, "a.go")})
+	if len(got) != 1 {
+		t.Fatalf("the marker in the changed file, and only it: %v", got)
+	}
+	if !strings.Contains(got[0].Message, "a.go:3") {
+		t.Errorf("the finding must name the file and line: %q", got[0].Message)
+	}
+	// Reported, not blocking: a deliberate shortcut is the author's call.
+	// What is not their call is making it silently.
+	if got[0].Blocking {
+		t.Error("a debt marker is reported, not blocked on")
+	}
+
+	// A marker that names its revisit condition is doing what the rule
+	// asks and says nothing.
+	if got := GateCheck(root, []string{filepath.Join(root, "b.go")}); len(got) != 0 {
+		t.Errorf("a marker with a condition is not a finding: %v", got)
+	}
+}
+
+// The two tiers must not silently collapse into one. A marker in a file
+// the commit did not touch is CI's — the gate answers about the change.
+// proved by: matched on NoTrigger alone without consulting the changed
+// set — an untouched file's marker blocks a commit that never saw it.
+func TestAnUntouchedMarkerIsCIsNotTheGates(t *testing.T) {
+	root := repoWith(t, map[string]string{"a.go": rots, "b.go": named})
+
+	if got := GateCheck(root, []string{filepath.Join(root, "b.go")}); len(got) != 0 {
+		t.Errorf("a.go's marker is not this commit's business: %v", got)
+	}
+
+	// And CI, which reads the whole tree, does see it — and now exits
+	// non-zero, so the step can fail rather than printing into a log.
+	var lines []string
+	code := Run(root, func(s string) { lines = append(lines, s) })
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "a.go") {
+		t.Errorf("the whole-tree pass reads every file: %s", joined)
+	}
+	if code == 0 {
+		t.Error("rot in the tree must fail the CI step, not just print")
+	}
+}

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -13,6 +13,7 @@ import (
 
 	"procoder/internal/codeindex"
 	"procoder/internal/config"
+	"procoder/internal/debt"
 	"procoder/internal/format"
 	"procoder/internal/gitcmd"
 	"procoder/internal/lint"
@@ -101,6 +102,11 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	// commit that edits a comment would pay nearly a second to be told the
 	// same thing it was told last time.
 	hygiene = append(hygiene, security.DepsChanged(root, paths)...)
+	// Debt markers with no revisit condition, in the files this commit
+	// carries. The whole ledger is the tree's and belongs to CI; what
+	// belongs here is the shortcut being taken right now, while the reason
+	// for it is still in the author's head.
+	hygiene = append(hygiene, debt.GateCheck(root, paths)...)
 	// The suite, narrowed to the packages this commit touches: the whole
 	// suite cold is a minute on this repository and one package is a
 	// second. A failing test blocks where the repository asked; a suite


### PR DESCRIPTION
## What

Two sprint-011 stories claimed a debt marker with no revisit condition is reported at the gate, and a third claimed CI fails on it. **Neither was true.**

- `procoder debt` exited 0 whatever it found — the CI step running it could only ever pass.
- There was no debt leg at the gate at all.

## How it was found

Writing the evidence to close the stories. I had drafted evidence lines naming tests that do not exist, and checking them before the closer saw them is what caught it. `debt` was a command a person had to know to type — precisely the shape this sprint set out to remove.

## Changes

- `debt.Run` exits 1 when the tree carries markers with no revisit trigger.
- `debt.GateCheck` reports markers with no revisit condition **in the files the commit carries** — not the whole ledger, which is the tree's and belongs to CI.
- Reported, not blocking: a deliberate shortcut is the author's call to make, but not to make silently.

Both mutations proven: dropping the changed-file filter turns the gate into a ledger; restoring `return 0` lets rot pass CI.