### PR TITLE
backlog: sprint 012 closes, five of five

### DIFF
--- a/.procoder/backlog/sprints/012-review-with-judgment-not-just-tooling.md
+++ b/.procoder/backlog/sprints/012-review-with-judgment-not-just-tooling.md
@@ -1,6 +1,6 @@
 # Review with judgment, not just tooling
 
-Status: active
+Status: closed 2026-08-24
 Created: 2026-08-24
 
 ## Goal
@@ -33,8 +33,42 @@ worth a release on its own.
 
 ## Retro
 
-<!-- What slowed us down this sprint. -->
+**What slowed us down.** Nothing external. The cost was self-inflicted and
+worth recording: the trademark audit's regex was wrong in both directions
+at once — it captured "Status" from `func BmadStatus()`, missing the exact
+prefix the audit exists to find, and captured "Unlinted" from
+`func lintUnlinted`, a false positive on an unexported name. A greedy
+`[^)]*` ate the identifier. The first mutation run passed against that
+broken pattern, and passing is what surfaced it; reading the regex would
+not have.
 
-<!-- What we change next sprint because of it. -->
+That is the third time in two sessions an audit has been written that
+silently saw nothing — #153 was the same shape, and #159's first
+exemption was too. The pattern is specific: source-reading audits fail
+open, and a failing-open audit is indistinguishable from a passing tree
+until something is deliberately broken in front of it.
 
-<!-- One adaptation from this sprint worth keeping. -->
+**What we change.** A source-scanning audit is not finished when it
+passes. It is finished when a synthetic offender of every shape it claims
+to catch has been put in front of it and caught. The trademark audit has
+four such probes (command arm, exported func, exported type, receiver
+method) plus one proving the permissive direction — a config value and a
+doctor string are left alone. That fifth probe is the one worth
+generalising: an audit that only proves it catches things has not shown it
+distinguishes anything.
+
+**Worth keeping.** Checking `templates.Resolve` before writing a lens
+resolver, and then not using it. The engineering ladder says look for the
+helper a few files over, and it was there and nearly right — but a
+template falls back to procoder's version and blocks, while a lens must
+print nothing at all, because `procoder review` is not gated by the commit
+gate and an agent reading output may act on it whatever the exit code
+says. The ladder's rung is "does this codebase already have it", not "is
+there something close enough". The right outcome was a second resolver
+with a comment naming why it differs from the first.
+
+## Result
+
+committed: 5
+done: 5 (20260824-a-repository-carrying-procoder-review-lenses-adversarial-md, 20260824-an-empty-procoder-review-lenses-adversarial-md-blocks-and, 20260824-no-procoder-owned-feature-name-contains-bmad-asserted-by-an, 20260824-procoder-review-lens-edge-case-prints-exactly-that-lens-and, 20260824-procoder-review-over-a-fixture-diff-prints-all-five-lenses)
+carried: 0


### PR DESCRIPTION
Closes sprint 012. `procoder review` ships — procoder has an opinion about a change for the first time.

## Delivered

Five lenses (adversarial, edge-case, verification-gap, structure, prose), lens selection, D-OVERRIDE lens replacement, a refusal that prints nothing when an override cannot be read, and the trademark audit.

The binary judges nothing — it prints the lens and scope, the agent judges, tree byte-identical after. Asserted with a SHA-256 digest.

## The retro records a pattern, not an incident

**Three times in two sessions**, a source-reading audit was written that silently saw nothing:

- **#153** — the regex couldn't match Go's elided-type slice literal `[]T{{...}}`
- **#159** — the first exemption skipped whole files rather than one literal
- **this sprint** — the trademark regex captured `Status` from `func BmadStatus()` (missing the very prefix it exists to find) *and* flagged `lintUnlinted` as a false positive

**Every one passed on a clean tree.** Every one was found only by putting a synthetic offender in front of it.

**The adaptation:** a source-scanning audit isn't finished when it passes. It's finished when an offender of *every shape it claims to catch* has been caught — plus one probe proving it leaves the legitimate case alone. An audit that only proves it catches things hasn't shown it distinguishes anything.

## Worth keeping

Checking `templates.Resolve` before writing a lens resolver — and then deliberately not using it. The engineering ladder's rung is *"does this codebase already have it"*, not *"is there something close enough"*. A template falls back to procoder's version and blocks; a lens must print nothing at all, because `procoder review` isn't gated by the commit gate and an agent may act on printed output whatever the exit code says.

Nine stories remain in the epic: the analysis phase and the BMad seam.