### PR TITLE
backlog: the CI epic opens over thirteen stories

### DIFF
--- a/.procoder/backlog/epics/ci-that-procoder-writes.md
+++ b/.procoder/backlog/epics/ci-that-procoder-writes.md
@@ -1,0 +1,22 @@
+# ci-that-procoder-writes
+
+Status: open
+Created: 2026-08-22
+Spec: ci-that-procoder-writes @ c4f650f98475
+
+## Description
+
+Procoder's second tier becomes portable. Today the whole-tree checks
+exist as a workflow file in this repository, so every other repository
+that adopts Procoder gets a commit gate and nothing behind it — and the
+domain that polices CI cannot see the gap, because `ciops.Check` reports
+a repository with no workflows as clean.
+
+This epic makes the tier something Procoder can describe and check
+anywhere: emitted per repository from what that repository actually
+contains, configured by its own config, overridable block by block, and
+reported against when an existing workflow omits it. One unit of value,
+because a generator nobody is told they need and a check with nothing to
+suggest are each half a feature.
+
+Seeded from .procoder/specs/ci-that-procoder-writes.md — one story per acceptance criterion.

--- a/.procoder/backlog/stories/20260822-a-repository-carrying-procoder-ci-whole-tree-yml-gets-that.md
+++ b/.procoder/backlog/stories/20260822-a-repository-carrying-procoder-ci-whole-tree-yml-gets-that.md
@@ -1,0 +1,27 @@
+# A repository carrying `.procoder/ci/whole-tree.yml` gets that content in place of the built-in block, and a repository without the file gets the built-in block unchanged.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+D-OVERRIDE, applied here like everywhere else: a repository that
+disagrees with a block replaces it, without forking the emitter or
+abandoning the rest of what it generates.
+
+Done means the override file's content appears in place of the built-in
+block, and a repository without the file gets the built-in unchanged.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository carrying `.procoder/ci/whole-tree.yml` gets that content in place of the built-in block, and a repository without the file gets the built-in block unchanged.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-a-repository-whose-github-workflows-is-unreadable-produces.md
+++ b/.procoder/backlog/stories/20260822-a-repository-whose-github-workflows-is-unreadable-produces.md
@@ -1,0 +1,27 @@
+# A repository whose `.github/workflows` is unreadable produces a different, blocking finding that names the directory — not the absent-CI one.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+Absent and unreadable are different answers, and only one of them is
+the repository's choice. A permissions failure that reads as "no CI
+here" would send somebody to write a workflow that already exists.
+
+Done means the unreadable case blocks and names the directory, distinct
+from the finding a repository with genuinely no CI receives.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository whose `.github/workflows` is unreadable produces a different, blocking finding that names the directory — not the absent-CI one.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-a-repository-with-no-workflow-files-at-all-produces-a.md
+++ b/.procoder/backlog/stories/20260822-a-repository-with-no-workflow-files-at-all-produces-a.md
@@ -1,0 +1,29 @@
+# A repository with no workflow files at all produces a finding naming the whole-tree tier as missing, where `ciops.Check` previously returned nil.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+A repository that adopts Procoder gets a commit gate and no second
+tier, and today nothing tells it so. `ciops.Check` opens
+`.github/workflows`, finds nothing, and returns nil — the repository is
+reported clean by the domain whose subject is CI.
+
+Done means it is told: a finding that names the whole-tree tier as
+missing, so somebody who has never read this spec learns the tier exists
+at the moment it is absent.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository with no workflow files at all produces a finding naming the whole-tree tier as missing, where `ciops.Check` previously returned nil.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-a-workflow-that-runs-procoder-check-but-not-procoder-debt.md
+++ b/.procoder/backlog/stories/20260822-a-workflow-that-runs-procoder-check-but-not-procoder-debt.md
@@ -1,0 +1,28 @@
+# A workflow that runs `procoder check` but not `procoder debt` is told that `debt` is missing and is not told that `check` is.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+Most repositories will not adopt a generated file wholesale; they
+have a workflow already and want to know what it is missing. A report
+that says "your CI is incomplete" is useless, and one that says "add
+these six steps" when five are present is worse.
+
+Done means the finding names exactly the checks that are absent, and
+says nothing about the ones that are there.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A workflow that runs `procoder check` but not `procoder debt` is told that `debt` is missing and is not told that `check` is.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-a-workflow-that-runs-the-whole-tree-commands-under-step.md
+++ b/.procoder/backlog/stories/20260822-a-workflow-that-runs-the-whole-tree-commands-under-step.md
@@ -1,0 +1,28 @@
+# A workflow that runs the whole-tree commands under step names Procoder did not choose produces no missing-check finding.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+Detection has to match what runs, not what it is called. Step names
+are the most-edited thing in any workflow, and a checker keyed on them
+tells every repository that renamed a step that it lost a check it
+still runs — which is how a checker gets ignored.
+
+Done means a workflow running the right commands under any names
+produces no missing-check finding.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A workflow that runs the whole-tree commands under step names Procoder did not choose produces no missing-check finding.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-an-empty-procoder-ci-whole-tree-yml-blocks-and-names-the.md
+++ b/.procoder/backlog/stories/20260822-an-empty-procoder-ci-whole-tree-yml-blocks-and-names-the.md
@@ -1,0 +1,27 @@
+# An empty `.procoder/ci/whole-tree.yml` blocks and names the file, rather than falling back to the built-in.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+Falling back to the built-in when an override cannot be read would
+mean a repository believing it had replaced a block that is still
+running Procoder's version — a silent green wearing a config file.
+
+Done means an empty or unreadable override blocks and names the file
+rather than quietly substituting the default.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] An empty `.procoder/ci/whole-tree.yml` blocks and names the file, rather than falling back to the built-in.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-host-with-an-unrecognised-name-reports-the-name-and-prints.md
+++ b/.procoder/backlog/stories/20260822-host-with-an-unrecognised-name-reports-the-name-and-prints.md
@@ -1,0 +1,27 @@
+# `--host` with an unrecognised name reports the name and prints no workflow.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+A partial workflow is worse than none: YAML that parses but omits
+half the checks is a CI that silently tests less, and nothing in the
+run says so.
+
+Done means an unrecognised `--host` names what it was given and prints
+nothing at all.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `--host` with an unrecognised name reports the name and prints no workflow.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-procoder-ci-emit-in-a-go-repository-prints-a-workflow.md
+++ b/.procoder/backlog/stories/20260822-procoder-ci-emit-in-a-go-repository-prints-a-workflow.md
@@ -1,0 +1,28 @@
+# `procoder ci --emit` in a Go repository prints a workflow containing the whole-tree steps (`check` over tracked files, `security --deep`, `docs --external`, `maintain`, `debt`, `deps`) and a Go suite step.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+The whole point: a repository asks what its CI should contain and is
+handed it, rather than translating this repository's `ci.yml` by hand.
+
+Done means the emitted workflow carries the whole-tree tier — `check`
+over tracked files, `security --deep`, `docs --external`, `maintain`,
+`debt`, `deps` — plus the suite step for the ecosystem actually
+present.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder ci --emit` in a Go repository prints a workflow containing the whole-tree steps (`check` over tracked files, `security --deep`, `docs --external`, `maintain`, `debt`, `deps`) and a Go suite step.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-procoder-ci-emit-leaves-every-file-s-bytes-unchanged.md
+++ b/.procoder/backlog/stories/20260822-procoder-ci-emit-leaves-every-file-s-bytes-unchanged.md
@@ -1,0 +1,28 @@
+# `procoder ci --emit` leaves every file's bytes unchanged, asserted by comparing a digest of the tree before and after.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+P-CONTROL, at the surface where breaking it would be most tempting.
+A tool that writes CI is a tool that can disable CI, and a generator
+that edits files is one bad merge away from replacing a workflow
+somebody depends on.
+
+Done means the command prints, and a digest of the tree is identical
+before and after.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder ci --emit` leaves every file's bytes unchanged, asserted by comparing a digest of the tree before and after.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-the-emitted-workflow-passes-procoder-ci-s-hygiene-rules.md
+++ b/.procoder/backlog/stories/20260822-the-emitted-workflow-passes-procoder-ci-s-hygiene-rules.md
@@ -1,0 +1,28 @@
+# The emitted workflow passes `procoder ci`'s hygiene rules: asserted by feeding the emitter's own output back into `ciops.Check` and requiring no findings.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+One binary contains both the generator and the checker. If what it
+emits fails what it checks — unpinned actions, a job with no timeout,
+concurrency that does not cancel — then one of the two is wrong, and a
+user meets that contradiction on their first run.
+
+Done means the emitter's own output is fed back into `ciops.Check` and
+produces no findings.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] The emitted workflow passes `procoder ci`'s hygiene rules: asserted by feeding the emitter's own output back into `ciops.Check` and requiring no findings.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-the-emitted-workflow-runs-procoder-docs-external-and-not.md
+++ b/.procoder/backlog/stories/20260822-the-emitted-workflow-runs-procoder-docs-external-and-not.md
@@ -1,0 +1,30 @@
+# The emitted workflow runs `procoder docs --external` and not the bare `procoder docs`: the offline half already rides the gate, so emitting it again in CI would repeat the commit's answer while leaving link rot — the only part CI can see — unchecked.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+`procoder docs` and `procoder docs --external` are different checks.
+The offline half already rides the commit gate, so emitting it in CI
+spends a job repeating the answer the commit gave, while leaving link
+rot unchecked — and link rot is the one thing only CI can see, because
+it happens when somebody else's server changes and no commit here
+touches anything.
+
+Done means the emitted step is the external one, asserted so an
+implementation cannot satisfy the neighbouring criterion either way.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] The emitted workflow runs `procoder docs --external` and not the bare `procoder docs`: the offline half already rides the gate, so emitting it again in CI would repeat the commit's answer while leaving link rot — the only part CI can see — unchecked.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-the-same-command-in-a-repository-with-only-a-composer-json.md
+++ b/.procoder/backlog/stories/20260822-the-same-command-in-a-repository-with-only-a-composer-json.md
@@ -1,0 +1,27 @@
+# The same command in a repository with only a `composer.json` and PHP sources prints the PHP suite step and no Go step.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+Modular means the emitter answers about the repository in front of it.
+A PHP project handed a Go workflow learns nothing except that this tool
+was built for somebody else.
+
+Done means a repository with only `composer.json` and PHP sources gets
+the PHP suite step and no Go step at all.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] The same command in a repository with only a `composer.json` and PHP sources prints the PHP suite step and no Go step.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260822-this-repository-s-own-ci-yml-contains-every-whole-tree-step.md
+++ b/.procoder/backlog/stories/20260822-this-repository-s-own-ci-yml-contains-every-whole-tree-step.md
@@ -1,0 +1,28 @@
+# This repository's own `ci.yml` contains every whole-tree step the emitter emits for it, asserted by a test, so the shipped example and the running CI cannot drift apart.
+
+Status: open
+Created: 2026-08-22
+Epic: ci-that-procoder-writes
+Sprint: -
+
+## Description
+
+This repository's CI is also the worked example. If the emitter and
+`ci.yml` drift apart, then either the example is a fiction or our own CI
+has quietly lost a check — and both failures are invisible without
+something asserting they agree.
+
+Done means a test holds the two together, so the drift cannot happen
+silently.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] This repository's own `ci.yml` contains every whole-tree step the emitter emits for it, asserted by a test, so the shipped example and the running CI cannot drift apart.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->


### PR DESCRIPTION
## What

Seeds `.procoder/backlog/` from the spec merged in #143 — one story per acceptance criterion, pinned to the spec's fingerprint so the two cannot drift silently.

## Descriptions written now, not at close time

Sprint 011's close was **refused** because all thirteen stories still had the template comment as their Description — discovered at the moment I was trying to close them, which is the worst moment to learn a story never said who needed it or why.

The controller was right. The fix belongs here, before any story is worked.

## The thirteen

**The report (4)** — a repository with no CI at all; one whose workflows directory cannot be read; one whose workflow omits checks; one that runs them under names we did not choose.

**The emitter (7)** — what it prints for a Go repository and for a PHP one; that its output passes the checker in the same binary; that it writes nothing; that a block can be replaced; that an unreadable replacement blocks rather than falling back.

**The edges (2)** — an unknown host prints nothing rather than half a file; and this repository's own `ci.yml` is asserted to contain what the emitter would emit for it, so the worked example cannot quietly become fiction.