### PR TITLE
backlog: the planning epic opens over fourteen stories

### DIFF
--- a/.procoder/backlog/epics/planning-methodology.md
+++ b/.procoder/backlog/epics/planning-methodology.md
@@ -1,0 +1,25 @@
+# planning-methodology
+
+Status: open
+Created: 2026-08-24
+Spec: planning-methodology @ 86cabf0d9508
+
+## Description
+
+Procoder learns the half it never built — planning — and lets a
+repository opt out of that half entirely in favour of the tool that
+already does it well.
+
+Track 1 grows the capability in procoder's own code: a multi-lens
+review that applies judgment where the gate only applies tooling, an
+analysis phase for reaching a spec worth checking, perspectives as
+review stances, and right-sizing that names which entry point a change
+belongs at. Track 2 lets a repository set `[planning] method = "bmad"`
+and have procoder validate BMad's artifacts instead of demanding its
+own, with the governance backbone untouched.
+
+One epic, because the boundary is the point: every capability track 1
+adds is one track 2 must not duplicate, and the two only stay coherent
+while somebody is holding both. Either track can ship first.
+
+Seeded from .procoder/specs/planning-methodology.md — one story per acceptance criterion.

--- a/.procoder/backlog/stories/20260824-a-repository-carrying-procoder-review-lenses-adversarial-md.md
+++ b/.procoder/backlog/stories/20260824-a-repository-carrying-procoder-review-lenses-adversarial-md.md
@@ -1,0 +1,28 @@
+# A repository carrying `.procoder/review/lenses/adversarial.md` gets that content in place of the shipped lens; without the file it gets the shipped one unchanged.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+D-OVERRIDE, applied to review like every other domain: a repository that
+disagrees with a lens replaces it, without forking procoder or giving up
+the other four.
+
+Done means the override file's content appears in place of the shipped
+lens, and a repository without the file gets the shipped one
+unchanged.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A repository carrying `.procoder/review/lenses/adversarial.md` gets that content in place of the shipped lens; without the file it gets the shipped one unchanged.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-a-sprint-status-yaml-that-will-not-parse-produces-a.md
+++ b/.procoder/backlog/stories/20260824-a-sprint-status-yaml-that-will-not-parse-produces-a.md
@@ -1,0 +1,27 @@
+# A `sprint-status.yaml` that will not parse produces a blocking finding naming the file, distinct from the finding for one that is absent.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+Unreadable and absent are different answers, and only one of them is the
+repository's choice. A parse failure reported as "no sprint yet" sends
+somebody to plan work that is already planned.
+
+Done means the unparseable case blocks and names the file, distinct from
+the finding for a repository that has not planned anything.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A `sprint-status.yaml` that will not parse produces a blocking finding naming the file, distinct from the finding for one that is absent.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-a-status-in-sprint-status-yaml-that-procoder-does-not.md
+++ b/.procoder/backlog/stories/20260824-a-status-in-sprint-status-yaml-that-procoder-does-not.md
@@ -1,0 +1,27 @@
+# A status in `sprint-status.yaml` that procoder does not recognise is reported by name rather than mapped to a procoder status.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+BMad owns its status vocabulary and may extend it. Mapping an unknown
+status to the nearest procoder equivalent — deciding `blocked` is close
+enough to `open` — is how a status machine quietly loses a state, and the
+report then misrepresents work nobody can see is misrepresented.
+
+Done means an unrecognised status is reported by name.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] A status in `sprint-status.yaml` that procoder does not recognise is reported by name rather than mapped to a procoder status.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-an-empty-procoder-review-lenses-adversarial-md-blocks-and.md
+++ b/.procoder/backlog/stories/20260824-an-empty-procoder-review-lenses-adversarial-md-blocks-and.md
@@ -1,0 +1,27 @@
+# An empty `.procoder/review/lenses/adversarial.md` blocks and names the file rather than falling back to the shipped lens, exiting 1 — a lens that could not load is a refusal, and a review that did not happen must not exit 0.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+Falling back to the shipped lens when an override cannot be read would
+mean a repository believing it replaced a lens that is still running
+procoder's version — a silent green wearing a config file.
+
+Done means an empty or unreadable override blocks, names the file, and
+exits 1. A review that did not happen must not exit 0.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] An empty `.procoder/review/lenses/adversarial.md` blocks and names the file rather than falling back to the shipped lens, exiting 1 — a lens that could not load is a refusal, and a review that did not happen must not exit 0.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
+++ b/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
@@ -1,0 +1,29 @@
+# No procoder-owned feature name contains "BMad", asserted by an audit over the source and the command table, so the trademark boundary cannot erode by accident.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+"BMad" and "BMAD-METHOD" are trademarks of BMad Code, LLC. Naming BMad to
+describe interoperation — a setting value, a doctor line, a sentence in
+the docs — is fine. Naming a procoder feature after it is not, and that
+boundary erodes by accident rather than by decision: someone adds
+`procoder bmad-sync` because it is the clearest name available.
+
+Done means an audit over the source and the command table catches it, so
+the boundary is held by a test rather than by everyone remembering.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] No procoder-owned feature name contains "BMad", asserted by an audit over the source and the command table, so the trademark boundary cannot erode by accident.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-planning-method-bmad-with-a-fixture-bmad-install-reports.md
+++ b/.procoder/backlog/stories/20260824-planning-method-bmad-with-a-fixture-bmad-install-reports.md
@@ -1,0 +1,27 @@
+# `[planning] method = "bmad"` with a fixture BMad install reports sprint state from `sprint-status.yaml`, with each story's status, and does not report from `.procoder/backlog/`.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+The whole promise of track 2. A repository that plans in BMad should see
+its own sprint reflected back by procoder, not an empty procoder backlog
+next to a BMad one that is actually being worked.
+
+Done means sprint state comes from `sprint-status.yaml` with each story's
+status, and `.procoder/backlog/` is not the source.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `[planning] method = "bmad"` with a fixture BMad install reports sprint state from `sprint-status.yaml`, with each story's status, and does not report from `.procoder/backlog/`.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-planning-method-bmad-with-no-bmad-installed-produces-a.md
+++ b/.procoder/backlog/stories/20260824-planning-method-bmad-with-no-bmad-installed-produces-a.md
@@ -1,0 +1,28 @@
+# `[planning] method = "bmad"` with no BMad installed produces a blocking finding naming both the setting and the missing installation.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+Silently falling back to procoder's own chain would leave a repository
+believing BMad governs its planning while procoder quietly governed it
+instead — and the first they would learn of it is a report that does not
+match the artifacts on disk.
+
+Done means the mismatch is named: a blocking finding citing both the
+setting and the missing installation.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `[planning] method = "bmad"` with no BMad installed produces a blocking finding naming both the setting and the missing installation.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-planning-method-nonsense-is-a-config-problem-naming-the.md
+++ b/.procoder/backlog/stories/20260824-planning-method-nonsense-is-a-config-problem-naming-the.md
@@ -1,0 +1,28 @@
+# `[planning] method = "nonsense"` is a config Problem naming the line, and the run continues on the default.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+Every other key in config.toml names the line when its value means
+nothing, because a writer who mistypes a setting believes it is set. This
+one is no different, and it is more consequential than most: a typo here
+silently decides which methodology governs the repository.
+
+Done means an unrecognised value is a Problem naming the line, and the
+run continues on the default.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `[planning] method = "nonsense"` is a config Problem naming the line, and the run continues on the default.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-procoder-analyze-check-refuses-a-hollow-analysis-document-a.md
+++ b/.procoder/backlog/stories/20260824-procoder-analyze-check-refuses-a-hollow-analysis-document-a.md
@@ -1,0 +1,28 @@
+# `procoder analyze check` refuses a hollow analysis document — a section left as its template comment is not a filled section — and passes a filled one.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+The analysis phase is only worth having if its documents are worth
+reading. A brief whose sections are still template comments has recorded
+nothing, and passing it would make the phase a formality that costs time
+and buys nothing.
+
+Done means `analyze check` refuses a hollow document the way `spec check`
+already refuses a hollow spec — same standard, same reason.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder analyze check` refuses a hollow analysis document — a section left as its template comment is not a filled section — and passes a filled one.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-procoder-doctor-under-method-bmad-names-bmad-s-installed.md
+++ b/.procoder/backlog/stories/20260824-procoder-doctor-under-method-bmad-names-bmad-s-installed.md
@@ -1,0 +1,28 @@
+# `procoder doctor` under `method = "bmad"` names BMad's installed version, and says plainly that it is absent when it is.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+A repository whose planning depends on a tool procoder does not ship
+needs to know that tool is there, and which version — because BMad's
+artifact layout is what procoder reads, and a layout change is a version
+fact.
+
+Done means doctor names the installed version, and says plainly that it
+is absent when it is.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder doctor` under `method = "bmad"` names BMad's installed version, and says plainly that it is absent when it is.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-procoder-review-lens-edge-case-prints-exactly-that-lens-and.md
+++ b/.procoder/backlog/stories/20260824-procoder-review-lens-edge-case-prints-exactly-that-lens-and.md
@@ -1,0 +1,28 @@
+# `procoder review --lens edge-case` prints exactly that lens and exits 0; an unrecognised name reports the name, prints no lens at all, and exits 2 — a usage error, not a finding.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+A full review is the default, but a reader who already knows what they
+are worried about should be able to ask one question rather than five.
+
+Done means `--lens` selects, exits 0 when it resolved, and treats an
+unrecognised name as a usage error — reported by name, nothing printed,
+exit 2 — rather than silently running the other four and leaving the
+reader believing they got the lens they asked for.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder review --lens edge-case` prints exactly that lens and exits 0; an unrecognised name reports the name, prints no lens at all, and exits 2 — a usage error, not a finding.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-procoder-review-over-a-fixture-diff-prints-all-five-lenses.md
+++ b/.procoder/backlog/stories/20260824-procoder-review-over-a-fixture-diff-prints-all-five-lenses.md
@@ -1,0 +1,31 @@
+# `procoder review` over a fixture diff prints all five lenses with the content in scope, and leaves every file's bytes unchanged, asserted by comparing a digest of the tree before and after.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+The gate reads formatting, secrets, linters and hygiene — every one of
+them mechanical. Nothing in procoder applies judgment to a change, so
+whether anyone asks "is this the right shape, what breaks at the edges"
+depends on who happens to be looking.
+
+Done means `procoder review` exists and prints all five lenses over the
+content in scope, for the agent to judge. And it writes nothing: the
+binary prints, the agent decides — the same contract `procoder format`
+already holds, asserted by comparing a digest of the tree before and
+after.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder review` over a fixture diff prints all five lenses with the content in scope, and leaves every file's bytes unchanged, asserted by comparing a digest of the tree before and after.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-procoder-spec-check-names-the-analysis-document-a-spec-came.md
+++ b/.procoder/backlog/stories/20260824-procoder-spec-check-names-the-analysis-document-a-spec-came.md
@@ -1,0 +1,28 @@
+# `procoder spec check` names the analysis document a spec came from when one exists, and does not require one when it does not.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+The point of the analysis phase is that a spec comes from somewhere. A
+reader asking why a spec says what it says should be able to follow the
+link back, without the chain becoming a new tollgate for people who
+already know what they are building.
+
+Done means `spec check` names the analysis document when one exists and
+stays silent when none does — analysis is available, never required.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] `procoder spec check` names the analysis document a spec came from when one exists, and does not require one when it does not.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->

