### PR TITLE
fix(docs): resolve absolute links from the OKF bundle root, not the repo root

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -170,6 +170,10 @@ func RelativeRefs(root, file string) []gitx.Finding {
 	if err != nil {
 		return nil
 	}
+	// OKF bundles (a directory whose index.md declares okf_version) resolve
+	// absolute links from the bundle root, not the repo root — "/log.md"
+	// inside .okf/ means .okf/log.md. Empty when the file is in no bundle.
+	bundle := okfBundleRoot(root, file)
 	var out []gitx.Finding
 	inFence := false
 	for i, line := range strings.Split(string(data), "\n") {
@@ -198,7 +202,11 @@ func RelativeRefs(root, file string) []gitx.Finding {
 			}
 			resolved := filepath.Join(filepath.Dir(file), filepath.FromSlash(target))
 			if strings.HasPrefix(target, "/") {
-				resolved = filepath.Join(root, filepath.FromSlash(target))
+				base := root
+				if bundle != "" {
+					base = bundle
+				}
+				resolved = filepath.Join(base, filepath.FromSlash(target))
 			}
 			if _, err := os.Stat(resolved); err != nil {
 				out = append(out, gitx.Finding{File: file, Line: i + 1, Blocking: true,
@@ -218,6 +226,56 @@ func RelativeRefs(root, file string) []gitx.Finding {
 		}
 	}
 	return out
+}
+
+// okfBundleRoot walks from the file's directory up to the repo root and
+// returns the nearest directory whose index.md declares okf_version in its
+// frontmatter — the OKF bundle root. Empty when no ancestor is one.
+func okfBundleRoot(root, file string) string {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return ""
+	}
+	dir, err := filepath.Abs(filepath.Dir(file))
+	if err != nil {
+		return ""
+	}
+	for {
+		if hasOKFVersion(filepath.Join(dir, "index.md")) {
+			return dir
+		}
+		if dir == absRoot {
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir || len(parent) < len(absRoot) {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// hasOKFVersion reports whether the file opens with a YAML frontmatter block
+// that declares okf_version.
+func hasOKFVersion(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return false
+	}
+	for _, l := range lines[1:] {
+		t := strings.TrimSpace(l)
+		if t == "---" {
+			return false
+		}
+		if strings.HasPrefix(t, "okf_version:") {
+			return true
+		}
+	}
+	return false
 }
 
 var (

--- a/internal/docs/docs_test.go
+++ b/internal/docs/docs_test.go
@@ -41,6 +41,31 @@ func TestBrokenRelativeReferenceIsBlockingAndNamed(t *testing.T) {
 	}
 }
 
+// Inside an OKF bundle (a directory whose index.md declares okf_version),
+// absolute links are bundle-root-relative per the OKF spec — "/log.md" in
+// .okf/ means .okf/log.md. Outside a bundle they stay repo-root-relative,
+// and a bundle link to a file that truly does not exist still blocks.
+func TestOKFBundleLinksResolveFromBundleRoot(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, ".okf/index.md", "---\nokf_version: \"0.2\"\n---\n\n# B\n")
+	write(t, root, ".okf/log.md", "log\n")
+	write(t, root, ".okf/areas/corpus.md", "x\n")
+	write(t, root, "repo-file.md", "x\n")
+
+	inBundle := write(t, root, ".okf/roadmap.md",
+		"[log](/log.md) [c](/areas/corpus.md) [gone](/nope.md)\n")
+	got := RelativeRefs(root, inBundle)
+	if len(got) != 1 || !strings.Contains(got[0].Message, "/nope.md") {
+		t.Fatalf("want only the truly missing bundle link flagged, got %+v", got)
+	}
+
+	outside := write(t, root, "README.md", "[r](/repo-file.md) [l](/log.md)\n")
+	got = RelativeRefs(root, outside)
+	if len(got) != 1 || !strings.Contains(got[0].Message, "/log.md") {
+		t.Fatalf("outside a bundle, absolute links stay repo-root-relative: %+v", got)
+	}
+}
+
 func TestExternalAndAnchorLinksAreNotRelativeFindings(t *testing.T) {
 	root := t.TempDir()
 	md := write(t, root, "README.md",


### PR DESCRIPTION
## The bug

The markdown link checker (`RelativeRefs` in `internal/docs/docs.go`) resolves every link starting with `/` from the repository root. [OKF](https://openknowledgeformat.org) bundles — a directory whose `index.md` declares `okf_version` in its YAML frontmatter — define those links as **bundle-root-relative**: `/log.md` inside `.okf/` points at `.okf/log.md`.

Result: on a real-world repo carrying a conformant bundle (certified by `okf validate`), `procoder check` reported **22 blocking "broken reference" findings**, all false positives, e.g.:

```
BLOCKING  .okf/index.md:17  broken reference: "/reference/" does not resolve
BLOCKING  .okf/roadmap.md:29  broken reference: "/log.md" does not resolve
```

## The fix

`RelativeRefs` now walks from the checked file up to the repo root looking for the nearest directory whose `index.md` carries `okf_version` frontmatter, and resolves `/`-links from that directory when found.

- Files outside a bundle keep the existing repo-root behavior, unchanged.
- A bundle link whose target genuinely does not exist still blocks.
- Anchor checking keeps working through the same resolved path.

## Verification

- New test `TestOKFBundleLinksResolveFromBundleRoot` covers all three cases (bundle link resolves, missing bundle target still blocks, non-bundle absolute links unchanged); `go test ./internal/docs/` passes.
- Re-ran the built binary against the affected real repo: 22 findings → 0, while a probe repo with genuinely broken relative and absolute links still produces blocking findings.