### PR TITLE
docs: the lifecycle map, on the site rather than beside it

### DIFF
--- a/docs/domains.md
+++ b/docs/domains.md
@@ -5,7 +5,9 @@ the same architecture: the binary computes findings, the write hook hands
 them to the agent in the same turn, the gate carries them at commit time,
 a skill packages the workflow, and every rule is repo-overridable
 (D-OVERRIDE). This page is the detailed reference: what each domain
-checks, with what, what blocks, and where its knobs live.
+checks, with what, what blocks, and where its knobs live. For the same
+checks grouped by _when_ they run — session start, every write, the
+commit gate, CI — see [when each check runs](lifecycle.md).
 
 Reading the tables: **blocks** fails the gate and CI; **reports** informs
 the agent's judgment; **NOT-checked** means the tool was missing or

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,190 @@
+# When each check runs
+
+**A reference.** Every check Procoder runs, placed at the lifecycle event
+that fires it. [The ten domains](domains.md) lists the checks by subject;
+this page is the other cut — by moment. For why the chain refuses at all,
+see [the quality chain](quality-chain.md).
+
+Nothing here waits to be asked. Each check fires on an event, whether or
+not anyone remembered it existed — which is the whole point, because a
+check you have to know about protects only the people who already know
+about it.
+
+Two tiers run the same rules at different scopes: **the gate answers
+about the change, CI answers about the tree.** A commit is judged on what
+it carries; the repository is judged on all of it.
+
+<ul class="procoder-legend">
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span> stops the commit, or fails the job</li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span> printed; blocks only where the repository asked</li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span> context for a judgement you make</li>
+</ul>
+
+<div class="procoder-track">
+
+<section class="procoder-stop">
+<div class="procoder-stop__node">1</div>
+<div class="procoder-stop__card">
+<div class="procoder-stop__head">
+<h3>Session starts</h3>
+<code class="procoder-stop__trigger">SessionStart · 15s</code>
+</div>
+<p class="procoder-stop__why">The agent is handed the rules and the state of the repository before it writes anything — computed fresh, never carried over from a previous session.</p>
+<ul class="procoder-checks">
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>engineering principles</b><i>The ladder, the delegation rules, the formatting contract.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>state of play</b><i>Branch against the default, dirty count, active sprint, open stories, unlearned lessons, index freshness — inside a hard three-second budget.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>deferred suites</b><i>Names the test suites the gate will not run here, so a green gate is never mistaken for a suite that passed.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>version check</b><i>Asks GitHub off the critical path — a slow network cannot hold a session open.</i></span></li>
+</ul>
+</div>
+</section>
+
+<section class="procoder-stop">
+<div class="procoder-stop__node">2</div>
+<div class="procoder-stop__card">
+<div class="procoder-stop__head">
+<h3>Every file written</h3>
+<code class="procoder-stop__trigger">PostToolUse · Write|Edit · 60s</code>
+</div>
+<p class="procoder-stop__why">The fastest feedback in the chain, on the one file that just changed. Everything here is milliseconds, because it runs on every edit.</p>
+<ul class="procoder-checks">
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>format verdict</b><i>Clean, unformatted, UNCHECKED, or out of scope — for that file.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>secret scan</b><i>A flagged value is never echoed — not to the terminal, not into a question.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>linter</b><i>The language's canonical linter, over just this file.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>code index</b><i>Kept current, but only where an index already exists.</i></span></li>
+</ul>
+</div>
+</section>
+
+<section class="procoder-stop procoder-stop--wide">
+<div class="procoder-stop__node">3</div>
+<div class="procoder-stop__card">
+<div class="procoder-stop__head">
+<h3>Before the commit — the gate</h3>
+<code class="procoder-stop__trigger">PreToolUse · Bash · 120s</code>
+</div>
+<p class="procoder-stop__why">The big one. Eighteen legs over the changed set, intercepting <code>git commit</code> before it runs — and installable as a real pre-commit hook, so it holds outside the agent too. A file the gate could not look at is not a passing file: UNCHECKED fails it exactly like unformatted does.</p>
+<ul class="procoder-checks">
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>secrets</b><i>In a changed file. Always blocking, never configurable.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>SAST</b><i>semgrep over the files carried, at the severity <code>[security] sast_blocks_at</code> sets.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>known vulnerabilities</b><i>Only when the commit touches a dependency manifest.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>agents drift</b><i>A host rule file out of step with AGENTS.md is another agent reading rules this repository dropped.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>documentation obligation</b><i>A new exported symbol changes a doc, or the message carries <code>docs: none — reason</code>.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>test suite</b><i>Narrowed to the changed packages. A failure blocks under <code>[test] policy</code>; a suite that could not run blocks either way.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>emptied documentation</b><i>A Markdown file reduced to nothing, with the command to restore it.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>config that could not apply</b><i>An unreadable config.toml never silently falls back to defaults.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>conflict markers, junk, oversized files</b><i>And commits landing straight on the default branch.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>AI attribution in the message</b><i>Commits are the author's alone.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>format verdicts</b><i>Over every changed file. Unformatted fails the gate.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>linters</b><i>Blocking where the repository sets <code>[lint] policy = "block"</code>.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>complexity</b><i>Named as the function is written. Blocks under <code>[maintain] policy</code>.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>debt with no revisit condition</b><i>Asked while the reason for the shortcut is still in your head.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>workflow and infra hygiene</b><i>Pinned actions, timeouts, concurrency — across all workflows, not only changed ones.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--reports">Reports</span><span><b>loosened defaults</b><i>Every setting weakened from its default prints on every run. Strengthening one is silent.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>blast radius</b><i>What else the changed symbols reach, from the code index.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>open questions and captured leaks</b><i>Review findings recorded and never closed; questions waiting on a person.</i></span></li>
+</ul>
+</div>
+</section>
+
+<section class="procoder-stop">
+<div class="procoder-stop__node">4</div>
+<div class="procoder-stop__card">
+<div class="procoder-stop__head">
+<h3>Session ends or compacts</h3>
+<code class="procoder-stop__trigger">Stop · PreCompact · 10s</code>
+</div>
+<p class="procoder-stop__why">The handoff. What the next session inherits is written down rather than reconstructed from scrollback.</p>
+<ul class="procoder-checks">
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>handoff note</b><i>Written to state. A note that cannot be written is a lost note, never a broken session.</i></span></li>
+</ul>
+</div>
+</section>
+
+<section class="procoder-stop procoder-stop--wide">
+<div class="procoder-stop__node">5</div>
+<div class="procoder-stop__card">
+<div class="procoder-stop__head">
+<h3>Push and pull request</h3>
+<code class="procoder-stop__trigger">CI · test + gate jobs</code>
+</div>
+<p class="procoder-stop__why">Where the tree gets answered for. The gate saw only what the commit carried; these run over everything, on three operating systems.</p>
+<ul class="procoder-checks">
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>the suite — ubuntu, macOS, windows</b><i>The full run on all three, every push.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>committed binaries rebuild</b><i>Rebuilt reproducibly and compared by hash. A shipped binary nobody can reproduce is one nobody can check.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>gofmt, build, launcher</b><i>Including that the launcher resolves a binary in the shell each OS really uses.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>the gate over the whole tracked tree</b><i><code>git ls-files | xargs procoder check</code> — every file, not just the diff.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>security, the deep pass</b><i>Full SAST and dependency scan across the repository.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>documentation, external links included</b><i>The check that needs the network, kept off the commit path.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>maintain, debt, deps</b><i>The whole-tree pass: complexity everywhere, the full debt ledger, dependency freshness.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>doctor</b><i>Every tool present and answering, so no check above can pass by being absent.</i></span></li>
+</ul>
+</div>
+</section>
+
+<section class="procoder-stop">
+<div class="procoder-stop__node">6</div>
+<div class="procoder-stop__card">
+<div class="procoder-stop__head">
+<h3>Merged to main</h3>
+<code class="procoder-stop__trigger">CI · docs job</code>
+</div>
+<p class="procoder-stop__why">Publication. Branch protection requires linear history and every check green on the tip, so nothing arrives here unverified.</p>
+<ul class="procoder-checks">
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>mkdocs --strict</b><i>A broken reference fails the build rather than shipping a dead page.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>the changelog, served twice</b><i>One file copied into the site, so the repository and the docs cannot disagree.</i></span></li>
+</ul>
+</div>
+</section>
+
+<section class="procoder-stop">
+<div class="procoder-stop__node">7</div>
+<div class="procoder-stop__card">
+<div class="procoder-stop__head">
+<h3>Tagged <code>v*</code></h3>
+<code class="procoder-stop__trigger">CI · release job</code>
+</div>
+<p class="procoder-stop__why">A tag is the release. The job runs only after the suite and the gate pass on the tagged tree — what people download is published on the same evidence as everything else.</p>
+<ul class="procoder-checks">
+<li><span class="procoder-verdict procoder-verdict--blocks">Blocks</span><span><b>suite and gate on the tagged tree</b><i>Re-verified at the tag, not inherited from the branch.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>the changelog entry becomes the notes</b><i>Extracted verbatim — what is written there is what a person downloading reads.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>five platform binaries and SHA256SUMS</b><i>The manifest <code>procoder self-upgrade</code> verifies a download against.</i></span></li>
+</ul>
+</div>
+</section>
+
+</div>
+
+## Off the arrow: the controllers that refuse
+
+These are not on the timeline, because they do not fire at a fixed
+moment. They fire whenever you try to call something finished — and each
+one refuses, naming what is missing.
+
+| Controller                                       | What it refuses                                                                                                                                                                                              |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `procoder spec`, `procoder plan`                 | Hollow documents. A section left as its template comment is not a filled section.                                                                                                                            |
+| `procoder backlog close story`                   | A story with no real description, unchecked criteria, or no recorded evidence — then it runs the gate and the suite before agreeing.                                                                         |
+| `procoder backlog close epic`, `close milestone` | Closing while any child is still open.                                                                                                                                                                       |
+| `procoder sprint close`                          | Closing unless every story is done or explicitly carried, with a reason.                                                                                                                                     |
+| `procoder sprint start`                          | Starting until the last sprint's retro is written. The learning loop is enforced, not encouraged.                                                                                                            |
+| `procoder adr check`                             | Hollow records, unknown statuses, and supersede references pointing at nothing.                                                                                                                              |
+| `procoder release <version>`                     | Tagging until the version matches across every file, the changelog entry exists, the tree is clean, the gate is clean and the suite is green. It then prints the `git tag` command — it tags nothing itself. |
+| `procoder audit`                                 | Nothing — it is the onboarding sweep, every domain's checks over a tree Procoder has not governed before.                                                                                                    |
+
+## The three rules underneath
+
+**No silent green.** A check that could not run never reads as one that
+passed. A missing tool, an unparseable config, a suite that never
+started — each says so, and blocks. The failure this exists to prevent is
+the comfortable default: nothing found, therefore nothing wrong.
+
+**No budget on the heavy checks.** A slow scan finishes and reports what
+it found, rather than being cut off and reported anyway. A verdict that
+depends on how fast your laptop is, is not a verdict about your code. The
+ceiling that remains is a hung-process net: when it fires, it says the
+check was NOT run.
+
+**The binary prints, the agent writes.** Nothing here edits your files.
+Every check computes and reports; acting on the result is the author's
+move. That is what makes the whole chain safe to run on every event.

