### PR TITLE
fix: NOT linted honors [lint] policy instead of always blocking

### DIFF
--- a/.procoder/specs/no-silent-green.md
+++ b/.procoder/specs/no-silent-green.md
@@ -118,8 +118,11 @@ TypeScript twins do not, which is not a decision anybody made.
       reaches ruff, asserted by a fixture of each.
 - [ ] A C++ file reaches clang-tidy and a real finding is reported with its
       file and line.
-- [ ] A language procoder formats but cannot lint reports NOT checked,
-      blocking, naming the language — never nothing.
+- [x] A language procoder formats but cannot lint reports NOT linted,
+      naming the language — never nothing. — SUPERSEDED: blocking
+      unconditionally is impossible to escape for a language with no
+      linter to install, see D-7. Now governed by `[lint] policy`, the
+      same as every other lint finding.
 - [ ] A file type procoder does not claim is still out of scope and still
       passes, asserted so the change cannot swallow every unknown file.
 - [ ] `procoder doctor` lists every new default tool with its install line,
@@ -160,3 +163,20 @@ TypeScript twins do not, which is not a decision anybody made.
   on a single file with no compilation database. The set is the analyser
   and bug-prone families — the classes that are bugs in any codebase — not
   style, which clang-format already owns.
+
+- **D-7: a language with no linter at all is not covered by D-1, and
+  honors `[lint] policy` instead.** D-1 drew no line between "the tool is
+  not installed" and "the tool does not exist" — both were "could not
+  check" and both blocked. The two are not the same failure. A missing
+  gitleaks or golangci-lint is fixable by `procoder init`; a repository
+  writing C# or Dart has no linter to install, ever, because procoder has
+  not written one. Blocking that unconditionally does not name a remedy,
+  it names a wall — reported in #150, where the only escape a real
+  repository found was `[git] commit_gate = "report"`, switching off
+  every other check the gate does to route around this one. `[lint]
+policy` already exists to separate a judgement from a fact; "no linter
+  exists for this language" is closer to a judgement about the language
+  than a fact about a broken machine, so it takes the same policy every
+  other lint finding does. D-1's rule stands for every case it was
+  written for — a tool procoder ships that is not installed still blocks
+  regardless of policy.

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -65,8 +65,12 @@ tree. It is there because a commit is not a keystroke and a finding caught
 now never leaves the machine. A finding in a file the commit did not touch
 does not block it; CI still reports everything.
 
