### PR TITLE
backlog: sprint 011 closes, thirteen of thirteen

### DIFF
--- a/.procoder/backlog/epics/checks-that-run-themselves.md
+++ b/.procoder/backlog/epics/checks-that-run-themselves.md
@@ -1,6 +1,6 @@
 # checks-that-run-themselves
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Spec: checks-that-run-themselves @ b903540aae01
 

--- a/.procoder/backlog/sprints/009-no-silent-green-every-gate-says-when-it-did-not-run.md
+++ b/.procoder/backlog/sprints/009-no-silent-green-every-gate-says-when-it-did-not-run.md
@@ -64,4 +64,3 @@ committed: 11
 done: 11 (20260821-a-c-file-in-a-repository-with-no-clang-format-is-formatted, 20260821-a-c-file-reaches-clang-tidy-and-a-real-finding-is-reported, 20260821-a-file-type-procoder-does-not-claim-is-still-out-of-scope, 20260821-a-language-procoder-formats-but-cannot-lint-reports-not, 20260821-a-php-file-with-no-prettier-plugin-is-unchecked-with-the, 20260821-a-repository-carrying-its-own-clang-format-is-formatted-by, 20260821-a-ts-file-in-a-repository-with-no-eslint-config-is-linted, 20260821-mts-and-cts-files-reach-the-same-linter-as-ts-and-pyi, 20260821-no-domain-anywhere-in-the-tree-reports-a-check-that-did-not, 20260821-procoder-doctor-lists-every-new-default-tool-with-its, 20260821-with-no-linter-installed-procoder-check-over-a-file-of-that)
 carried: 0
 
-## Retro

--- a/.procoder/backlog/sprints/011-checks-that-run-themselves-the-gate-for-the-change-ci-for.md
+++ b/.procoder/backlog/sprints/011-checks-that-run-themselves-the-gate-for-the-change-ci-for.md
@@ -32,22 +32,33 @@ Done means a green gate covers what a reader would assume it covers, and
 
 ## Retro
 
-<!-- What slowed us down this sprint. -->
+**What slowed us down.** Three of thirteen stories had no test and two
+had no feature, and none of that was found by the gate, by CI, or by
+review. It was found by writing the close-out evidence — drafting a line
+that named a test, then checking whether the test existed. It did not.
+Nor did the feature: `procoder debt` returned 0 whatever it found, so the
+CI step running it could only ever pass, and there was no debt leg at the
+gate at all. The sprint about checks that run themselves nearly shipped
+a check that ran and reported nothing.
 
-<!-- What we change next sprint because of it. -->
+The three missing tests were worse in kind. All three were the
+assertions behind the rule the sprint turned on — the heavy checks get no
+budget. The rule was stated, argued for, and built to; it was never
+asserted. A rule with no test is a rule until somebody is in a hurry.
 
-<!-- One adaptation from this sprint worth keeping. -->
+**What we change.** Evidence is written before the story is called done,
+not after, and every test it names is run at the moment it is named. A
+close-out is not paperwork over finished work — this sprint it was the
+only check that caught anything, and it caught five things.
+
+**Worth keeping.** Asserting the match before editing. Every mutation and
+every scripted edit went through a guard that fails when the text it
+expects is not there. It fired twice: once on a doc edit that silently
+had not applied, and once on a mutation that would have printed `ok` from
+a run where nothing was mutated. Both would have been reported as proof.
 
 ## Result
 
 committed: 13
 done: 13 (20260821-a-check-that-is-slow-still-completes-and-still-reports-its, 20260821-a-commit-adding-a-function-past-the-complexity-limit-is, 20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by, 20260821-a-debt-marker-with-no-revisit-condition-in-a-file-the, 20260821-a-debt-marker-with-no-revisit-condition-is-reported-at-the, 20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks, 20260821-a-failing-test-suite-blocks-the-commit-where-the-repository, 20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule, 20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and, 20260821-procoder-status-names-every-check-the-gate-deferred-and, 20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate, 20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole, 20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a)
 carried: 0