--- a/docs/quality-chain.md
+++ b/docs/quality-chain.md
@@ -3,7 +3,8 @@
 **An explanation.** Why Procoder makes "done" a verdict something else
 gives, rather than a judgment the agent makes about its own work. For
 the commands, see the [command reference](commands.md); for the daily
-sequence, see [how to ship a change](workflow.md).
+sequence, see [how to ship a change](workflow.md); for the moment each
+check fires, see [when each check runs](lifecycle.md).
 
 ## The problem it solves
 

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -176,3 +176,240 @@
 .md-typeset [hidden] {
   display: none !important;
 }
+
+/* ── The lifecycle map (reference/lifecycle.md) ──────────────────────
+   One arrow, one station per lifecycle event, one row per check. The
+   verdict colors are semantic rather than brand — they answer "does
+   this stop me?", so they stay outside the purple→cyan family on
+   purpose and are not in brand/README.md. */
+
+.procoder-track {
+  --pc-rail: 4.25rem;
+  position: relative;
+  padding-left: var(--pc-rail);
+  margin: 2rem 0 1rem;
+}
+
+/* the spine carries the signature gradient, running the length of the
+   lifecycle rather than sitting as a band across the top */
+.procoder-track::before {
+  content: "";
+  position: absolute;
+  left: 1.5rem;
+  top: 0;
+  bottom: 4.25rem;
+  width: 0.7rem;
+  border-radius: 0.35rem 0.35rem 0 0;
+  background: linear-gradient(
+    to bottom,
+    var(--procoder-violet) 0%,
+    var(--procoder-purple) 30%,
+    var(--procoder-blue) 65%,
+    var(--procoder-cyan) 100%
+  );
+}
+
+.procoder-track::after {
+  content: "";
+  position: absolute;
+  left: 0.65rem;
+  bottom: 1.6rem;
+  width: 0;
+  height: 0;
+  border-left: 1.25rem solid transparent;
+  border-right: 1.25rem solid transparent;
+  border-top: 2.6rem solid var(--procoder-cyan);
+}
+
+.procoder-stop {
+  position: relative;
+  margin-bottom: 1.75rem;
+}
+
+.procoder-stop__node {
+  position: absolute;
+  left: calc(-1 * var(--pc-rail) + 0.4rem);
+  top: 0.35rem;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--md-default-bg-color);
+  border: 2px solid var(--procoder-purple);
+  color: var(--procoder-purple);
+  font-family: var(--md-code-font-family), monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.procoder-stop__card {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.procoder-stop__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem 0.9rem;
+  padding: 0.9rem 1.1rem;
+  background: var(--md-code-bg-color);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.md-typeset .procoder-stop__head h3 {
+  margin: 0 !important;
+  flex: 1 1 auto;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.md-typeset .procoder-stop__trigger {
+  font-family: var(--md-code-font-family), monospace;
+  font-size: 0.7rem;
+  color: var(--md-default-fg-color--light);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 6px;
+  padding: 0.15rem 0.45rem;
+  white-space: nowrap;
+}
+
+.md-typeset .procoder-stop__why {
+  margin: 0;
+  padding: 0.85rem 1.1rem 0.35rem;
+  font-size: 0.78rem;
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .procoder-checks {
+  list-style: none;
+  margin: 0 !important;
+  padding: 0.5rem;
+  display: grid;
+  gap: 0.1rem;
+}
+
+.md-typeset .procoder-stop--wide .procoder-checks {
+  grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
+  gap: 0.1rem 0.5rem;
+}
+
+.md-typeset .procoder-checks li {
+  display: grid;
+  grid-template-columns: 5.2rem 1fr;
+  gap: 0.6rem;
+  align-items: start;
+  margin: 0 !important;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+}
+
+.md-typeset .procoder-checks li:nth-child(odd) {
+  background: var(--md-code-bg-color);
+}
+
+.md-typeset .procoder-checks b {
+  font-family: var(--md-code-font-family), monospace;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.md-typeset .procoder-checks i {
+  display: block;
+  font-style: normal;
+  font-size: 0.72rem;
+  color: var(--md-default-fg-color--light);
+}
+
+/* verdict chips: the answer to "does this stop me?" */
+.md-typeset .procoder-verdict {
+  font-family: var(--md-code-font-family), monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+[data-md-color-scheme="default"] {
+  --pc-blocks: #a3271b;
+  --pc-blocks-bg: #f8e5e2;
+  --pc-reports: #86560a;
+  --pc-reports-bg: #f9eedb;
+  --pc-info: #3f5a75;
+  --pc-info-bg: #e8edf3;
+}
+
+[data-md-color-scheme="slate"] {
+  --pc-blocks: #f4897d;
+  --pc-blocks-bg: #341a1a;
+  --pc-reports: #dda54f;
+  --pc-reports-bg: #2f2616;
+  --pc-info: #9db2c6;
+  --pc-info-bg: #1a2432;
+}
+
+.md-typeset .procoder-verdict--blocks {
+  color: var(--pc-blocks);
+  background: var(--pc-blocks-bg);
+}
+.md-typeset .procoder-verdict--reports {
+  color: var(--pc-reports);
+  background: var(--pc-reports-bg);
+}
+.md-typeset .procoder-verdict--info {
+  color: var(--pc-info);
+  background: var(--pc-info-bg);
+}
+
+.md-typeset .procoder-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.md-typeset .procoder-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0 !important;
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--light);
+}
+
+@media screen and (max-width: 44em) {
+  .procoder-track {
+    --pc-rail: 2.6rem;
+  }
+  .procoder-track::before {
+    left: 0.8rem;
+    width: 0.5rem;
+  }
+  .procoder-track::after {
+    left: 0.2rem;
+    border-left-width: 0.85rem;
+    border-right-width: 0.85rem;
+    border-top-width: 1.8rem;
+  }
+  .procoder-stop__node {
+    width: 1.8rem;
+    height: 1.8rem;
+    font-size: 0.7rem;
+    left: calc(-1 * var(--pc-rail) + 0.1rem);
+  }
+  .md-typeset .procoder-checks li {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+  .md-typeset .procoder-verdict {
+    justify-self: start;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Commands: commands.md
       - Configuration: configuration.md
       - The ten domains: domains.md
+      - When each check runs: lifecycle.md
       - Every agent: portability.md
       - Changelog: changelog.md
   - Explanation:


### PR DESCRIPTION
## What

A new reference page — **Reference → When each check runs** (`docs/lifecycle.md`) — showing every check Procoder runs, placed at the lifecycle event that fires it.

One arrow, seven stations: session start · every file written · the commit gate · session end · push & PR · merge to main · tagged `v*`. Each check carries a chip saying whether it **Blocks**, **Reports**, or is **Info**.

## Why

The site documented every check by *subject* (`domains.md`) and none by *moment*. Which hook fires the format verdict, what the gate adds over the write hook, which legs are CI's rather than the gate's — all true somewhere across `commands.md`, `workflow.md` and `architecture.md`, and nowhere as one picture.

The verdict is the information. "Does this block me?" is the first question anyone asks of a check, so it's what the eye lands on first rather than a clause at the end of a sentence.

## Built in the site's system, not beside it

- The signature purple→cyan gradient runs down the arrow spine.
- Material's own tokens carry both colour schemes — no `prefers-color-scheme` media query, matching `brand.css` convention.
- Component selectors are scoped under `.md-typeset`, because Material's element rules (`code`, `h3`, `li`) are specificity (0,2,0) and would otherwise win the cascade.
- Verdict colours sit **outside** the brand family and **outside** `brand/README.md` — they're semantic, not brand.

The refusing controllers are documented *off* the arrow, since they fire when you claim to be finished rather than at a fixed moment.

`mkdocs build --strict` exits 0; gate clean.