### PR TITLE
fix: csharpier runs with --no-cache, so a formatted file still answers

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -280,8 +280,12 @@ var (
 		},
 	}
 	csharpier = &Tool{
-		Name:        "csharpier",
-		Args:        func(f string) []string { return []string{"format", "--write-stdout", f} },
+		Name: "csharpier",
+		// --no-cache: csharpier 1.x keeps a formatting cache and prints
+		// nothing for a file it has already seen, which the print-not-write
+		// contract this tool exists for reads as "did not answer" — a
+		// correctly formatted file then fails the gate as UNCHECKED.
+		Args:        func(f string) []string { return []string{"format", "--write-stdout", "--no-cache", f} },
 		Install:     "dotnet tool install -g csharpier",
 		VersionArgs: []string{"--version"},
 		InstallVia: []InstallCandidate{

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -351,3 +351,23 @@ func TestRepoRootReturnsTheInputWhenThereIsNoRepository(t *testing.T) {
 		t.Errorf("RepoRoot = %q, want the input %q unchanged", got, dir)
 	}
 }
+
+// csharpier 1.x caches formatting results and prints nothing for a file
+// it has already seen — a correctly formatted file then reads as a tool
+// that "did not answer" and fails the gate as UNCHECKED. --no-cache keeps
+// the print-not-write contract this tool exists for holding regardless of
+// cache state.
+// proved by: dropped --no-cache from the argv — this fails, and so does
+// procoder against a real csharpier on a second run over the same file.
+func TestCsharpierNeverUsesTheCache(t *testing.T) {
+	args := csharpier.Args("/x/a.cs")
+	var noCache bool
+	for _, a := range args {
+		if a == "--no-cache" {
+			noCache = true
+		}
+	}
+	if !noCache {
+		t.Errorf("csharpier must run with --no-cache: %v", args)
+	}
+}


### PR DESCRIPTION
Fixes #149.

## Bug

csharpier 1.x keeps a formatting cache and prints nothing for a file it has already seen. procoder's csharpier call prints-not-writes on purpose — the printed result is what the caller reviews — and reads an empty answer as the tool having not run at all.

Effect: a correctly formatted `.cs` file fails the gate as `UNCHECKED — csharpier did not answer: printed nothing for a non-empty file` on every commit after the first that touched it, because the cache fills on the very run `procoder format` suggests.

## Fix

`--no-cache` on the argv, holding the print-not-write contract regardless of cache state.

Reported and confirmed by @Acroaticum in #149 — csharpier 1.3.0, Windows 11, .NET 10.

## Verification

`TestCsharpierNeverUsesTheCache` asserts `--no-cache` is present; mutation (drop the flag) proven failing.