-
-## Retro
-
-<!-- What slowed us down this sprint. -->
-
-<!-- What we change next sprint because of it. -->
-
-<!-- One adaptation from this sprint worth keeping. -->

--- a/.procoder/backlog/sprints/011-checks-that-run-themselves-the-gate-for-the-change-ci-for.md
+++ b/.procoder/backlog/sprints/011-checks-that-run-themselves-the-gate-for-the-change-ci-for.md
@@ -1,6 +1,6 @@
 # Checks that run themselves: the gate for the change, CI for the tree
 
-Status: active
+Status: closed 2026-08-21
 Created: 2026-08-21
 
 ## Goal
@@ -29,6 +29,20 @@ Done means a green gate covers what a reader would assume it covers, and
 ## Stories
 
 <!-- pulled below -->
+
+## Retro
+
+<!-- What slowed us down this sprint. -->
+
+<!-- What we change next sprint because of it. -->
+
+<!-- One adaptation from this sprint worth keeping. -->
+
+## Result
+
+committed: 13
+done: 13 (20260821-a-check-that-is-slow-still-completes-and-still-reports-its, 20260821-a-commit-adding-a-function-past-the-complexity-limit-is, 20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by, 20260821-a-debt-marker-with-no-revisit-condition-in-a-file-the, 20260821-a-debt-marker-with-no-revisit-condition-is-reported-at-the, 20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks, 20260821-a-failing-test-suite-blocks-the-commit-where-the-repository, 20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule, 20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and, 20260821-procoder-status-names-every-check-the-gate-deferred-and, 20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate, 20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole, 20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a)
+carried: 0
 
 ## Retro
 

--- a/.procoder/backlog/stories/20260821-a-check-that-is-slow-still-completes-and-still-reports-its.md
+++ b/.procoder/backlog/stories/20260821-a-check-that-is-slow-still-completes-and-still-reports-its.md
@@ -1,14 +1,26 @@
 # A check that is slow still completes and still reports its findings, asserted against a deliberately slow stub — the gate waits rather than reporting a verdict it did not reach.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A developer on a slow laptop and a developer on a fast one must get the
+same answer about the same commit. A check cut off partway and reported
+anyway turns the verdict into a fact about the machine, and the first
+time someone's commit passes on their machine and fails on a colleague's,
+they stop believing any of it.
+
+So the heavy legs get no budget. Done means a check that takes seconds
+still finishes and still reports what it found, asserted against a stub
+that is deliberately slow rather than against a real tool that might be
+fast on the test runner.
+
+The ceiling that exists is a hung-process net, not a budget: when it
+fires it says the check was NOT run and blocks. Waiting forever and
+passing silently are both worse than saying so.
 
 ## Acceptance criteria
 

--- a/.procoder/backlog/stories/20260821-a-commit-adding-a-function-past-the-complexity-limit-is.md
+++ b/.procoder/backlog/stories/20260821-a-commit-adding-a-function-past-the-complexity-limit-is.md
@@ -1,14 +1,21 @@
 # A commit adding a function past the complexity limit is blocked.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+Complexity was a thing `procoder maintain` would tell you about if you
+thought to ask. Nobody asks. The function that needs splitting is easiest
+to split while it is being written, and hardest six months later when it
+is the one everybody is afraid of.
+
+Done means the commit that adds it says so. Reported by default rather
+than blocking, because a threshold that blocks by surprise stops work on
+exactly the files that need the refactor; blocking when the repository
+sets `[maintain] policy = "block"`.
 
 ## Acceptance criteria
 
@@ -19,4 +26,4 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Evidence
 
