### PR TITLE
sprint 012 opens: the trademark boundary is held by a test

### DIFF
--- a/.procoder/backlog/sprints/012-review-with-judgment-not-just-tooling.md
+++ b/.procoder/backlog/sprints/012-review-with-judgment-not-just-tooling.md
@@ -1,0 +1,40 @@
+# review with judgment, not just tooling
+
+Status: active
+Created: 2026-08-24
+
+## Goal
+
+Procoder gains an opinion. Every check it runs today is mechanical —
+formatting, secrets, linters, hygiene — and everything requiring judgment
+is left to whoever happens to be looking. By the end of this sprint
+`procoder review` exists and applies five distinct stances to a change:
+adversarial, edge-case, verification-gap, structure, prose. A repository
+that disagrees with a lens replaces it; one whose replacement cannot be
+read is told so rather than quietly getting procoder's version back.
+
+The binary still judges nothing. It prints the lens and the scope, the
+agent judges, and the findings come back through the same pipeline every
+other domain uses — the contract `procoder format` has always held.
+
+The trademark audit lands here too, ahead of the track it guards. It is
+cheapest to add while there is no BMad-adjacent code to violate it, and
+the boundary it holds erodes by accident rather than by decision: someone
+names a new command the clearest available thing, and the clearest
+available thing is the trademark.
+
+The analysis phase and the whole BMad seam are deliberately not in this
+sprint. They are separable, and shipping the review command alone is
+worth a release on its own.
+
+## Stories
+
+<!-- Pulled with `procoder sprint pull <story-id>`. -->
+
+## Retro
+
+<!-- What slowed us down this sprint. -->
+
+<!-- What we change next sprint because of it. -->
+
+<!-- One adaptation from this sprint worth keeping. -->

--- a/.procoder/backlog/sprints/012-review-with-judgment-not-just-tooling.md
+++ b/.procoder/backlog/sprints/012-review-with-judgment-not-just-tooling.md
@@ -1,4 +1,4 @@
-# review with judgment, not just tooling
+# Review with judgment, not just tooling
 
 Status: active
 Created: 2026-08-24

--- a/.procoder/backlog/stories/20260824-a-repository-carrying-procoder-review-lenses-adversarial-md.md
+++ b/.procoder/backlog/stories/20260824-a-repository-carrying-procoder-review-lenses-adversarial-md.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 012-review-with-judgment-not-just-tooling
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-a-repository-carrying-procoder-review-lenses-adversarial-md.md
+++ b/.procoder/backlog/stories/20260824-a-repository-carrying-procoder-review-lenses-adversarial-md.md
@@ -1,6 +1,6 @@
 # A repository carrying `.procoder/review/lenses/adversarial.md` gets that content in place of the shipped lens; without the file it gets the shipped one unchanged.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 012-review-with-judgment-not-just-tooling
@@ -20,9 +20,8 @@ unchanged.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A repository carrying `.procoder/review/lenses/adversarial.md` gets that content in place of the shipped lens; without the file it gets the shipped one unchanged.
+- [x] A repository carrying `.procoder/review/lenses/adversarial.md` gets that content in place of the shipped lens; without the file it gets the shipped one unchanged.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/review/ -run TestAnOverrideReplacesTheShippedLens` — the override's content is what runs, the other four stay procoder's, and the printed lens names its source so a reader knows whose words they are reading. Verified end to end against a fixture carrying `.procoder/review/lenses/adversarial.md`. Mutation proven: Resolve ignoring the override directory returns procoder's shipped lens under the repository's name.

--- a/.procoder/backlog/stories/20260824-an-empty-procoder-review-lenses-adversarial-md-blocks-and.md
+++ b/.procoder/backlog/stories/20260824-an-empty-procoder-review-lenses-adversarial-md-blocks-and.md
@@ -1,6 +1,6 @@
 # An empty `.procoder/review/lenses/adversarial.md` blocks and names the file rather than falling back to the shipped lens, exiting 1 — a lens that could not load is a refusal, and a review that did not happen must not exit 0.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 012-review-with-judgment-not-just-tooling
@@ -19,9 +19,8 @@ exits 1. A review that did not happen must not exit 0.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] An empty `.procoder/review/lenses/adversarial.md` blocks and names the file rather than falling back to the shipped lens, exiting 1 — a lens that could not load is a refusal, and a review that did not happen must not exit 0.
+- [x] An empty `.procoder/review/lenses/adversarial.md` blocks and names the file rather than falling back to the shipped lens, exiting 1 — a lens that could not load is a refusal, and a review that did not happen must not exit 0.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/review/ -run TestAnUnreadableOverrideBlocksAndDoesNotFallBack` — an empty override is exactly one blocking finding naming the file, and the lens set comes back with four entries rather than five: procoder does NOT substitute its own. Verified end to end: `procoder review` printed the block and no lens at all, exit 1. Mutation proven: returning the shipped lens alongside the finding, the way templates.Resolve does, restores the count to five and prints procoder's stance under the repository's name.

