### PR TITLE
fix: the branch line honors the report's three-second budget

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -19,7 +19,6 @@ import (
 
 	"procoder/internal/backlog"
 	"procoder/internal/codeindex"
-	"procoder/internal/gitx"
 	"procoder/internal/lessons"
 	"procoder/internal/testrun"
 	"procoder/internal/todo"
@@ -131,8 +130,17 @@ func gitLines(ctx context.Context, root string) ([]string, string) {
 // branchLine names where the work is happening and how it stands against the
 // default branch. A detached HEAD and a rebase in progress are named, never
 // smoothed over into a branch name that is not true.
+//
+// currentBranch and defaultBranch below are reimplemented from gitx rather
+// than called from it: gitx.CurrentBranch and gitx.DefaultBranch take no
+// context, so a hung or slow git made this one line in the report run past
+// the wall the rest of it honours, with no note explaining why — the
+// deadline expired and the call was simply still running.
 func branchLine(ctx context.Context, root, gitDir string) string {
-	current := gitx.CurrentBranch(root)
+	current, err := currentBranch(ctx, root)
+	if err != nil {
+		return "branch: unknown — " + gitReason(err)
+	}
 	state := rebaseState(gitDir)
 	if current == "" {
 		at := shortHead(ctx, root)
@@ -141,19 +149,55 @@ func branchLine(ctx context.Context, root, gitDir string) string {
 		}
 		return "branch: detached HEAD at " + at + state
 	}
-	def := gitx.DefaultBranch(root)
+	def, err := defaultBranch(ctx, root)
+	if err != nil {
+		return "branch: " + current + state + " — default branch unknown — " + gitReason(err)
+	}
 	if def == "" {
 		return "branch: " + current + state + " — default branch unknown (no origin/HEAD, no main or master)"
 	}
 	if def == current {
 		return "branch: " + current + state + " — this is the default branch"
 	}
-	counts, err := git(ctx, root, "rev-list", "--left-right", "--count", def+"...HEAD")
+	counts, cerr := git(ctx, root, "rev-list", "--left-right", "--count", def+"...HEAD")
 	fields := strings.Fields(counts)
-	if err != nil || len(fields) != 2 {
-		return "branch: " + current + state + " — distance from " + def + " unknown (" + gitReason(err) + ")"
+	if cerr != nil || len(fields) != 2 {
+		return "branch: " + current + state + " — distance from " + def + " unknown (" + gitReason(cerr) + ")"
 	}
 	return fmt.Sprintf("branch: %s%s — %s ahead, %s behind %s", current, state, fields[1], fields[0], def)
+}
+
+// currentBranch is gitx.CurrentBranch under the report's deadline: the same
+// command, "" with a nil error for a legitimately detached HEAD — git exits
+// 0 with empty output for that — and a non-nil error only when the call
+// itself did not answer, which is what a plain "" could not tell apart from
+// detached.
+func currentBranch(ctx context.Context, root string) (string, error) {
+	return git(ctx, root, "branch", "--show-current")
+}
+
+// defaultBranch is gitx.DefaultBranch under the report's deadline: origin's
+// HEAD first, then the conventional names. It stops at the first candidate
+// that answers and keeps falling through on a plain miss — no origin
+// remote, no main, no master are all ordinary, negative-but-legitimate
+// answers, matching gitx.DefaultBranch exactly. The one thing it will not
+// do is spend the rest of the budget finding that out three times: once
+// ctx itself has expired, every remaining candidate fails the same way, so
+// it stops and reports why rather than trying them anyway.
+func defaultBranch(ctx context.Context, root string) (string, error) {
+	if ref, err := git(ctx, root, "symbolic-ref", "refs/remotes/origin/HEAD", "--short"); err == nil {
+		return strings.TrimPrefix(ref, "origin/"), nil
+	} else if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	for _, name := range []string{"main", "master"} {
+		if _, err := git(ctx, root, "rev-parse", "--verify", "refs/heads/"+name); err == nil {
+			return name, nil
+		} else if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+	}
+	return "", nil
 }
 
 // rebaseState names an in-progress rebase, the way git's own directories

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -333,9 +333,46 @@ func TestAGitCallThatDidNotAnswerIsNotACleanTree(t *testing.T) {
 		t.Errorf("a directory that is not a repository is unknown: %q", e)
 	}
 
-	// branchLine is deliberately NOT asserted here: it reaches git through
-	// gitx.CurrentBranch and gitx.DefaultBranch, which take no context, so
-	// it answers whatever the deadline says. That is a real gap in the
-	// budget rather than a property worth pinning — filed separately, and
-	// asserting it here would pin the gap in place.
+	// branchLine takes the same deadline now too — the gap #145 filed and
+	// this test used to name rather than assert.
+	gitDir := filepath.Join(root, ".git")
+	b := branchLine(ctx, root, gitDir)
+	if !strings.Contains(b, "unknown") {
+		t.Errorf("branch must be unknown when git did not answer: %q", b)
+	}
+	if !strings.Contains(b, "—") {
+		t.Errorf("unknown must carry the reason: %q", b)
+	}
+}
+
+// currentBranch and defaultBranch are what closed #145: gitx.CurrentBranch
+// and gitx.DefaultBranch take no context, so branchLine answered whatever a
+// hung or slow git said, past the report's own deadline, with no note
+// explaining why. Each is asserted directly, because branchLine only
+// reaches defaultBranch once currentBranch has already succeeded — a
+// cancelled context from the start proves currentBranch's awareness and
+// nothing about defaultBranch's.
+// proved by: swallowing ctx.Err() and returning "", nil the way
+// gitx.CurrentBranch and gitx.DefaultBranch do — both report a legitimate
+// negative (detached HEAD, no default branch) instead of the timeout that
+// actually happened.
+func TestBranchLookupsHonourTheDeadline(t *testing.T) {
+	requireGit(t)
+	root := gitRepo(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := currentBranch(ctx, root); err == nil {
+		t.Error("currentBranch must report why it could not answer, not silently \"\"")
+	}
+	if _, err := defaultBranch(ctx, root); err == nil {
+		t.Error("defaultBranch must report why it could not answer, not silently \"\"")
+	}
+
+	// And working git untouched: a live context still gets the real
+	// branch back, so the deadline check is not swallowing good answers.
+	if got, err := currentBranch(context.Background(), root); err != nil || got != "main" {
+		t.Errorf("a live context must still resolve the real branch: %q %v", got, err)
+	}
 }


### PR DESCRIPTION
Fixes #145.

## Bug

`status.Report` advertises a hard 3-second budget and drops state with a note when it expires. `dirtyLine` and `headLine` already honor it, answering `unknown — <reason>` under a cancelled context. `branchLine` didn't — it reached git through `gitx.CurrentBranch`/`gitx.DefaultBranch`, neither of which takes a context, so a hung or slow git made this one line run past the wall the rest of the report honors, with no note explaining why.

## Fix

Reimplemented locally in `status.go` rather than threading a context through `gitx`'s public API — `gitx.CurrentBranch`/`DefaultBranch` have five other callers (`backlog`, `docs`, `gitcmd`, `ciops`), none budget-constrained, and changing the signature would have forced a context onto all of them for nothing. `currentBranch`/`defaultBranch` mirror the originals exactly, using status's own local, context-aware `git()`.

`defaultBranch`'s three sequential candidates needed care: a plain miss on any one (no configured remote, repo uses `main` not `master`) is a legitimate, common answer and must keep falling through — only `ctx.Err()` stops the search, so a real "no default branch" is never mistaken for a timeout and vice versa.

## Verification

Both new functions asserted directly with a cancelled context — `branchLine` only reaches `defaultBranch` once `currentBranch` has already succeeded, so testing `branchLine` alone would only prove the first. Both mutations proven failing (swallowing `ctx.Err()` the way `gitx` does).