-- `go test ./internal/maintain/` — ComplexityChanged reports a function over the limit for a changed file and blocks when `[maintain] policy = "block"`. (#134)
+- `go test ./internal/maintain/ -run TestComplexityIsReportedAtTheGateAndBlocksOnlyOnRequest` — ComplexityChanged reports a function over the limit in a changed file, and blocks when `[maintain] policy = "block"`. (#134)

--- a/.procoder/backlog/stories/20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by.md
+++ b/.procoder/backlog/stories/20260821-a-commit-touching-a-file-with-a-sast-finding-is-blocked-by.md
@@ -1,14 +1,19 @@
 # A commit touching a file with a SAST finding is blocked by the gate at the configured severity, where previously only CI saw it.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A security finding caught in CI is caught after the code has left the
+machine, been pushed, and started a review. Caught at the commit it is
+still a thought the author is having.
+
+Done means a commit touching a file with a finding at or above the
+configured severity is blocked, where previously only CI saw it. The
+severity bar is the repository's to set — `[security] sast_blocks_at`.
 
 ## Acceptance criteria
 

--- a/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-in-a-file-the.md
+++ b/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-in-a-file-the.md
@@ -1,23 +1,30 @@
 # A debt marker with no revisit condition, in a file the commit did not touch, is caught by CI and not by the gate — asserted so the two tiers cannot silently collapse into one.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The two tiers answer different questions — the gate about the change, CI
+about the tree — and the failure mode is that they quietly become one.
+Either the gate grows into a whole-tree scan that reports the same eight
+markers on every commit until people learn to skip the output, or CI
+narrows to the change and stops catching what nobody has touched in a
+year.
+
+Done means the split is asserted rather than assumed: a marker in a file
+the commit did not touch produces nothing at the gate, and is caught by
+the whole-tree pass.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A debt marker with no revisit condition, in a file the commit did not touch, is caught by CI and not by the gate — asserted so the two tiers cannot silently collapse into one.
+- [x] A debt marker with no revisit condition, in a file the commit did not touch, is caught by CI and not by the gate — asserted so the two tiers cannot silently collapse into one.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/debt/ -run TestAnUntouchedMarkerIsCIsNotTheGates` — a marker in an untouched file produces no gate finding, while Run over the whole tree names it AND exits non-zero so the CI step fails. Red on both halves: matching NoTrigger without the changed set, and restoring the unconditional `return 0`. (#138)

--- a/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-is-reported-at-the.md
+++ b/.procoder/backlog/stories/20260821-a-debt-marker-with-no-revisit-condition-is-reported-at-the.md
@@ -1,23 +1,29 @@
 # A debt marker with no revisit condition is reported at the gate.
 
-Status: open
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+A `debt:` marker records a corner cut on purpose. The rule is that it
+names the condition to revisit — otherwise it is not recorded debt, it is
+a shortcut with no way back, and the ledger fills with entries nobody can
+act on.
+
+The moment to ask for that condition is while the author still knows why
+they cut the corner. Done means the gate says it for the files the commit
+carries. Reported rather than blocking: a deliberate shortcut is a
+judgement the author is entitled to make, but not to make silently.
 
 ## Acceptance criteria
 
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A debt marker with no revisit condition is reported at the gate.
+- [x] A debt marker with no revisit condition is reported at the gate.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/debt/ -run TestAMarkerWithNoRevisitConditionIsReportedAtTheGate` — a marker with no revisit condition in a changed file is reported with its file and line, non-blocking; one that names its condition says nothing. Red when the changed-file filter is dropped. (#138)

--- a/.procoder/backlog/stories/20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks.md
+++ b/.procoder/backlog/stories/20260821-a-dependency-manifest-carrying-a-known-vulnerability-blocks.md
@@ -1,14 +1,21 @@
 # A dependency manifest carrying a known vulnerability blocks the commit that changes it.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+Adding a dependency is the moment its vulnerabilities are cheapest to
+avoid — before anything is built on top of it. After that, removing it is
+a project.
+
+Done means a commit that changes a manifest is checked against known
+vulnerabilities and blocked by what it finds. Only when a manifest
+changes: running it on every commit would report the same advisories
+forever, at nearly a second each, which is how a check becomes something
+people route around.
 
 ## Acceptance criteria
 
@@ -19,4 +26,4 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Evidence
 
-- `go test ./internal/security/ -run TestDeps` — an osv-scanner stub reporting a vulnerability blocks the commit that touches the manifest, and does not run when no manifest changed. (#135)
+- `go test ./internal/security/ -run TestTheScanRunsWhenAManifestChanges` — an osv-scanner stub's finding blocks the commit that touches the manifest, and the scan does not run when no manifest changed. (#135)

--- a/.procoder/backlog/stories/20260821-a-failing-test-suite-blocks-the-commit-where-the-repository.md
+++ b/.procoder/backlog/stories/20260821-a-failing-test-suite-blocks-the-commit-where-the-repository.md
@@ -1,14 +1,19 @@
 # A failing test suite blocks the commit where the repository set the test policy to block, and reports without blocking otherwise.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+`[test] policy` has always governed whether a failing suite stops the
+close controllers. It should mean the same thing at the commit.
+
+Done means a failing suite blocks where the repository asked for block
+and reports otherwise — and a suite that could NOT run blocks either way,
+because the policy governs whether a FAILING test stops a commit and "no
+answer" is not a verdict it has an opinion about.
 
 ## Acceptance criteria
 

--- a/.procoder/backlog/stories/20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule.md
+++ b/.procoder/backlog/stories/20260821-a-repository-with-no-test-setup-no-manifests-and-no-rule.md
@@ -1,14 +1,21 @@
 # A repository with no test setup, no manifests and no rule files commits without any new blocking finding.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+This sprint gives the gate five new legs. Each has to decide what to say
+about a repository that has nothing for it to look at, and the wrong
+answer is easy to reach one leg at a time: each is individually defensible
+and together they make an empty repository unable to commit a text file.
+
+Done means a repository with no test setup, no manifests and no rule
+files commits with no new blocking finding — "nothing here" comes out
+silent. A machine missing the scanners still blocks, loudly and on
+purpose; that is a different question and has its own test.
 
 ## Acceptance criteria
 

--- a/.procoder/backlog/stories/20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and.md
+++ b/.procoder/backlog/stories/20260821-ci-runs-maintain-debt-and-deps-over-the-whole-tree-and.md
@@ -1,14 +1,21 @@
 # CI runs `maintain`, `debt` and `deps` over the whole tree and fails the job on a blocking finding from any of them.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+`maintain`, `debt` and `deps` answer about the tree, not the change:
+complexity across a codebase, the debt ledger, dependency freshness.
+Asking them of every commit would either repeat the same finding forever
+or rescan everything each time somebody edits a line.
+
+Until now they ran nowhere unless a person typed them, which meant they
+protected whoever already knew they existed. Done means CI runs all three
+over the whole tree and the job fails on what they find — a command that
+reports into a log nobody reads is not a check.
 
 ## Acceptance criteria
 
@@ -19,4 +26,4 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Evidence
 
-- `.github/workflows/ci.yml` whole-tree pass step runs `procoder maintain`, `procoder debt` and `procoder deps`; the gate job has passed on every PR since. (#132)
+- `.github/workflows/ci.yml` runs `procoder maintain`, `procoder debt` and `procoder deps` in the whole-tree pass. Exit codes verified by hand: maintain returns 1 when a check could NOT run, deps returns 1 when a tool errored, debt returns 1 on a marker with no revisit trigger (#138 — it returned 0 unconditionally before, so the step could only ever pass). (#132, #138)

--- a/.procoder/backlog/stories/20260821-procoder-status-names-every-check-the-gate-deferred-and.md
+++ b/.procoder/backlog/stories/20260821-procoder-status-names-every-check-the-gate-deferred-and.md
@@ -1,14 +1,22 @@
 # `procoder status` names every check the gate deferred, and says nothing when none were.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The gate narrows to the runners it can scope, so some suites are CI's.
+That is a reasonable trade and an invisible one: a JavaScript commit
+passes a green gate having never run its suite, and green reads as a
+suite that passed.
+
+Done means the state-of-play report names what the gate will not run
+here, and says nothing when there is nothing to name — a line on every
+session of a single-language repository is noise the reader learns to
+skip, and a reader who skips this line is the reader it was written
+for.
 
 ## Acceptance criteria
 

--- a/.procoder/backlog/stories/20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate.md
+++ b/.procoder/backlog/stories/20260821-rule-files-that-have-drifted-from-agents-md-block-the-gate.md
@@ -1,14 +1,20 @@
 # Rule files that have drifted from AGENTS.md block the gate, making the sentence already in docs/commands.md true.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+`docs/commands.md` already says the gate blocks on agent-rule drift. It
+did not. A stale rule file is another agent being told something this
+repository stopped believing, and the documentation promising otherwise
+is worse than silence.
+
+Done means the sentence is true: drifted host files block, a repository
+with no AGENTS.md is asked nothing, and a master that cannot be read
+blocks rather than passing as absent.
 
 ## Acceptance criteria
 
@@ -19,4 +25,4 @@ Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Evidence
 
-- `go test ./internal/portability/` — AgentsDrift returns blocking findings for a drifted host file, nil when no AGENTS.md exists, and blocks on an unreadable one. (#130)
+- `go test ./internal/portability/ -run TestDriftedRuleFilesBlock` — a drifted host file produces a blocking finding; TestMatchingFilesAndNoAgentLayerAreSilent covers the no-AGENTS.md case and TestAnUnreadableMasterIsNotAnAbsentAgentLayer the unreadable one. (#130)

--- a/.procoder/backlog/stories/20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole.md
+++ b/.procoder/backlog/stories/20260821-sast-at-the-gate-is-given-the-changed-files-not-the-whole.md
@@ -1,14 +1,21 @@
 # SAST at the gate is given the changed files, not the whole tree, asserted by a fixture where an untouched file carries a finding and the commit is not blocked by it.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+SAST at the gate must answer about the commit. A developer blocked by a
+finding in a file they have never opened cannot act on it, and learns
+that the way to commit is to turn the gate off.
+
+Done means an untouched file's finding does not block the commit,
+asserted by a fixture that carries one. Note the implementation scans the
+tree and filters the results: naming target files changes what semgrep
+itself chooses to scan, which produced findings the real tool never
+reports.
 
 ## Acceptance criteria
 

--- a/.procoder/backlog/stories/20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a.md
+++ b/.procoder/backlog/stories/20260821-the-same-commit-produces-the-same-findings-on-a-fast-and-a.md
@@ -1,14 +1,19 @@
 # The same commit produces the same findings on a fast and a slow run, asserted by running the gate twice against stubs of different speeds and comparing the output.
 
-Status: done
+Status: done 2026-08-21
 Created: 2026-08-21
 Epic: checks-that-run-themselves
 Sprint: 011-checks-that-run-themselves-the-gate-for-the-change-ci-for
 
 ## Description
 
-<!-- The user story: who needs what, and why. What "done" looks like in
-     the reader's terms — a title is not a description. -->
+The companion assertion to the no-budget rule, stated as the property a
+budget would take away: run the same commit twice, changing only how long
+the scanner takes, and compare.
+
+Done means the two outputs are identical, asserted by comparison rather
+than by inspection — a test that merely checks "some finding appeared" in
+both runs would pass against a budget that dropped half of them.
 
 ## Acceptance criteria
 

--- a/internal/backlog/items.go
+++ b/internal/backlog/items.go
@@ -34,7 +34,10 @@ const (
 )
 
 var (
-	statusRe    = regexp.MustCompile(`(?m)^Status:\s*(.+?)\s*$`)
+	statusRe = regexp.MustCompile(`(?m)^Status:\s*(.+?)\s*$`)
+	// The retro heading, so a close does not append a second one beneath
+	// the template's.
+	retroRe     = regexp.MustCompile(`(?m)^##\s+Retro\s*$`)
 	milestoneRe = regexp.MustCompile(`(?m)^Milestone:\s*(\S+)`)
 	epicRe      = regexp.MustCompile(`(?m)^Epic:\s*(\S+)`)
 	sprintRe    = regexp.MustCompile(`(?m)^Sprint:\s*(\S+)`)

--- a/internal/backlog/sprint.go
+++ b/internal/backlog/sprint.go
@@ -319,12 +319,18 @@ func SprintClose(root string, out func(string)) int {
 	text += "\n## Result\n\n" +
 		fmt.Sprintf("committed: %d\n", len(done)+len(carried)) +
 		"done: " + countWithIDs(done) + "\n" +
-		"carried: " + countWithIDs(carried) + "\n" +
-		// the retro scaffold: filling it is the price of the next sprint
-		"\n## Retro\n\n" +
-		"<!-- What slowed us down this sprint. -->\n\n" +
-		"<!-- What we change next sprint because of it. -->\n\n" +
-		"<!-- One adaptation from this sprint worth keeping. -->\n"
+		"carried: " + countWithIDs(carried) + "\n"
+	// The retro scaffold, only where the template did not already supply
+	// one. Appending it unconditionally gave every sprint two ## Retro
+	// headings — and if the person had already written their retro in the
+	// first, the empty second one sat underneath it, so the next sprint's
+	// check could read either.
+	if !retroRe.MatchString(text) {
+		text += "\n## Retro\n\n" +
+			"<!-- What slowed us down this sprint. -->\n\n" +
+			"<!-- What we change next sprint because of it. -->\n\n" +
+			"<!-- One adaptation from this sprint worth keeping. -->\n"
+	}
 	if err := os.WriteFile(active.Path, []byte(text), 0o644); err != nil {
 		out("cannot update the sprint file: " + err.Error())
 		return 2

--- a/internal/backlog/sprint_test.go
+++ b/internal/backlog/sprint_test.go
@@ -362,3 +362,37 @@ func TestSprintOpenRetroGateOnSprintPredatingTheScaffold(t *testing.T) {
 		t.Fatalf("refusal must name the sprint file: %v", *lines)
 	}
 }
+
+// The sprint template already ships a ## Retro section, so appending one
+// on close gave every sprint two of them. Worse than untidy: a retro the
+// person had already written sat above an empty scaffold, and the next
+// sprint's refusal had two sections to choose between.
+// proved by: appended the scaffold unconditionally — the closed file
+// carries two ## Retro headings and the written retro is no longer the
+// only one.
+func TestCloseDoesNotAddASecondRetro(t *testing.T) {
+	root := t.TempDir()
+	const written = "Blocked three days on a flaky fixture."
+	sp := writeItem(t, root, KindSprint, "001-mvp",
+		"# mvp\n\nStatus: active\n\n## Retro\n\n"+written+"\n")
+
+	out, lines := collect()
+	if code := SprintClose(root, out); code != 0 {
+		t.Fatalf("close: exit %d %v", code, *lines)
+	}
+	raw, err := os.ReadFile(sp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if n := strings.Count(text, "## Retro"); n != 1 {
+		t.Errorf("one Retro section, got %d:\n%s", n, text)
+	}
+	// And the one that survives is the one with the writing in it.
+	if !strings.Contains(text, written) {
+		t.Errorf("the written retro must survive the close:\n%s", text)
+	}
+	if strings.Contains(text, "What slowed us down") {
+		t.Errorf("no empty scaffold beneath a filled retro:\n%s", text)
+	}
+}


### PR DESCRIPTION
## Sprint 011 — checks that run themselves

Thirteen stories, each closed by the controller with evidence.

**At the commit:** SAST, complexity, known vulnerabilities, the narrowed suite, agents drift, and debt markers with no revisit condition.
**Over the tree, in CI:** `maintain`, `debt`, `deps`.
**In the report:** the suites the gate leaves to CI, so the trade is visible rather than merely defensible.

## What the close-out found

Writing the evidence is what caught these — not the gate, not CI.

- **Three stories had no test.** All three were the assertions behind the rule this sprint turned on: the heavy checks get no budget. A rule with no test is a rule until somebody is in a hurry.
- **Two stories had no feature.** `procoder debt` exited 0 whatever it found, so the CI step running it could only ever pass, and there was no debt leg at the gate at all.

`debt` survived the sprint that was about it because nothing checked whether the story matched the code — which is this sprint's own argument arriving from the other side.