--- a/.procoder/backlog/stories/20260824-an-empty-procoder-review-lenses-adversarial-md-blocks-and.md
+++ b/.procoder/backlog/stories/20260824-an-empty-procoder-review-lenses-adversarial-md-blocks-and.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 012-review-with-judgment-not-just-tooling
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
+++ b/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
@@ -21,9 +21,16 @@ the boundary is held by a test rather than by everyone remembering.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] No procoder-owned feature name contains "BMad", asserted by an audit over the source and the command table, so the trademark boundary cannot erode by accident.
+- [x] No procoder-owned feature name contains "BMad", asserted by an audit over the source and the command table, so the trademark boundary cannot erode by accident.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/audit/ -run TestNoProcoderFeatureIsNamedAfterATrademark`
+  — audits the command table in `cmd/procoder/main.go` and every exported
+  `func`/`type` under `internal/`. Four mutations proven failing: a
+  `case "bmad-sync":` arm (caught at main.go:446), an exported func, an
+  exported type, and a method on a receiver (each caught by file and line).
+  A fifth probe proved the distinction holds in the other direction — a
+  config value `"bmad"`, a doctor string naming BMad, and an unexported
+  helper are all permitted, because naming the mark to describe
+  interoperation is nominative use and only a feature NAME is a claim.

--- a/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
+++ b/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 012-review-with-judgment-not-just-tooling
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
+++ b/.procoder/backlog/stories/20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an.md
@@ -1,6 +1,6 @@
 # No procoder-owned feature name contains "BMad", asserted by an audit over the source and the command table, so the trademark boundary cannot erode by accident.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 012-review-with-judgment-not-just-tooling

--- a/.procoder/backlog/stories/20260824-procoder-review-lens-edge-case-prints-exactly-that-lens-and.md
+++ b/.procoder/backlog/stories/20260824-procoder-review-lens-edge-case-prints-exactly-that-lens-and.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 012-review-with-judgment-not-just-tooling
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-procoder-review-lens-edge-case-prints-exactly-that-lens-and.md
+++ b/.procoder/backlog/stories/20260824-procoder-review-lens-edge-case-prints-exactly-that-lens-and.md
@@ -1,6 +1,6 @@
 # `procoder review --lens edge-case` prints exactly that lens and exits 0; an unrecognised name reports the name, prints no lens at all, and exits 2 — a usage error, not a finding.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 012-review-with-judgment-not-just-tooling
@@ -20,9 +20,8 @@ reader believing they got the lens they asked for.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder review --lens edge-case` prints exactly that lens and exits 0; an unrecognised name reports the name, prints no lens at all, and exits 2 — a usage error, not a finding.
+- [x] `procoder review --lens edge-case` prints exactly that lens and exits 0; an unrecognised name reports the name, prints no lens at all, and exits 2 — a usage error, not a finding.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/review/ -run TestSelectNarrowsAndNamesWhatItDoesNotKnow` — `--lens edge-case` yields exactly that lens, selection keeps the caller's order rather than the shipped one, and an unknown name comes back by name. Verified end to end: `procoder review --lens edge-case` exits 0; `--lens nope` prints `no such lens: nope — procoder has adversarial, edge-case, verification-gap, structure, prose` and exits 2, a usage error per ADR 0003. Mutation proven: Select swallowing the unknown name gives a full review and exit 0.

--- a/.procoder/backlog/stories/20260824-procoder-review-over-a-fixture-diff-prints-all-five-lenses.md
+++ b/.procoder/backlog/stories/20260824-procoder-review-over-a-fixture-diff-prints-all-five-lenses.md
@@ -1,6 +1,6 @@
 # `procoder review` over a fixture diff prints all five lenses with the content in scope, and leaves every file's bytes unchanged, asserted by comparing a digest of the tree before and after.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 012-review-with-judgment-not-just-tooling
@@ -23,9 +23,8 @@ after.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder review` over a fixture diff prints all five lenses with the content in scope, and leaves every file's bytes unchanged, asserted by comparing a digest of the tree before and after.
+- [x] `procoder review` over a fixture diff prints all five lenses with the content in scope, and leaves every file's bytes unchanged, asserted by comparing a digest of the tree before and after.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/review/ -run TestReviewPrintsEveryLensAndWritesNothing` — all five lens bodies reach the output with the scope named, and a SHA-256 digest of every file's path and content is identical before and after. Verified end to end against a real git fixture: `procoder review` printed five lenses over the changed file, exit 0, tree unchanged. Mutation proven: Print writing a file alongside its output fails the digest while the printed bytes stay identical.