--- a/.procoder/backlog/stories/20260824-under-method-bmad-procoder-check-produces-byte-identical.md
+++ b/.procoder/backlog/stories/20260824-under-method-bmad-procoder-check-produces-byte-identical.md
@@ -1,0 +1,28 @@
+# Under `method = "bmad"`, `procoder check` produces byte-identical output to the same tree under `method = "procoder"`, asserted on a fixture — the setting governs planning and nothing else.
+
+Status: open
+Created: 2026-08-24
+Epic: planning-methodology
+Sprint: -
+
+## Description
+
+The seam this whole track rests on: planning moves, governance does not.
+It is the only reason a BMad repository would install procoder at all, and
+the tempting design — a spectrum where the setting dials procoder back by
+degrees — erodes it one exception at a time.
+
+Done means the gate's output is byte-identical across the setting on a
+fixture, so the seam cannot drift without a test going red.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [ ] Under `method = "bmad"`, `procoder check` produces byte-identical output to the same tree under `method = "procoder"`, asserted on a fixture — the setting governs planning and nothing else.
+
+## Evidence
+
+<!-- Filled at close time: the commands run and what their output proved,
+     one line per criterion. Empty evidence keeps the story open. -->


### PR DESCRIPTION
Seeds `.procoder/backlog/` from the spec merged in #161 — one story per acceptance criterion, pinned to the spec's fingerprint.