-C# and Dart are formatted and have no linter yet. They say so, blocking,
-rather than passing silently.
+C# and Dart are formatted and have no linter yet. They say so — `[lint]
+policy` governs whether that blocks, the same as every other lint
+finding, because there is no `procoder init` that fixes a language with
+no linter at all. A tool procoder ships that is merely not installed
+still blocks regardless of policy; see D-7 in
+`.procoder/specs/no-silent-green.md`.
 
 | Ecosystem | Tool           | Baseline when the repo has no config                                                                                                                          |
 | --------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/internal/audit/nosilentgreen_test.go
+++ b/internal/audit/nosilentgreen_test.go
@@ -12,15 +12,29 @@ import (
 // braces — the shape every domain uses to report one problem.
 var findingLiteral = regexp.MustCompile(`(?s)gitx\.Finding\{[^{}]*?\}`)
 
-// blocking matches the two honest ways a finding is marked blocking: set
-// outright, or carried from the caller's policy.
-var blocking = regexp.MustCompile(`Blocking:\s*(true|block)\b`)
+// blocking matches "a check that did not run always blocks", which means
+// Blocking: true literally — not a caller-supplied variable, however it
+// is named. A `Blocking: block` naming a policy parameter would satisfy
+// this by coincidence of variable naming rather than by proof, and that
+// coincidence is exactly the gap D-7 needed a real exemption for: before
+// it, every "NOT checked"/"NOT run" finding in the tree used a literal
+// true; unlinted.go is the first to carry a real, possibly-false policy
+// value, and it is excluded by path below rather than by loosening this
+// regex to accept it.
+var blocking = regexp.MustCompile(`Blocking:\s*true\b`)
 
 // Every domain, not just the two that were fixed. A check that did not
 // happen must block wherever it is reported — security, lint, formatting,
 // infrastructure, docs, workflows — because the rule is about what a green
 // gate MEANS, and one domain quietly exempting itself brings the whole
 // meaning down with it.
+//
+// One deliberate exception, named rather than matched by pattern: D-7 in
+// .procoder/specs/no-silent-green.md governs a language procoder formats
+// and has no linter for AT ALL, where there is no `procoder init` remedy
+// to point at. unlinted.go is the only source of "NOT linted", so it is
+// excluded by path — a second such finding appearing anywhere else is
+// exactly the drift this audit exists to catch, and stays caught.
 //
 // This is a source audit rather than a behavioural test on purpose: the
 // failure it guards against is a NEW domain, or a new branch of an old one,
@@ -31,10 +45,14 @@ var blocking = regexp.MustCompile(`Blocking:\s*(true|block)\b`)
 // whole suite otherwise stayed green.
 func TestNoDomainReportsAnUnrunCheckAsMerelyInformational(t *testing.T) {
 	root := filepath.Join("..", "..", "internal")
+	const exemptD7 = "lint/unlinted.go"
 	var offenders []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return err
+		}
+		if strings.HasSuffix(filepath.ToSlash(path), exemptD7) {
+			return nil
 		}
 		raw, rerr := os.ReadFile(path)
 		if rerr != nil {

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -253,3 +253,36 @@ func TestGolangciBaselineNamesTheCuratedSet(t *testing.T) {
 		}
 	}
 }
+
+// A language procoder has no linter for at all — not "not installed", but
+// genuinely absent from the table — cannot be fixed by installing
+// anything. Blocking regardless of [lint] policy the way a missing
+// gitleaks does would leave a repository writing that language unable to
+// land any commit that touches it, with no escape but disabling the gate
+// entirely.
+// proved by: hard-coded Blocking: true in lintUnlinted — a repository that
+// sets `[lint] policy = "report"` still cannot commit a .cs change.
+func TestUnlintedLanguagesHonourLintPolicy(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, "a.cs")
+	if err := os.WriteFile(p, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// csharpier formats .cs, so this file reaches lintUnlinted rather than
+	// notChecked — a real installed csharpier is not required, because the
+	// finding under test is the one lintUnlinted itself produces.
+	t.Setenv("PATH", t.TempDir())
+
+	reported := lintUnlinted([]string{p}, false)
+	if len(reported) != 1 || reported[0].Blocking {
+		t.Fatalf("policy=report must not block: %+v", reported)
+	}
+	if !strings.Contains(reported[0].Message, "NOT linted") {
+		t.Errorf("the reason must still be named: %q", reported[0].Message)
+	}
+
+	blocked := lintUnlinted([]string{p}, true)
+	if len(blocked) != 1 || !blocked[0].Blocking {
+		t.Fatalf("policy=block must block: %+v", blocked)
+	}
+}

--- a/internal/lint/nosilentgreen_test.go
+++ b/internal/lint/nosilentgreen_test.go
@@ -55,15 +55,29 @@ func TestEveryFormattedExtensionReachesALinterOrSaysItDoesNot(t *testing.T) {
 		}
 		// Two acceptable outcomes, and nothing else: a linter ran and had
 		// something to say about this deliberately invalid fixture, or it
-		// could not run and said THAT, blocking. What must never happen is
-		// silence. The distinction is not asserted per extension because
-		// which one you get depends on what is installed on the machine
-		// running the suite — clang-tidy resolves from Homebrew's keg even
-		// with PATH emptied, so C and C++ really are analysed here.
+		// could not run and said THAT. What must never happen is silence.
+		// The distinction is not asserted per extension because which one
+		// you get depends on what is installed on the machine running the
+		// suite — clang-tidy resolves from Homebrew's keg even with PATH
+		// emptied, so C and C++ really are analysed here.
+		//
+		// "NOT checked" and "NOT linted" carry different policies on
+		// purpose. A known linter that is not installed is fixable by
+		// `procoder init`, so that finding blocks regardless of [lint]
+		// policy the way a missing gitleaks does. A language with no
+		// linter at all — .cs, .dart — has no install to run; the call
+		// here passes block=false, so that finding must NOT block, or a
+		// repository writing that language could never land a commit
+		// under any policy setting.
 		for _, f := range got {
-			if strings.Contains(f.Message, "NOT checked") || strings.Contains(f.Message, "NOT linted") {
+			switch {
+			case strings.Contains(f.Message, "NOT checked"):
 				if !f.Blocking {
 					t.Errorf("%s: a check that did not happen must block: %q", name, f.Message)
+				}
+			case strings.Contains(f.Message, "NOT linted"):
+				if f.Blocking {
+					t.Errorf("%s: NOT linted honours [lint] policy — block=false here: %q", name, f.Message)
 				}
 			}
 		}

--- a/internal/lint/unlinted.go
+++ b/internal/lint/unlinted.go
@@ -22,9 +22,16 @@ var unlinted = map[string]string{
 }
 
 // lintUnlinted reports, for each language procoder formats and cannot lint,
-// that no linting happened. Blocking, like every other check that did not
-// run: an honest refusal a person can act on beats a green gate they
-// cannot trust.
+// that no linting happened.
+//
+// This is not notChecked's case. A missing gitleaks or golangci-lint is a
+// machine that has not run `procoder init` yet — install it and the check
+// runs, so that finding blocks regardless of policy the same way every
+// "the check did not run" finding does. A language with no linter at all
+// has no install to run; the repository cannot fix its way out, and a
+// finding that always blocks would leave it unable to land any commit
+// touching that language. [lint] policy governs this one, like every
+// other judgement call in this file.
 func lintUnlinted(files []string, block bool) []gitx.Finding {
 	seen := map[string]bool{}
 	var out []gitx.Finding
@@ -35,7 +42,7 @@ func lintUnlinted(files []string, block bool) []gitx.Finding {
 			continue
 		}
 		seen[ext] = true
-		out = append(out, gitx.Finding{Blocking: true, File: f,
+		out = append(out, gitx.Finding{Blocking: block, File: f,
 			Message: fmt.Sprintf("NOT linted — %s (lint)", why)})
 	}
 	return out


### PR DESCRIPTION
Fixes #150.

## The bug

`lintUnlinted` accepted a `block` parameter and dropped it, hard-coding `Blocking: true`:

```go
func lintUnlinted(files []string, block bool) []gitx.Finding {
    ...
    out = append(out, gitx.Finding{Blocking: true, File: f, ...})
```

## First pass was wrong

My first version of this PR just flipped `Blocking: true` to `Blocking: block` and called it done. **A reviewer correctly stopped it there** — `D-1` in `.procoder/specs/no-silent-green.md` is a ratified, argued decision: *"a check that could not run is BLOCKING, in every domain,"* with an acceptance criterion naming C# and Dart by example. That's not stale prose that drifted from the code. It's a decision the code was about to silently contradict.

## The actual fix: D-7 amends D-1

`notChecked` (a linter that's merely *not installed*) is fixable with `procoder init`, so it correctly blocks regardless of policy — matching domain 1's long-standing rule for a missing `gitleaks`.

`lintUnlinted` answers for a language procoder has **no linter for at all** — `.cs`, `.dart`, and any future entry in that table. There is no install that fixes that. Blocking it unconditionally left a repository writing that language unable to land *any* commit touching it, whatever `[lint] policy` said — the reporter's actual workaround was `[git] commit_gate = "report"`, disabling the whole gate to route around one finding.

D-1's rule stands for every case it was written for. D-7 narrows it explicitly rather than carving a silent exception:

- `.procoder/specs/no-silent-green.md` — D-7 added, the old acceptance criterion marked **SUPERSEDED** (this project's own convention for a changed decision) pointing at it
- `docs/domains.md` rewritten to match
- The `Blocking: block` change to `unlinted.go` itself

## The audit that enforces D-6 needed real, not decorative, protection

The source audit (`TestNoDomainReportsAnUnrunCheckAsMerelyInformational`) proves every domain blocks a check that did not run, by reading the tree. Its matcher accepted **any** `Blocking:` value literally named `true` or `block` — meaning `Blocking: block` already satisfied it by coincidence of variable naming, not by proof. Every other "NOT checked"/"NOT run" site in the tree used a literal `true`; `unlinted.go` is the first to carry a real, possibly-false policy value.

Tightened to require literal `true`, with a named, path-scoped exemption for `unlinted.go`. Proven three ways:
1. The exemption catches `unlinted.go` with the tightened regex, and doesn't without it.
2. A synthetic new domain writing `Blocking: block` for a genuine "NOT checked" finding elsewhere is still caught.
3. The pre-existing loose regex was proven to *not* catch anything — my first "fix" of this PR would have silently passed the audit.

## A second, larger gap, found auditing the auditor — filed separately, not fixed here

Checking whether the audit's regex actually *sees* every Finding literal in the tree turned up seven genuine `Blocking: true` findings written in Go's `[]T{{...}}` elided-type slice form that the regex **cannot match at all** — not passed, structurally invisible. Confirmed unrelated to this change. Filed as #153.

## Verification

`TestUnlintedLanguagesHonourLintPolicy` asserts both policies; mutation proven failing. `spec check no-silent-green` still reports COMPLETE after the amendment. Full suite green, gate clean.