--- a/.procoder/backlog/stories/20260824-procoder-review-over-a-fixture-diff-prints-all-five-lenses.md
+++ b/.procoder/backlog/stories/20260824-procoder-review-over-a-fixture-diff-prints-all-five-lenses.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 012-review-with-judgment-not-just-tooling
 
 ## Description
 

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -45,6 +45,7 @@ import (
 	"procoder/internal/principles"
 	"procoder/internal/release"
 	"procoder/internal/releases"
+	"procoder/internal/review"
 	"procoder/internal/runcmd"
 	"procoder/internal/security"
 	"procoder/internal/spec"
@@ -443,6 +444,8 @@ func run(args []string) int {
 			return 2
 		}
 		return formatCmd(args[1:])
+	case "review":
+		return reviewCmd(args[1:])
 	case "audit":
 		return audit.Run(doctor.Root(), printLine)
 	case "status":
@@ -1194,4 +1197,64 @@ func formatCmd(files []string) int {
 		}
 	}
 	return code
+}
+
+// reviewCmd is the judgment half of the gate: it prints the lenses and the
+// scope, and the agent judges. The binary writes nothing, which is what
+// makes it safe to run on anything.
+//
+// Exit codes follow ADR 0003: 0 when every selected lens resolved, 1 when
+// one could not — a lens that failed to load is a refusal, and a review
+// that did not happen must not exit 0 — and 2 for a name that is not a
+// lens, which is a usage error rather than a finding about the code.
+func reviewCmd(args []string) int {
+	root := doctor.Root()
+
+	var want []string
+	var paths []string
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--lens" && i+1 < len(args):
+			i++
+			want = append(want, strings.Split(args[i], ",")...)
+		case strings.HasPrefix(args[i], "--lens="):
+			want = append(want, strings.Split(strings.TrimPrefix(args[i], "--lens="), ",")...)
+		case strings.HasPrefix(args[i], "-"):
+			fmt.Fprintf(os.Stderr, "procoder review: unknown flag %q\n", args[i])
+			return 2
+		default:
+			paths = append(paths, args[i])
+		}
+	}
+
+	lenses, problems := review.Resolve(root)
+	// The refusal comes before anything is printed. A lens that could not
+	// be read must not be discovered halfway down a review the reader has
+	// already started acting on.
+	if len(problems) > 0 {
+		printFindings(root, "review", problems, printLine)
+		return 1
+	}
+
+	if len(want) > 0 {
+		selected, unknown := review.Select(lenses, want)
+		if len(unknown) > 0 {
+			fmt.Fprintf(os.Stderr, "procoder review: no such lens: %s — procoder has %s\n",
+				strings.Join(unknown, ", "), strings.Join(review.Names(lenses), ", "))
+			return 2
+		}
+		lenses = selected
+	}
+
+	if len(paths) == 0 {
+		changed, err := gitx.ChangedFiles(root)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "procoder review: cannot list changed files (%v) — pass paths explicitly\n", err)
+			return 2
+		}
+		paths = changed
+	}
+
+	review.Print(os.Stdout, paths, lenses)
+	return 0
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,6 +84,35 @@ lint, CI hygiene, infrastructure hygiene, lint findings, secrets (blocking),
 docs checks, and the change's blast radius from the index. Exit 1 on any
 blocking finding.
 
+#### `procoder review [--lens <name>[,<name>]] [paths...]`
+
+The judgment half of the gate. Every other check Procoder runs is
+mechanical and has one right answer; this one asks the questions that do
+not — is this the right shape, what breaks at the edges, would a test
+catch this regressing.
+
+It prints five lenses over the changed files (or the given paths), each a
+distinct stance rather than a checklist: **adversarial** (assume it is
+wrong and find where), **edge-case** (enumerate paths, report only the
+unhandled ones), **verification-gap** (would verification actually fail if
+this broke?), **structure** (how it is organised), and **prose** (how it
+is expressed). Overlap between two lenses is signal, not duplication.
+
+The binary judges nothing — it cannot, it is not a language model. It
+prints the lens and the scope; the agent judges. Same contract as
+`procoder format`: the binary prints, the agent writes, and nothing on
+disk changes.
+
+`--lens` narrows to the named ones. A name that is not a lens is a usage
+error (exit 2), never a silent full review.
+
+Any lens is replaceable from `.procoder/review/lenses/<name>.md`
+(D-OVERRIDE). An empty or unreadable override **blocks and prints
+nothing** — unlike a template, which falls back to Procoder's version and
+says so. A lens shapes a judgment, and a review under your lens's name
+running Procoder's words is worse than no review, so nothing is printed
+for an agent to act on by mistake. Exit 1.
+
 #### `procoder git`
 
 The pre-finish status: branch vs default, changed-file count, template

