### PR TITLE
docs: the changelog links every PR and names every reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ what is written here is what a person downloading the binary reads.
     *One sentence: what this release is for, for someone deciding whether
     to upgrade.*
 
-    **Fixed — the headline, as a statement.** (link the issue here) Then
-    the prose: what was wrong, what it cost the person using it, what is
-    true now. Paragraphs, not bullet lists — a changelog is read, not
-    parsed.
+    **Fixed — the headline, as a statement.**
+    ([#123](https://github.com/azrtydxb/procoder/pull/123)) Then the
+    prose: what was wrong, what it cost the person using it, what is
+    true now. Reported by
+    [@handle](https://github.com/handle). Paragraphs, not bullet lists —
+    a changelog is read, not parsed.
 
 Rules that earn their place:
 
@@ -26,9 +28,23 @@ Rules that earn their place:
   whole without reading the paragraph.
 - Something that was broken for everyone leads. Order by what it costs the
   reader, not by what it cost to build.
-- Link the issue or PR in the headline. An entry a reader cannot get from
-  the sentence to the change is a claim they have to take on faith.
-- Name outside contributors. They are why the thing got fixed.
+- Every entry links the PR (or PRs) that shipped it —
+  `[#123](https://github.com/azrtydxb/procoder/pull/123)` — not just the
+  issue. An entry that changed several PRs' worth of code links all of
+  them, the way 1.4.0's entries do. Link the tracking issue too when one
+  exists and the reader would otherwise have no way to find it.
+- Every outside contributor is named AND linked to their GitHub profile —
+  `[@handle](https://github.com/handle)`, never the bare @handle text,
+  which is not a link inside this file. This covers whoever reported it,
+  diagnosed it, or wrote the fix; being the reason something got looked
+  at is the bar, not having sent a PR. Filing the issue and nothing else
+  still earns the credit — say so plainly ("Reported by ...") rather than
+  folding a reporter into a sentence about the fix, which reads as if the
+  fixer noticed it unprompted.
+- Get the name right. A misattributed credit is worse than none — verify
+  who actually opened the issue or PR being cited (`gh issue view <n>`,
+  `gh pr view <n>`) before writing the handle, rather than recalling it
+  from memory or another entry's context.
 -->
 
 ## 1.4.0 — 2026-08-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Rules that earn their place:
   reader, not by what it cost to build.
 - Every entry links the PR (or PRs) that shipped it —
   `[#123](https://github.com/azrtydxb/procoder/pull/123)` — not just the
-  issue. An entry that changed several PRs' worth of code links all of
+  issue. An entry that spans several PRs' worth of change links all of
   them, the way 1.4.0's entries do. Link the tracking issue too when one
   exists and the reader would otherwise have no way to find it.
 - Every outside contributor is named AND linked to their GitHub profile —


### PR DESCRIPTION
## What

Tightens the two changelog authoring rules — "link the issue or PR" and "name outside contributors" — into what was actually meant.

- Every entry links every PR that shipped it (`[#123](.../pull/123)`), not just a tracking issue — matching how 1.4.0's multi-PR entries already work. The tracking issue is linked too when one exists and differs.
- Every outside contributor is a real markdown link to their GitHub profile — `[@handle](https://github.com/handle)` — never bare `@handle` text, which is not a link inside a plain `.md` file.
- Filing an issue with no code attached still earns credit. Say so plainly ("Reported by ...") rather than folding a reporter into a sentence about the fix, which reads as the fixer having noticed it unprompted.
- Verify the handle against the actual issue/PR (`gh issue view <n>`) before writing it.

## Why now

Writing this surfaced a real instance of the exact problem it prevents: the merged commit for #151 credits `@Acroaticum` for reporting #149. The actual reporter is `codixio` — `Acroaticum` opened the unrelated #148. I pulled the wrong handle from a nearby PR in the same working set instead of checking. Corrected on the issue itself; not rewriting the already-merged commit's history.