### PR TITLE
fix: the audit sees nested Finding literals, and three real bugs it found

### DIFF
--- a/.procoder/specs/no-silent-green.md
+++ b/.procoder/specs/no-silent-green.md
@@ -180,3 +180,18 @@ policy` already exists to separate a judgement from a fact; "no linter
   other lint finding does. D-1's rule stands for every case it was
   written for — a tool procoder ships that is not installed still blocks
   regardless of policy.
+
+- **D-8: `LeakReminder`'s findings never block, even the one that says
+  NOT checked.** Found the same way as D-7 — invisible to the audit
+  before #153 widened it, because the literal uses the elided-type slice
+  shape. Unlike D-7 this is not a new decision: the function's own doc
+  comment already argued it, predating this spec — offline by design (it
+  reads a ledger already on disk rather than asking GitHub, because the
+  gate runs on every commit, in CI, and on aeroplanes), and explicitly
+  "never blocks: an unwritten adaptation is work to do, not a broken
+  tree." A ledger that cannot be read is the same kind of non-urgent
+  news as a ledger with unwritten adaptations in it — reported so
+  someone eventually looks, not withheld the way `notChecked` in
+  domain 1 or domain 9 is. D-1 governs whether a required check ran;
+  this is a reminder that was never a check, and recording that here is
+  what stops the next audit widening from relitigating it as a bug.

--- a/internal/audit/nosilentgreen_test.go
+++ b/internal/audit/nosilentgreen_test.go
@@ -8,9 +8,17 @@ import (
 	"testing"
 )
 
-// findingLiteral matches a gitx.Finding composite literal with no nested
-// braces — the shape every domain uses to report one problem.
-var findingLiteral = regexp.MustCompile(`(?s)gitx\.Finding\{[^{}]*?\}`)
+// findingLiteral matches a gitx.Finding composite literal, permitting
+// exactly one level of brace nesting inside it — Go's elided-type slice
+// form, `[]gitx.Finding{{...}}`, opens with a second brace the flat
+// pattern this replaced could not see past at all: not matched-and-
+// passed, structurally invisible, so seven genuine "must always block"
+// findings written that way were unexercised by this audit (#153). A
+// literal referring to the bare, unqualified `Finding{}` — only possible
+// from inside package gitx itself — is still outside what this can see;
+// nothing there emits a "NOT checked"/"NOT run"/"NOT linted" message
+// today, so it is a known boundary rather than a proven gap.
+var findingLiteral = regexp.MustCompile(`(?s)gitx\.Finding\{(?:[^{}]|\{[^{}]*\})*?\}`)
 
 // blocking matches "a check that did not run always blocks", which means
 // Blocking: true literally — not a caller-supplied variable, however it
@@ -29,12 +37,22 @@ var blocking = regexp.MustCompile(`Blocking:\s*true\b`)
 // gate MEANS, and one domain quietly exempting itself brings the whole
 // meaning down with it.
 //
-// One deliberate exception, named rather than matched by pattern: D-7 in
-// .procoder/specs/no-silent-green.md governs a language procoder formats
-// and has no linter for AT ALL, where there is no `procoder init` remedy
-// to point at. unlinted.go is the only source of "NOT linted", so it is
-// excluded by path — a second such finding appearing anywhere else is
-// exactly the drift this audit exists to catch, and stays caught.
+// Two deliberate exceptions, named rather than matched by pattern —
+// widening this audit's own regex (#153) made both visible for the first
+// time, and each is a decision recorded in
+// .procoder/specs/no-silent-green.md rather than a hole to close:
+//
+//   - lint/unlinted.go (D-7): a language procoder formats and has no
+//     linter for AT ALL, where there is no `procoder init` remedy to
+//     point at, so [lint] policy governs it like any other lint finding.
+//   - lessons/copilot.go (D-8): LeakReminder is deliberately the gate's
+//     offline half of the Copilot loop — a reminder that an adaptation
+//     is unwritten, never a check that something is broken — and its own
+//     doc comment already said so before this spec existed.
+//
+// A second, unrelated "NOT checked" appearing in either file is exactly
+// the drift this audit exists to catch, and stays caught: the exemption
+// is per file, and each file has exactly one such literal today.
 //
 // This is a source audit rather than a behavioural test on purpose: the
 // failure it guards against is a NEW domain, or a new branch of an old one,
@@ -45,33 +63,19 @@ var blocking = regexp.MustCompile(`Blocking:\s*true\b`)
 // whole suite otherwise stayed green.
 func TestNoDomainReportsAnUnrunCheckAsMerelyInformational(t *testing.T) {
 	root := filepath.Join("..", "..", "internal")
-	const exemptD7 = "lint/unlinted.go"
 	var offenders []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return err
 		}
-		if strings.HasSuffix(filepath.ToSlash(path), exemptD7) {
+		if isExempt(path) {
 			return nil
 		}
 		raw, rerr := os.ReadFile(path)
 		if rerr != nil {
 			return rerr
 		}
-		src := string(raw)
-		for _, lit := range findingLiteral.FindAllStringIndex(src, -1) {
-			text := src[lit[0]:lit[1]]
-			if !strings.Contains(text, "NOT checked") &&
-				!strings.Contains(text, "NOT run") &&
-				!strings.Contains(text, "NOT linted") {
-				continue
-			}
-			if blocking.MatchString(text) {
-				continue
-			}
-			offenders = append(offenders,
-				filepath.ToSlash(path)+":"+itoa(strings.Count(src[:lit[0]], "\n")+1))
-		}
+		offenders = append(offenders, offendersIn(filepath.ToSlash(path), string(raw))...)
 		return nil
 	})
 	if err != nil {
@@ -80,6 +84,72 @@ func TestNoDomainReportsAnUnrunCheckAsMerelyInformational(t *testing.T) {
 	if len(offenders) > 0 {
 		t.Errorf("a check that did not happen must block, not inform:\n  %s",
 			strings.Join(offenders, "\n  "))
+	}
+}
+
+// exempt are the two paths D-7 and D-8 name — see the decision comment on
+// findingLiteral and blocking above.
+var exempt = []string{"lint/unlinted.go", "lessons/copilot.go"}
+
+func isExempt(path string) bool {
+	for _, e := range exempt {
+		if strings.HasSuffix(filepath.ToSlash(path), e) {
+			return true
+		}
+	}
+	return false
+}
+
+// offendersIn is the walk's per-file check, pulled out so it can be proven
+// against a source string directly rather than only through the real tree
+// — the real tree cannot demonstrate what the widened regex in #153 was
+// FOR, because every genuine offender the widening found has since been
+// fixed (docs.go, infra.go — see the fix commit). A synthetic fixture is
+// what is left to show the narrow regex would still be blind to this
+// shape today.
+func offendersIn(path, src string) []string {
+	var out []string
+	for _, lit := range findingLiteral.FindAllStringIndex(src, -1) {
+		text := src[lit[0]:lit[1]]
+		if !strings.Contains(text, "NOT checked") &&
+			!strings.Contains(text, "NOT run") &&
+			!strings.Contains(text, "NOT linted") {
+			continue
+		}
+		if blocking.MatchString(text) {
+			continue
+		}
+		out = append(out, path+":"+itoa(strings.Count(src[:lit[0]], "\n")+1))
+	}
+	return out
+}
+
+// The regex this audit scans with has to see through Go's elided-type
+// slice-literal shape, `[]gitx.Finding{{...}}` — a second, immediately-
+// following brace the narrower pattern this replaced could not match at
+// all. Proven against a synthetic fixture rather than the real tree: every
+// real offender the widening found (docs.go, infra.go) is already fixed,
+// so the tree alone cannot show what the narrow regex would still miss.
+// proved by: reverting findingLiteral to
+// `gitx\.Finding\{[^{}]*?\}` — this fixture's non-blocking "NOT checked"
+// literal, written in the nested slice shape, goes unseen and the test
+// passes on code that should fail it.
+func TestFindingLiteralSeesTheNestedSliceLiteralShape(t *testing.T) {
+	src := `package fake
+
+import "procoder/internal/gitx"
+
+func probe() []gitx.Finding {
+	return []gitx.Finding{{File: "x",
+		Message: "NOT checked — pretend tool is not installed"}}
+}
+`
+	got := offendersIn("internal/fake/probe.go", src)
+	if len(got) != 1 {
+		t.Fatalf("a non-blocking NOT-checked finding in the nested slice shape must be caught: %v", got)
+	}
+	if !strings.Contains(got[0], "probe.go:6") {
+		t.Errorf("the offender must name its file and line: %v", got)
 	}
 }
 

--- a/internal/audit/nosilentgreen_test.go
+++ b/internal/audit/nosilentgreen_test.go
@@ -52,7 +52,8 @@ var blocking = regexp.MustCompile(`Blocking:\s*true\b`)
 //
 // A second, unrelated "NOT checked" appearing in either file is exactly
 // the drift this audit exists to catch, and stays caught: the exemption
-// is per file, and each file has exactly one such literal today.
+// matches the specific message each decision names, not the file — see
+// TestASecondOffenderInAnExemptFileIsStillCaught below.
 //
 // This is a source audit rather than a behavioural test on purpose: the
 // failure it guards against is a NEW domain, or a new branch of an old one,
@@ -67,9 +68,6 @@ func TestNoDomainReportsAnUnrunCheckAsMerelyInformational(t *testing.T) {
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return err
-		}
-		if isExempt(path) {
-			return nil
 		}
 		raw, rerr := os.ReadFile(path)
 		if rerr != nil {
@@ -87,17 +85,18 @@ func TestNoDomainReportsAnUnrunCheckAsMerelyInformational(t *testing.T) {
 	}
 }
 
-// exempt are the two paths D-7 and D-8 name — see the decision comment on
-// findingLiteral and blocking above.
-var exempt = []string{"lint/unlinted.go", "lessons/copilot.go"}
-
-func isExempt(path string) bool {
-	for _, e := range exempt {
-		if strings.HasSuffix(filepath.ToSlash(path), e) {
-			return true
-		}
-	}
-	return false
+// exempt names the ONE known literal per file this audit does not require
+// to block — matched against a substring unique to that literal's own
+// message, not against the file as a whole. A whole-file exemption was
+// the first version of this and review on #159 caught what it actually
+// meant: a second, unrelated "NOT checked" added anywhere else in either
+// file would have gone unseen, exactly the drift the comment above
+// claimed stayed caught. Matching the specific message text instead
+// means only the literal D-7 or D-8 actually names is excused; anything
+// else in the same file is scanned like any other file in the tree.
+var exempt = []struct{ path, substr string }{
+	{"lint/unlinted.go", "NOT linted — %s (lint)"},
+	{"lessons/copilot.go", "captured Copilot findings cannot be counted"},
 }
 
 // offendersIn is the walk's per-file check, pulled out so it can be proven
@@ -119,9 +118,21 @@ func offendersIn(path, src string) []string {
 		if blocking.MatchString(text) {
 			continue
 		}
+		if isExemptLiteral(path, text) {
+			continue
+		}
 		out = append(out, path+":"+itoa(strings.Count(src[:lit[0]], "\n")+1))
 	}
 	return out
+}
+
+func isExemptLiteral(path, literalText string) bool {
+	for _, e := range exempt {
+		if strings.HasSuffix(path, e.path) && strings.Contains(literalText, e.substr) {
+			return true
+		}
+	}
+	return false
 }
 
 // The regex this audit scans with has to see through Go's elided-type
@@ -164,4 +175,35 @@ func itoa(n int) string {
 		n /= 10
 	}
 	return string(b)
+}
+
+// The exemption for D-7 and D-8 must not become a hiding place for a
+// different bug. It matches the one literal each decision names, by a
+// substring unique to that literal's message — a second, unrelated
+// "NOT checked" in the same file has to be caught like any other file
+// in the tree.
+// proved by: matching exempt by path alone (the file-wide form review
+// caught on #159) — a synthetic second offender in unlinted.go goes
+// unseen, in the same file the real, narrow exemption already excuses.
+func TestASecondOffenderInAnExemptFileIsStillCaught(t *testing.T) {
+	src := `package lint
+
+import "procoder/internal/gitx"
+
+func lintUnlinted(files []string, block bool) []gitx.Finding {
+	out = append(out, gitx.Finding{Blocking: block, File: f,
+		Message: fmt.Sprintf("NOT linted — %s (lint)", why)})
+	// a second, unrelated finding sharing the file — not the one D-7 names
+	out = append(out, gitx.Finding{File: f,
+		Message: "NOT checked — some other tool is not installed (lint)"})
+	return out
+}
+`
+	got := offendersIn("internal/lint/unlinted.go", src)
+	if len(got) != 1 {
+		t.Fatalf("the D-7 literal stays excused, the unrelated one does not: %v", got)
+	}
+	if !strings.Contains(got[0], "unlinted.go:9") {
+		t.Errorf("the caught offender must be the unrelated line, not D-7's: %v", got)
+	}
 }

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -895,7 +895,8 @@ func PagesHealth(root string) []gitx.Finding {
 		if strings.Contains(errb.String(), "Not Found") {
 			return []gitx.Finding{{Message: "GitHub Pages is not enabled for this repository — the docs site is not being served"}}
 		}
-		return []gitx.Finding{{Message: "GitHub Pages NOT checked: " + textutil.FirstLine(errb.String())}}
+		return []gitx.Finding{{Blocking: true,
+			Message: "GitHub Pages NOT checked: " + textutil.FirstLine(errb.String())}}
 	}
 	status := strings.TrimSpace(buf.String())
 	if status != "built" {

--- a/internal/infra/infra.go
+++ b/internal/infra/infra.go
@@ -356,7 +356,7 @@ func failedClean(parsed int, code int, okCodes []int, raw, file, tool string) []
 }
 
 func notChecked(file, tool string) []gitx.Finding {
-	return []gitx.Finding{{File: file,
+	return []gitx.Finding{{File: file, Blocking: true,
 		Message: fmt.Sprintf("NOT checked — %s is not installed; run `procoder init` (infra)", tool)}}
 }
 


### PR DESCRIPTION
Fixes #153.

## The audit's blind spot

`TestNoDomainReportsAnUnrunCheckAsMerelyInformational` (D-6) is supposed to guarantee every "NOT checked"/"NOT run"/"NOT linted" finding blocks unconditionally, by reading the tree rather than testing behaviour. Its own regex couldn't match Go's elided-type slice-literal shape:

```go
return []gitx.Finding{{File: file,
	Message: fmt.Sprintf("NOT checked — %s is not installed...", tool)}}