--- a/internal/audit/trademark_test.go
+++ b/internal/audit/trademark_test.go
@@ -1,0 +1,102 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// commandCase matches a command or subcommand name in the CLI dispatch —
+// the `case "name":` arms of main.go's switch. These are the names a user
+// types, which is what makes them procoder's own rather than a mention.
+var commandCase = regexp.MustCompile(`(?m)^\s*case\s+((?:"[a-z0-9-]+"(?:,\s*)?)+):`)
+
+// exportedName matches a Go declaration procoder owns — `func Name`,
+// `func (r T) Name`, `type Name` — anchored at column zero, because a
+// declaration nested inside another block is not package API surface.
+//
+// Written this way after the obvious form proved wrong in both
+// directions: `\s*(?:func|type)\s+\(?[^)]*\)?\s*([A-Z]...)` captured
+// "Status" from `func BmadStatus()`, missing the very prefix this audit
+// exists to find, and captured "Unlinted" from `func lintUnlinted`, a
+// false positive on an unexported name. The greedy `[^)]*` ate the
+// identifier. Both were caught by running the mutation rather than by
+// reading the pattern.
+var exportedName = regexp.MustCompile(`(?m)^(?:func\s+(?:\([^)]*\)\s*)?|type\s+)([A-Z][A-Za-z0-9_]*)`)
+
+// trademarked are the marks procoder must not name a feature after. Lower
+// case, matched against a lower-cased candidate, so BMad, BMAD and bmad are
+// one rule rather than three.
+var trademarked = []string{"bmad"}
+
+// "BMad" and "BMAD-METHOD" are trademarks of BMad Code, LLC. Naming the
+// mark to describe interoperation is fine and necessary — the config value
+// `[planning] method = "bmad"`, a doctor line saying which version is
+// installed, a sentence of documentation. Naming a procoder FEATURE after
+// it is not.
+//
+// The distinction this audit draws is between a name a user types or a
+// symbol procoder exports, and a string procoder prints. The first is
+// procoder claiming the name; the second is procoder referring to somebody
+// else's product, which is what nominative use means.
+//
+// It exists because that boundary erodes by accident rather than by
+// decision. Nobody sets out to infringe a trademark; somebody adds a
+// command and picks the clearest available name for it, and when the
+// feature reads BMad's artifacts the clearest available name is the
+// trademark. A convention in a spec does not catch that. A test does.
+// proved by: add `case "bmad-sync":` to main.go's dispatch, or an exported
+// `func BmadStatus()` anywhere under internal/ — each is named with its
+// file and line, where the whole suite otherwise stays green.
+func TestNoProcoderFeatureIsNamedAfterATrademark(t *testing.T) {
+	var offenders []string
+
+	// The command table: what a user types.
+	main := filepath.Join("..", "..", "cmd", "procoder", "main.go")
+	raw, err := os.ReadFile(main)
+	if err != nil {
+		t.Fatalf("the command table must be readable for this audit to mean anything: %v", err)
+	}
+	src := string(raw)
+	for _, m := range commandCase.FindAllStringSubmatchIndex(src, -1) {
+		arm := src[m[2]:m[3]]
+		for _, mark := range trademarked {
+			if strings.Contains(strings.ToLower(arm), mark) {
+				offenders = append(offenders, "cmd/procoder/main.go:"+
+					itoa(strings.Count(src[:m[0]], "\n")+1)+" command "+arm)
+			}
+		}
+	}
+
+	// The API surface: what procoder exports.
+	err = filepath.Walk(filepath.Join("..", "..", "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		src := string(raw)
+		for _, m := range exportedName.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			for _, mark := range trademarked {
+				if strings.Contains(strings.ToLower(name), mark) {
+					offenders = append(offenders, filepath.ToSlash(path)+":"+
+						itoa(strings.Count(src[:m[0]], "\n")+1)+" exports "+name)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("the tree must be readable for this audit to mean anything: %v", err)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("a trademark may be referred to, never used as a procoder feature name:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/audit/trademark_test.go
+++ b/internal/audit/trademark_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -65,7 +66,7 @@ func TestNoProcoderFeatureIsNamedAfterATrademark(t *testing.T) {
 		for _, mark := range trademarked {
 			if strings.Contains(strings.ToLower(arm), mark) {
 				offenders = append(offenders, "cmd/procoder/main.go:"+
-					itoa(strings.Count(src[:m[0]], "\n")+1)+" command "+arm)
+					strconv.Itoa(strings.Count(src[:m[0]], "\n")+1)+" command "+arm)
 			}
 		}
 	}
@@ -85,7 +86,7 @@ func TestNoProcoderFeatureIsNamedAfterATrademark(t *testing.T) {
 			for _, mark := range trademarked {
 				if strings.Contains(strings.ToLower(name), mark) {
 					offenders = append(offenders, filepath.ToSlash(path)+":"+
-						itoa(strings.Count(src[:m[0]], "\n")+1)+" exports "+name)
+						strconv.Itoa(strings.Count(src[:m[0]], "\n")+1)+" exports "+name)
 				}
 			}
 		}

--- a/internal/review/lenses.go
+++ b/internal/review/lenses.go
@@ -1,0 +1,93 @@
+package review
+
+// The shipped lenses. Each is a stance, not a checklist: a distinct way of
+// being wrong about a change, written so that two lenses reading the same
+// diff disagree about what matters. Overlap between them is signal — the
+// same line reached by two routes is a line worth looking at — so nothing
+// here tries to partition the space.
+//
+// These are procoder's own words. The idea of reviewing through named
+// lenses is not procoder's and is not claimed to be; the expression is,
+// which is what keeps this file free of anyone else's licence.
+//
+// A repository replaces any of them from .procoder/review/lenses/.
+
+const adversarialLens = `# Adversarial
+
+Assume this change is wrong and find where. You are not confirming it
+works; you are looking for the case its author did not.
+
+Read for the gap between what the change intends and what it does. A
+condition that is nearly right. An assumption that holds today because
+of something unrelated. A name that says one thing while the code does
+another. State the input or the sequence that breaks it — a concern
+without a trigger is not a finding.
+
+Zero findings is not a result here. Every other lens may legitimately
+find nothing; this one finding nothing almost always means it was not
+run properly, so treat an empty list as a signal to read again rather
+than an answer to report.`
+
+const edgeCaseLens = `# Edge cases
+
+Enumerate paths. Do not judge whether the change is good.
+
+Walk every branch mechanically rather than hunting by intuition: each
+condition, each loop bound, each early return, each error the code can
+receive. For every path, ask only whether it is handled.
+
+Report the unhandled ones and discard the rest silently — a list that
+includes what already works buries what does not. Empty, zero, one,
+many, absent, malformed, and the boundary either side of every limit
+the code names.`
+
+const verificationGapLens = `# Verification gap
+
+One question: if the behaviour this change is supposed to produce broke
+where it is actually used, would verification fail?
+
+Trace from the changed behaviour to whatever is supposed to catch it
+breaking — a test, an assertion, a type, a check downstream. Then ask
+whether that thing would actually go red, not whether it exists. A test
+that exercises the function but asserts nothing about the changed
+behaviour is a gap. A test whose fixture cannot reach the new branch is
+a gap. A test that would pass against the old code is a gap.
+
+Do not hunt for correctness bugs, but report the ones you notice while
+tracing.`
+
+const structureLens = `# Structure
+
+Judge how this is organised, never whether its claims are true. The
+content is the author's; the shape is what you are reading.
+
+Ask what a reader needs first and whether they get it there. Whether
+each section earns its place or restates its neighbour. Whether the
+order follows the reader's questions or the writer's discovery. Whether
+something buried three levels down is the thing most people came for.
+
+Name what to move, merge, split, or cut, and say what the reader gains.`
+
+const proseLens = `# Prose
+
+Judge how this is expressed, never whether its claims are true.
+
+Read for the sentence that has to be read twice. The clause that could
+go without losing anything. The word doing less work than its length
+suggests. Hedging that costs the reader confidence the writer meant to
+give them. A term used two ways in one document.
+
+Quote the passage and give the replacement. "This is unclear" is not a
+finding; the rewritten sentence is.`
+
+// Lenses are the shipped set, in the order a full review runs them.
+// Reading order is deliberate: the behavioural lenses go first, because a
+// document whose logic is wrong does not benefit from being told its
+// paragraphs are in the wrong order.
+var Lenses = []Lens{
+	{Name: "adversarial", Body: adversarialLens},
+	{Name: "edge-case", Body: edgeCaseLens},
+	{Name: "verification-gap", Body: verificationGapLens},
+	{Name: "structure", Body: structureLens},
+	{Name: "prose", Body: proseLens},
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -1,0 +1,141 @@
+// Package review is the judgment half of the gate. Every other check
+// procoder runs is mechanical — formatting, secrets, linters, hygiene —
+// and answers a question with one right answer. This one asks the
+// questions that do not: is this the right shape, what breaks at the
+// edges, would a test catch this regressing.
+//
+// The binary judges nothing. It cannot: it is not a language model. It
+// prints the lens and the scope, the agent judges, and what comes back
+// travels the same path as every other finding. That is the same contract
+// `procoder format` has always held — the binary prints, the agent
+// writes — and it is why this package has no opinion about the content it
+// names.
+package review
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// Dir is where a repository puts its own lenses.
+const Dir = ".procoder/review/lenses"
+
+// Lens is one stance, and where its text came from.
+type Lens struct {
+	Name string
+	Body string
+	// Source is "default" for a shipped lens, or the repo-relative path of
+	// the override that replaced it. Printed so a reader knows whose words
+	// they are reading.
+	Source string
+}
+
+// Resolve returns the lens set for this repository: the shipped lenses,
+// each replaced by an override where one exists.
+//
+// An unreadable or empty override is a refusal, and NOTHING is returned —
+// deliberately unlike templates.Resolve, which returns its embedded body
+// alongside the finding. A template is content the agent reads before
+// writing it somewhere, so showing procoder's version and blocking the
+// commit loses nothing. A lens is an instruction that shapes a judgment,
+// and `procoder review` is not gated by the commit gate: an agent reading
+// printed output may act on it whatever the exit code says. Printing
+// procoder's adversarial lens to a repository that wrote its own would
+// produce a review claiming to be one thing and being another. Printing
+// nothing leaves nothing to act on by mistake.
+func Resolve(root string) ([]Lens, []gitx.Finding) {
+	var out []Lens
+	var problems []gitx.Finding
+	for _, shipped := range Lenses {
+		path := filepath.Join(root, Dir, shipped.Name+".md")
+		rel := filepath.ToSlash(filepath.Join(Dir, shipped.Name+".md"))
+		data, err := os.ReadFile(path)
+		switch {
+		case os.IsNotExist(err):
+			shipped.Source = "default"
+			out = append(out, shipped)
+		case err != nil:
+			// Present and unreadable is not absent. A permissions failure
+			// reported as "no override here" runs procoder's lens under the
+			// repository's name.
+			problems = append(problems, gitx.Finding{Blocking: true, File: path,
+				Message: fmt.Sprintf("lens %s NOT read — %v (review)", shipped.Name, err)})
+		case strings.TrimSpace(string(data)) == "":
+			problems = append(problems, gitx.Finding{Blocking: true, File: path,
+				Message: fmt.Sprintf("lens %s is empty — procoder did NOT fall back to its own, because a review under your lens's name running procoder's words is worse than no review. If it was emptied by accident, `git checkout <ref> -- %s` restores it; if it is meant to go, delete the file (review)", shipped.Name, rel)})
+		default:
+			out = append(out, Lens{Name: shipped.Name, Body: string(data), Source: rel})
+		}
+	}
+	return out, problems
+}
+
+// Select narrows a lens set to the named ones, in the order the caller
+// asked for them. An unknown name is returned rather than guessed at: a
+// reader who asks for one lens and silently gets the other four believes
+// they got the one they asked for.
+func Select(all []Lens, names []string) ([]Lens, []string) {
+	byName := map[string]Lens{}
+	for _, l := range all {
+		byName[l.Name] = l
+	}
+	var out []Lens
+	var unknown []string
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		if l, ok := byName[n]; ok {
+			out = append(out, l)
+			continue
+		}
+		unknown = append(unknown, n)
+	}
+	return out, unknown
+}
+
+// Names lists the lens names in a set, for an error that has to say what
+// was available.
+func Names(all []Lens) []string {
+	out := make([]string, 0, len(all))
+	for _, l := range all {
+		out = append(out, l.Name)
+	}
+	return out
+}
+
+// Print writes the review request: what is in scope, then each lens.
+//
+// The scope is named rather than quoted. The agent can already read the
+// files; what only procoder knows is which ones the change touched and
+// what the lenses are.
+func Print(w io.Writer, scope []string, lenses []Lens) {
+	fmt.Fprintf(w, "== procoder review — %d lens(es) over %d file(s)\n\n", len(lenses), len(scope))
+	if len(scope) == 0 {
+		fmt.Fprintln(w, "no files in scope — pass paths, or make a change for the diff to carry")
+		return
+	}
+	fmt.Fprintln(w, "## In scope")
+	fmt.Fprintln(w)
+	for _, p := range scope {
+		fmt.Fprintln(w, "- "+p)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Read each file. Then apply every lens below, one at a time — they are")
+	fmt.Fprintln(w, "different stances, not a checklist to merge. Overlap between two lenses is")
+	fmt.Fprintln(w, "signal rather than duplication: keep both findings and say they agree.")
+	fmt.Fprintln(w)
+	for _, l := range lenses {
+		fmt.Fprintf(w, "---\n\n%s\n", l.Body)
+		if l.Source != "default" {
+			fmt.Fprintf(w, "\n(this lens comes from %s, not procoder's own)\n", l.Source)
+		}
+		fmt.Fprintln(w)
+	}
+}

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -1,0 +1,211 @@
+package review
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// treeDigest is every file's path and content, hashed — the evidence that
+// a command which only prints has only printed.
+func treeDigest(t *testing.T, root string) string {
+	t.Helper()
+	h := sha256.New()
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		fmt.Fprintf(h, "%s\x00%x\x00", path, sha256.Sum256(raw))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("the tree must be readable for the digest to mean anything: %v", err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func writeLens(t *testing.T, root, name, body string) {
+	t.Helper()
+	dir := filepath.Join(root, Dir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The whole point of the command: five distinct stances over the content,
+// and nothing written. The binary judges nothing — it prints the lens and
+// the scope, the agent judges — so a review that modified the tree would
+// have broken the contract that makes it safe to run on anything.
+// proved by: had Print write its output to a file under root as well as to
+// the writer — the digest changes and this fails, where the printed output
+// is byte-identical and every other assertion still passes.
+func TestReviewPrintsEveryLensAndWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before := treeDigest(t, root)
+
+	lenses, problems := Resolve(root)
+	if len(problems) != 0 {
+		t.Fatalf("a repository with no overrides has no problems: %+v", problems)
+	}
+	if len(lenses) != 5 {
+		t.Fatalf("five shipped lenses, got %d: %v", len(lenses), Names(lenses))
+	}
+
+	var buf bytes.Buffer
+	Print(&buf, []string{filepath.Join(root, "a.go")}, lenses)
+	out := buf.String()
+
+	for _, name := range []string{"adversarial", "edge-case", "verification-gap", "structure", "prose"} {
+		var l Lens
+		for _, c := range lenses {
+			if c.Name == name {
+				l = c
+			}
+		}
+		if l.Body == "" {
+			t.Fatalf("lens %s is missing from the shipped set", name)
+		}
+		if !strings.Contains(out, l.Body) {
+			t.Errorf("lens %s did not reach the output", name)
+		}
+	}
+	if !strings.Contains(out, "a.go") {
+		t.Errorf("the content in scope must be named:\n%s", out)
+	}
+
+	if after := treeDigest(t, root); after != before {
+		t.Errorf("review prints and never writes — the tree changed")
+	}
+}
+
+// Each lens is a distinct stance, not five wordings of one. A set where
+// two lenses say the same thing costs the reader five passes and returns
+// one perspective.
+// proved by: pointed two entries in Lenses at the same body — this fails
+// naming the pair, where every other test still passes because the count
+// and the printing are unaffected.
+func TestEveryLensIsADistinctStance(t *testing.T) {
+	seen := map[string]string{}
+	for _, l := range Lenses {
+		if l.Body == "" {
+			t.Errorf("lens %s has no instruction", l.Name)
+			continue
+		}
+		if prior, dup := seen[l.Body]; dup {
+			t.Errorf("lenses %s and %s are the same stance", prior, l.Name)
+		}
+		seen[l.Body] = l.Name
+	}
+}
+
+// A reader who already knows what they are worried about asks one
+// question rather than five. A name that is not a lens is returned rather
+// than skipped: silently running the other four leaves them believing they
+// got the lens they asked for.
+// proved by: dropped the unknown return from Select and skipped unknown
+// names — `--lens nope` then prints a full review and exits 0.
+func TestSelectNarrowsAndNamesWhatItDoesNotKnow(t *testing.T) {
+	all, _ := Resolve(t.TempDir())
+
+	got, unknown := Select(all, []string{"edge-case"})
+	if len(unknown) != 0 {
+		t.Fatalf("edge-case is a lens: %v", unknown)
+	}
+	if len(got) != 1 || got[0].Name != "edge-case" {
+		t.Fatalf("exactly the lens asked for: %v", Names(got))
+	}
+
+	// Order follows the caller, not the shipped order — someone who asks
+	// for prose then adversarial gets them that way round.
+	got, _ = Select(all, []string{"prose", "adversarial"})
+	if len(got) != 2 || got[0].Name != "prose" || got[1].Name != "adversarial" {
+		t.Errorf("selection keeps the caller's order: %v", Names(got))
+	}
+
+	if _, unknown = Select(all, []string{"nope"}); len(unknown) != 1 || unknown[0] != "nope" {
+		t.Errorf("an unknown name comes back by name: %v", unknown)
+	}
+}
+
+// D-OVERRIDE: a repository that disagrees with a lens replaces it, without
+// forking procoder or giving up the other four. The source is reported so
+// a reader knows whose words they are reading.
+// proved by: made Resolve ignore the override directory — the shipped
+// adversarial lens comes back under the repository's nose, and the review
+// claims a stance the repository deliberately replaced.
+func TestAnOverrideReplacesTheShippedLens(t *testing.T) {
+	root := t.TempDir()
+	const mine = "# Ours\n\nLook for the thing our last outage taught us.\n"
+	writeLens(t, root, "adversarial", mine)
+
+	lenses, problems := Resolve(root)
+	if len(problems) != 0 {
+		t.Fatalf("a readable override is not a problem: %+v", problems)
+	}
+	if len(lenses) != 5 {
+		t.Fatalf("an override replaces a lens, it does not remove one: %v", Names(lenses))
+	}
+	for _, l := range lenses {
+		switch l.Name {
+		case "adversarial":
+			if l.Body != mine {
+				t.Errorf("the override's content must be what runs:\n%s", l.Body)
+			}
+			if !strings.Contains(l.Source, "adversarial.md") {
+				t.Errorf("the source must name the override: %q", l.Source)
+			}
+		default:
+			if l.Source != "default" {
+				t.Errorf("%s has no override and must stay procoder's: %q", l.Name, l.Source)
+			}
+		}
+	}
+}
+
+// An override that cannot be read blocks, and procoder does NOT fall back
+// to its own — deliberately unlike templates.Resolve. A lens shapes a
+// judgment, and `procoder review` is not gated by the commit gate: an
+// agent reading printed output may act on it whatever the exit code says.
+// A review under the repository's lens name running procoder's words is
+// worse than no review, so there must be nothing printed to act on.
+// proved by: returned the shipped lens alongside the finding, the way
+// templates.Resolve does — the count goes back to five and procoder's
+// adversarial stance is printed under the repository's name.
+func TestAnUnreadableOverrideBlocksAndDoesNotFallBack(t *testing.T) {
+	root := t.TempDir()
+	writeLens(t, root, "adversarial", "   \n\t\n")
+
+	lenses, problems := Resolve(root)
+	if len(problems) != 1 {
+		t.Fatalf("an empty override is exactly one problem: %+v", problems)
+	}
+	if !problems[0].Blocking {
+		t.Error("a lens that could not load is a refusal, and must block")
+	}
+	if !strings.Contains(problems[0].File, "adversarial.md") {
+		t.Errorf("the finding must name the file: %q", problems[0].File)
+	}
+
+	for _, l := range lenses {
+		if l.Name == "adversarial" {
+			t.Fatal("procoder must not substitute its own lens for one the repository replaced")
+		}
+	}
+	if len(lenses) != 4 {
+		t.Errorf("the other four are unaffected: %v", Names(lenses))
+	}
+}


### PR DESCRIPTION
Opens sprint 012 against the epic from #162, and closes the first of its five stories.

## The sprint

Five stories, not the epic's fourteen — the whole `procoder review` surface (five lenses, lens selection, the override, the override that cannot be read) plus the trademark audit. The analysis phase and the BMad seam are deliberately left for later; they're separable by construction, and the review command alone is worth a release.

## Story 1 of 5 — done

**Why the audit lands first:** it's cheapest to add while there's no BMad-adjacent code to violate it, and the boundary erodes *by accident*. Nobody sets out to infringe a trademark — somebody adds a command and picks the clearest available name, and for a command that reads BMad's artifacts the clearest available name **is** the trademark.

The audit draws the line where the law does: between a name a user types or a symbol procoder exports, and a string procoder prints. The first claims the name; the second refers to someone else's product, which is what nominative use means.

| Permitted | Caught |
|---|---|
| `[planning] method = "bmad"` | `case "bmad-sync":` |
| a doctor line naming BMad | `func BmadStatus()` |
| unexported helpers | `type BmadConfig` |
| documentation prose | `func (p probe) BmadSync()` |

## The regex was wrong in both directions, and only the mutation found it

My first pattern captured **`Status`** from `func BmadStatus()` — missing the exact prefix the audit exists to find — and captured **`Unlinted`** from `func lintUnlinted`, a false positive on an unexported name. The greedy `[^)]*` ate the identifier.

The first mutation run **passed against the broken pattern**. That's the only reason either fault surfaced; reading the regex would not have found them. Same class as #153 — an audit that silently sees nothing looks identical to one that finds nothing.

Corrected pattern anchors at column zero and handles the receiver form. Four mutations now fail (command arm, exported func, exported type, receiver method), and a fifth probe proves the permissive direction holds.