## Descriptions written up front

Sprint 011's close was **refused** because all thirteen stories still had the template comment as their Description — found at the moment I was trying to close them, the worst moment to learn a story never said who needed it or why. Its retro says write them up front. This is the first seeding since, so this is where that either holds or doesn't.

## The fourteen, by track

**Track 1 — procoder's own capability (6)**
- `procoder review` prints all five lenses, writes nothing
- `--lens` selects; unknown name is a usage error (exit 2)
- lens override replaces the shipped one
- empty override blocks rather than falling back (exit 1)
- `analyze check` refuses a hollow document
- `spec check` names the analysis a spec came from, without requiring one

**Track 2 — the BMad passthrough (7)**
- `method = "bmad"` with no install → blocking finding naming both
- reads sprint state from `sprint-status.yaml`, not `.procoder/backlog/`
- unparseable status file blocks, distinct from absent
- unrecognised status reported by name, never mapped
- mistyped value is a config Problem naming the line
- **`procoder check` byte-identical across the setting** — the seam this track rests on
- `doctor` names BMad's installed version

**The boundary (1)**
- an audit asserts no procoder-owned feature name contains "BMad" — that line erodes by accident, when someone picks the clearest available name for a new command, not by decision

## Note

Formatted with an idempotency check this time — a backtick spanning a line break made prettier oscillate on #161, so each file is verified stable rather than just formatted once.