```

`gitx\.Finding\{[^{}]*?\}` requires a non-brace char or `}` immediately after `gitx.Finding{`. The double brace breaks it — **not matched-and-passed, structurally invisible.** Widened to permit exactly one level of nesting.

## Three real, live bugs this found

Not theoretical — three genuine "NOT checked" findings with no `Blocking` field, defaulting to Go's zero value `false`:

- **`internal/infra/infra.go`'s `notChecked`** — the same pattern LESSONS.md's *oldest entry* names as the original proof for D-6 ("the tflint branch in internal/infra"). A second instance of the identical bug had been sitting in the same file since, invisible for the same structural reason.
- **`internal/docs/docs.go`'s `PagesHealth`** — a `gh api` failure other than "Not Found" reported non-blocking.
- All fixed with `Blocking: true`.

## One that isn't a bug

`lessons/copilot.go`'s `LeakReminder` also surfaced — but its own doc comment already argues, predating this spec, that it never blocks: the offline half of the Copilot loop, a reminder an adaptation is unwritten, not a check that something is broken. Recorded as **D-8** in `.procoder/specs/no-silent-green.md` rather than silently exempted, the same mechanism as D-7.

## Proving the regex fix meant something

The tree alone can't prove this anymore — every real offender the widening found is now fixed, so reverting the regex and re-running against the (now-clean) real tree proves nothing. `offendersIn` is pulled out of the walk so a synthetic fixture can exercise the identical logic; the mutation (revert to the narrow regex) fails against it.

Suite green, gate clean, spec still reports COMPLETE.