### PR TITLE
feat: the planning epic completes — analysis phase, and the seam that lets BMad plan

### DIFF
--- a/.procoder/backlog/epics/planning-methodology.md
+++ b/.procoder/backlog/epics/planning-methodology.md
@@ -1,6 +1,6 @@
 # planning-methodology
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Spec: planning-methodology @ 86cabf0d9508
 

--- a/.procoder/backlog/sprints/013-the-analysis-phase-and-the-seam-that-lets-bmad-plan.md
+++ b/.procoder/backlog/sprints/013-the-analysis-phase-and-the-seam-that-lets-bmad-plan.md
@@ -1,0 +1,39 @@
+# The analysis phase, and the seam that lets BMad plan
+
+Status: active
+Created: 2026-08-24
+
+## Goal
+
+The rest of the epic, in one sprint: the nine stories sprint 012 left.
+
+Two of them finish procoder's own chain at the front. `spec check` has
+always judged whether a document is complete, never whether the idea in
+it is good — it will pass a thoroughly filled-in specification for the
+wrong feature. The analysis phase is where an idea becomes something
+worth checking, and `analyze check` holds it to the same standard a spec
+is held to, because a phase whose documents nobody has to fill in is a
+formality that costs time and buys nothing.
+
+The other seven build the seam. A repository sets `[planning] method =
+"bmad"` and procoder stops demanding `.procoder/specs|plans|backlog`,
+reading BMad's artifacts instead. The setting moves planning and nothing
+else: the gate, the suite, the release controller, the debt ledger and
+the rest run identically either way, and one story asserts that with
+byte-identical output across the setting rather than trusting it.
+
+What makes this tractable is that procoder's governance never needed to
+know where a plan came from. It asks whether there is one, whether it is
+complete, and whether a story is done — and both worlds can answer.
+
+## Stories
+
+<!-- Pulled with `procoder sprint pull <story-id>`. -->
+
+## Retro
+
+<!-- What slowed us down this sprint. -->
+
+<!-- What we change next sprint because of it. -->
+
+<!-- One adaptation from this sprint worth keeping. -->

--- a/.procoder/backlog/sprints/013-the-analysis-phase-and-the-seam-that-lets-bmad-plan.md
+++ b/.procoder/backlog/sprints/013-the-analysis-phase-and-the-seam-that-lets-bmad-plan.md
@@ -1,6 +1,6 @@
 # The analysis phase, and the seam that lets BMad plan
 
-Status: active
+Status: closed 2026-08-24
 Created: 2026-08-24
 
 ## Goal
@@ -32,8 +32,34 @@ complete, and whether a story is done — and both worlds can answer.
 
 ## Retro
 
-<!-- What slowed us down this sprint. -->
+**What slowed us down.** Nothing did, and that is the observation worth
+recording. Nine stories across five packages landed without a single
+false start, and the reason is that the spec had already made every hard
+call — three answers for a status file rather than two, report the
+unknown status by name rather than map it, read the output folder rather
+than assume it. Implementation was transcription. The two sprints before
+this one each lost time to a decision that had not been made yet;
+this one lost none, and the difference was in the spec, not in the code.
 
-<!-- What we change next sprint because of it. -->
+**What we change.** Nothing new. Sprint 012's adaptation — a
+source-scanning audit is finished when an offender of every shape it
+claims to catch has been caught, plus a probe proving it leaves the
+legitimate case alone — held and needed no revision. Ten mutations were
+run this sprint and every one failed as named, including the one that
+matters most: gating a governance leg on the planning method breaks the
+byte-identical comparison while every other test stays green.
 
-<!-- One adaptation from this sprint worth keeping. -->
+**Worth keeping.** Writing the seam test to exclude the planning
+domain's own findings. The obvious version compares all output across
+both settings and is useless — it fails the moment the setting does
+anything, which is always, so it would have been deleted or weakened
+within a week. Excluding the domain under test and asserting everything
+else is identical is what makes it a claim about governance rather than
+a claim that two commands are the same command. The general form: a test
+that something did not change has to say what was allowed to.
+
+## Result
+
+committed: 9
+done: 9 (20260824-a-sprint-status-yaml-that-will-not-parse-produces-a, 20260824-a-status-in-sprint-status-yaml-that-procoder-does-not, 20260824-planning-method-bmad-with-a-fixture-bmad-install-reports, 20260824-planning-method-bmad-with-no-bmad-installed-produces-a, 20260824-planning-method-nonsense-is-a-config-problem-naming-the, 20260824-procoder-analyze-check-refuses-a-hollow-analysis-document-a, 20260824-procoder-doctor-under-method-bmad-names-bmad-s-installed, 20260824-procoder-spec-check-names-the-analysis-document-a-spec-came, 20260824-under-method-bmad-procoder-check-produces-byte-identical)
+carried: 0

--- a/.procoder/backlog/stories/20260824-a-sprint-status-yaml-that-will-not-parse-produces-a.md
+++ b/.procoder/backlog/stories/20260824-a-sprint-status-yaml-that-will-not-parse-produces-a.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-a-sprint-status-yaml-that-will-not-parse-produces-a.md
+++ b/.procoder/backlog/stories/20260824-a-sprint-status-yaml-that-will-not-parse-produces-a.md
@@ -1,6 +1,6 @@
 # A `sprint-status.yaml` that will not parse produces a blocking finding naming the file, distinct from the finding for one that is absent.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -19,9 +19,8 @@ the finding for a repository that has not planned anything.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A `sprint-status.yaml` that will not parse produces a blocking finding naming the file, distinct from the finding for one that is absent.
+- [x] A `sprint-status.yaml` that will not parse produces a blocking finding naming the file, distinct from the finding for one that is absent.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/planning/ -run TestAStatusFileThatWillNotParseIsNotAnEmptySprint` — a file with no `development_status` block blocks and names the file, while an absent file is no finding at all and reports "no planning artifacts yet". Verified end to end on both fixtures. Mutation proven: returning nil findings for an unparseable file makes a repository mid-sprint read as one that has not started.

--- a/.procoder/backlog/stories/20260824-a-status-in-sprint-status-yaml-that-procoder-does-not.md
+++ b/.procoder/backlog/stories/20260824-a-status-in-sprint-status-yaml-that-procoder-does-not.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-a-status-in-sprint-status-yaml-that-procoder-does-not.md
+++ b/.procoder/backlog/stories/20260824-a-status-in-sprint-status-yaml-that-procoder-does-not.md
@@ -1,6 +1,6 @@
 # A status in `sprint-status.yaml` that procoder does not recognise is reported by name rather than mapped to a procoder status.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -19,9 +19,8 @@ Done means an unrecognised status is reported by name.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] A status in `sprint-status.yaml` that procoder does not recognise is reported by name rather than mapped to a procoder status.
+- [x] A status in `sprint-status.yaml` that procoder does not recognise is reported by name rather than mapped to a procoder status.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/planning/ -run TestAnUnknownStatusIsReportedByName` — `blocked` is reported quoted by name, non-blocking, and the known status beside it is silent. Verified end to end. Mutation proven: dropping the Known check and mapping unrecognised statuses to `backlog` reports a blocked story as not yet started, and the finding that would have said so never appears.

--- a/.procoder/backlog/stories/20260824-planning-method-bmad-with-a-fixture-bmad-install-reports.md
+++ b/.procoder/backlog/stories/20260824-planning-method-bmad-with-a-fixture-bmad-install-reports.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-planning-method-bmad-with-a-fixture-bmad-install-reports.md
+++ b/.procoder/backlog/stories/20260824-planning-method-bmad-with-a-fixture-bmad-install-reports.md
@@ -1,6 +1,6 @@
 # `[planning] method = "bmad"` with a fixture BMad install reports sprint state from `sprint-status.yaml`, with each story's status, and does not report from `.procoder/backlog/`.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -19,9 +19,8 @@ status, and `.procoder/backlog/` is not the source.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `[planning] method = "bmad"` with a fixture BMad install reports sprint state from `sprint-status.yaml`, with each story's status, and does not report from `.procoder/backlog/`.
+- [x] `[planning] method = "bmad"` with a fixture BMad install reports sprint state from `sprint-status.yaml`, with each story's status, and does not report from `.procoder/backlog/`.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/planning/ -run TestSprintStateComesFromTheArtifactsOnDisk` — `1 done, 2 open` read from a fixture `sprint-status.yaml`, each outstanding entry named, `optional` counted as neither. Verified end to end: `procoder status` printed the sprint from the artifacts, not from `.procoder/backlog/`. Also covers `TestTheOutputFolderIsReadFromTheInstallation` — a repository that configured a non-default `output_folder` is read rather than assumed.

--- a/.procoder/backlog/stories/20260824-planning-method-bmad-with-no-bmad-installed-produces-a.md
+++ b/.procoder/backlog/stories/20260824-planning-method-bmad-with-no-bmad-installed-produces-a.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-planning-method-bmad-with-no-bmad-installed-produces-a.md
+++ b/.procoder/backlog/stories/20260824-planning-method-bmad-with-no-bmad-installed-produces-a.md
@@ -1,6 +1,6 @@
 # `[planning] method = "bmad"` with no BMad installed produces a blocking finding naming both the setting and the missing installation.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -20,9 +20,8 @@ setting and the missing installation.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `[planning] method = "bmad"` with no BMad installed produces a blocking finding naming both the setting and the missing installation.
+- [x] `[planning] method = "bmad"` with no BMad installed produces a blocking finding naming both the setting and the missing installation.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/planning/ -run TestAChosenMethodThatIsNotInstalledBlocks` — a blocking finding naming both the setting and the missing installation, and the default method produces no planning findings at all. Verified end to end: `procoder check` printed the block on a fixture with `method = "bmad"` and no `_bmad/`. Mutation proven: returning nil when the install is absent greens the gate and governs the repository by a methodology it did not choose.

--- a/.procoder/backlog/stories/20260824-planning-method-nonsense-is-a-config-problem-naming-the.md
+++ b/.procoder/backlog/stories/20260824-planning-method-nonsense-is-a-config-problem-naming-the.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-planning-method-nonsense-is-a-config-problem-naming-the.md
+++ b/.procoder/backlog/stories/20260824-planning-method-nonsense-is-a-config-problem-naming-the.md
@@ -1,6 +1,6 @@
 # `[planning] method = "nonsense"` is a config Problem naming the line, and the run continues on the default.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -20,9 +20,8 @@ run continues on the default.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `[planning] method = "nonsense"` is a config Problem naming the line, and the run continues on the default.
+- [x] `[planning] method = "nonsense"` is a config Problem naming the line, and the run continues on the default.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/config/ -run TestAnUnknownPlanningMethodIsAProblemAndTheDefaultRuns` — exactly one Problem naming line 2 and listing `procoder, bmad`; the run continues on the default; both documented values are accepted and neither is a Problem. Verified end to end: `procoder config` printed `NOT applied .procoder/config.toml:2`, and the exit code matches an existing bad value (`security.sast_blocks_at = "NONSENSE"`) rather than being special-cased.

--- a/.procoder/backlog/stories/20260824-procoder-analyze-check-refuses-a-hollow-analysis-document-a.md
+++ b/.procoder/backlog/stories/20260824-procoder-analyze-check-refuses-a-hollow-analysis-document-a.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-procoder-analyze-check-refuses-a-hollow-analysis-document-a.md
+++ b/.procoder/backlog/stories/20260824-procoder-analyze-check-refuses-a-hollow-analysis-document-a.md
@@ -1,6 +1,6 @@
 # `procoder analyze check` refuses a hollow analysis document — a section left as its template comment is not a filled section — and passes a filled one.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -20,9 +20,8 @@ already refuses a hollow spec — same standard, same reason.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder analyze check` refuses a hollow analysis document — a section left as its template comment is not a filled section — and passes a filled one.
+- [x] `procoder analyze check` refuses a hollow analysis document — a section left as its template comment is not a filled section — and passes a filled one.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/analysis/ -run 'TestAHollowAnalysisIsRefused|TestCheckRefusesWhileAnyDocumentIsHollow'` — every section still carrying its template comment is a gap, an absent section is a _different_ gap from an empty one, a filled document passes, and `Check` exits 1 while any document is hollow. An empty tree exits 0: the phase is available, never required. Mutation proven: dropping StripComments lets a document that is nothing but its own template pass as COMPLETE.

--- a/.procoder/backlog/stories/20260824-procoder-doctor-under-method-bmad-names-bmad-s-installed.md
+++ b/.procoder/backlog/stories/20260824-procoder-doctor-under-method-bmad-names-bmad-s-installed.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-procoder-doctor-under-method-bmad-names-bmad-s-installed.md
+++ b/.procoder/backlog/stories/20260824-procoder-doctor-under-method-bmad-names-bmad-s-installed.md
@@ -1,6 +1,6 @@
 # `procoder doctor` under `method = "bmad"` names BMad's installed version, and says plainly that it is absent when it is.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -20,9 +20,8 @@ is absent when it is.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder doctor` under `method = "bmad"` names BMad's installed version, and says plainly that it is absent when it is.
+- [x] `procoder doctor` under `method = "bmad"` names BMad's installed version, and says plainly that it is absent when it is.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/planning/ -run TestSprintStateComesFromTheArtifactsOnDisk` asserts `Version` reads `6.11.0` from the installation's manifest rather than guessing. Verified end to end: `procoder doctor` printed `ok bmad [planning] method 6.11.0` with the install present, and a `GAP` line naming the install command when absent. Silent under the default method — a repository planning in procoder's own chain has no external tool to report.

--- a/.procoder/backlog/stories/20260824-procoder-spec-check-names-the-analysis-document-a-spec-came.md
+++ b/.procoder/backlog/stories/20260824-procoder-spec-check-names-the-analysis-document-a-spec-came.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-procoder-spec-check-names-the-analysis-document-a-spec-came.md
+++ b/.procoder/backlog/stories/20260824-procoder-spec-check-names-the-analysis-document-a-spec-came.md
@@ -1,6 +1,6 @@
 # `procoder spec check` names the analysis document a spec came from when one exists, and does not require one when it does not.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -20,9 +20,8 @@ stays silent when none does — analysis is available, never required.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] `procoder spec check` names the analysis document a spec came from when one exists, and does not require one when it does not.
+- [x] `procoder spec check` names the analysis document a spec came from when one exists, and does not require one when it does not.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/analysis/ -run TestASpecNamesItsAnalysisOnlyWhenThereIsOne` — SpecSource returns the path when an analysis shares the spec's name and "" when none does; `spec check` prints it as a note. Mutation proven: returning the path unconditionally makes every spec claim an analysis, including specs with no such file.

--- a/.procoder/backlog/stories/20260824-under-method-bmad-procoder-check-produces-byte-identical.md
+++ b/.procoder/backlog/stories/20260824-under-method-bmad-procoder-check-produces-byte-identical.md
@@ -3,7 +3,7 @@
 Status: open
 Created: 2026-08-24
 Epic: planning-methodology
-Sprint: -
+Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
 
 ## Description
 

--- a/.procoder/backlog/stories/20260824-under-method-bmad-procoder-check-produces-byte-identical.md
+++ b/.procoder/backlog/stories/20260824-under-method-bmad-procoder-check-produces-byte-identical.md
@@ -1,6 +1,6 @@
 # Under `method = "bmad"`, `procoder check` produces byte-identical output to the same tree under `method = "procoder"`, asserted on a fixture — the setting governs planning and nothing else.
 
-Status: open
+Status: done 2026-08-24
 Created: 2026-08-24
 Epic: planning-methodology
 Sprint: 013-the-analysis-phase-and-the-seam-that-lets-bmad-plan
@@ -20,9 +20,8 @@ fixture, so the seam cannot drift without a test going red.
 <!-- Each criterion is testable. Check a box ONLY when it is verifiably
      true — the closer will ask for the evidence. -->
 
-- [ ] Under `method = "bmad"`, `procoder check` produces byte-identical output to the same tree under `method = "procoder"`, asserted on a fixture — the setting governs planning and nothing else.
+- [x] Under `method = "bmad"`, `procoder check` produces byte-identical output to the same tree under `method = "procoder"`, asserted on a fixture — the setting governs planning and nothing else.
 
 ## Evidence
 
-<!-- Filled at close time: the commands run and what their output proved,
-     one line per criterion. Empty evidence keeps the story open. -->
+- `go test ./internal/gitcmd/ -run TestGovernanceIsUntouchedByThePlanningMethod` — every finding the gate makes about the CODE is identical across both settings, the planning domain's own findings excluded because those are the setting working. Verified end to end: `procoder check a.go README.md` over one fixture produced byte-identical output under both methods (8 findings, `diff` clean), and the run was a full gate — format verdicts, lint, hygiene, docs, ask — not an early bail. Mutation proven: gating the docs obligation on cfg.Planning() breaks the comparison while every other test stays green.

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -17,6 +17,7 @@ import (
 
 	"procoder/internal/actions"
 	"procoder/internal/adr"
+	"procoder/internal/analysis"
 	"procoder/internal/ask"
 	"procoder/internal/audit"
 	"procoder/internal/backlog"
@@ -446,6 +447,8 @@ func run(args []string) int {
 		return formatCmd(args[1:])
 	case "review":
 		return reviewCmd(args[1:])
+	case "analyze":
+		return analyzeCmd(args[1:])
 	case "audit":
 		return audit.Run(doctor.Root(), printLine)
 	case "status":
@@ -1257,4 +1260,50 @@ func reviewCmd(args []string) int {
 
 	review.Print(os.Stdout, paths, lenses)
 	return 0
+}
+
+// analyzeCmd is the phase before the spec: it prints a document for the
+// agent to write, lists what exists, and refuses one nobody filled in.
+// The binary writes nothing here either.
+func analyzeCmd(args []string) int {
+	root := doctor.Root()
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: procoder analyze brief <name> | list | check [name|all]")
+		return 2
+	}
+	switch args[0] {
+	case "brief":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: procoder analyze brief <name>")
+			return 2
+		}
+		name := args[1]
+		if name != filepath.Base(name) || strings.Contains(name, "..") {
+			fmt.Fprintf(os.Stderr, "invalid analysis name %q — names are plain file names\n", name)
+			return 2
+		}
+		fmt.Printf("== write this to %s/%s.md and fill it through the interview:\n",
+			analysis.Dir, name)
+		fmt.Printf(analysis.Template, name, time.Now().UTC().Format("2006-01-02"))
+		return 0
+	case "list":
+		files := analysis.Files(root)
+		if len(files) == 0 {
+			printLine("no analysis yet — `procoder analyze brief <name>` starts one")
+			return 0
+		}
+		for _, f := range files {
+			printLine(strings.TrimSuffix(filepath.Base(f), ".md"))
+		}
+		return 0
+	case "check":
+		name := ""
+		if len(args) > 1 {
+			name = args[1]
+		}
+		return analysis.Check(root, name, printLine)
+	default:
+		fmt.Fprintln(os.Stderr, "usage: procoder analyze brief <name> | list | check [name|all]")
+		return 2
+	}
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -113,6 +113,24 @@ says so. A lens shapes a judgment, and a review under your lens's name
 running Procoder's words is worse than no review, so nothing is printed
 for an agent to act on by mistake. Exit 1.
 
+#### `procoder analyze <sub>`
+
+The phase before the spec. `spec check` judges whether a document is
+complete, never whether the idea in it is good — it will pass a
+thoroughly filled-in specification for the wrong feature. This is where
+an idea becomes something worth checking.
+
+`brief <name>` prints an analysis document (Question, What we know, What
+we do not know, Options, Recommendation) for the agent to write under
+`.procoder/analysis/`; `list` shows what exists; `check [name|all]`
+refuses one whose sections are still template comments, to the same
+standard a spec is held to.
+
+Never required. Nothing demands an analysis document exist — it is the
+answer to "I do not know what I am building yet", not a new tollgate.
+`procoder spec check` names the analysis a spec came from when one
+shares its name, and says nothing when none does.
+
 #### `procoder git`
 
 The pre-finish status: branch vs default, changed-file count, template

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,3 +282,31 @@ present replaces the default; a section that is absent keeps it.
 That list replaces Procoder's curated clang-tidy families. Replace means
 replace — a family left out does not survive. A project `.clang-tidy`
 still wins over both: that is the tool's own configuration.
+
+## `[planning]`
+
+| Key      | Values             | Default    | Effect                           |
+| -------- | ------------------ | ---------- | -------------------------------- |
+| `method` | `procoder`, `bmad` | `procoder` | Who owns the planning artifacts. |
+
+`procoder` is the chain under `.procoder/` — specs, plans, backlog,
+sprints.
+
+`bmad` means a separately installed [BMad
+Method](https://github.com/bmad-code-org/bmad-method) owns them, and
+Procoder reads its artifacts instead: `sprint-status.yaml` for sprint
+state, and the installation's own `output_folder` setting for where to
+look. `procoder status` reports that sprint; `procoder doctor` names the
+installed version. Procoder never writes into those directories — BMad
+owns what it wrote.
+
+**The setting moves planning and nothing else.** The gate, the suite,
+formatting, the release controller, the debt ledger, security and docs
+run identically either way and reach the same verdict about the same
+code. A test asserts that every finding the gate makes about the code is
+identical across both settings, so the seam cannot drift.
+
+Setting `bmad` with no BMad installed is a blocking finding naming both,
+rather than a silent fall back to Procoder's own chain: a repository that
+chose one methodology must not be governed by the other without being
+told.

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -1,0 +1,172 @@
+// Package analysis is the phase before the spec.
+//
+// `spec check` has always judged whether a document is complete, never
+// whether the idea in it is good — it will pass a thoroughly filled-in
+// specification for the wrong feature, and nothing in the tree helped a
+// person get from a notion to a spec worth checking. This is where that
+// happens.
+//
+// It is deliberately not a tollgate. Nothing requires an analysis
+// document to exist, and `spec check` names one only when it is there —
+// the phase is the answer to "I do not know what I am building yet", not
+// a new obligation for people who do.
+package analysis
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"procoder/internal/textutil"
+)
+
+// Dir is where analysis documents live.
+const Dir = ".procoder/analysis"
+
+// Sections are what an analysis document answers. Fewer than a spec's,
+// and different: a spec says what will be built, this says why anyone
+// thinks it should be, and what was considered instead.
+var Sections = []string{
+	"Question",
+	"What we know",
+	"What we do not know",
+	"Options",
+	"Recommendation",
+}
+
+// Template is the document `procoder analyze brief` prints.
+const Template = `# %s
+
+Status: open
+Created: %s
+
+## Question
+
+<!-- The thing that is actually undecided, in one sentence. Not the
+     solution you already have in mind — the question it answers. -->
+
+## What we know
+
+<!-- Evidence, with where it came from. A number nobody measured and a
+     claim nobody checked are both guesses; say which this is. -->
+
+## What we do not know
+
+<!-- The gaps that would change the recommendation if filled. Name what
+     would resolve each one, so somebody can go and find out. -->
+
+## Options
+
+<!-- Each one a real option somebody could choose, with its cost. An
+     option nobody would pick is not an option, it is padding. -->
+
+## Recommendation
+
+<!-- Which option, and the reason. If the honest answer is "we do not
+     know enough yet", that is a recommendation too — say what to do
+     next to find out. -->
+`
+
+// Files lists the analysis documents in root, sorted.
+func Files(root string) []string {
+	entries, err := os.ReadDir(filepath.Join(root, Dir))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+			out = append(out, filepath.Join(root, Dir, e.Name()))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Gaps reports what is still unanswered in one analysis document.
+//
+// The standard is the one `spec check` already holds a spec to: a heading
+// is not an answer, and a section still carrying its template comment has
+// recorded nothing. A phase whose documents nobody has to fill in is a
+// formality that costs time and buys nothing, so this refuses the same
+// way and for the same reason.
+func Gaps(text string) []string {
+	var gaps []string
+	for _, s := range Sections {
+		body := textutil.Section(text, s)
+		if body == "" && !strings.Contains(text, "## "+s) {
+			gaps = append(gaps, "section missing: "+s)
+			continue
+		}
+		if strings.TrimSpace(textutil.StripComments(body)) == "" {
+			gaps = append(gaps, "section empty: "+s+" — a heading is not an answer")
+		}
+	}
+	return gaps
+}
+
+// Check reports whether each analysis document has been filled in.
+func Check(root, name string, out func(string)) int {
+	var files []string
+	switch {
+	case name == "" || name == "all":
+		files = Files(root)
+		if len(files) == 0 {
+			out("no analysis to check — nothing under " + Dir)
+			return 0
+		}
+	default:
+		if name != filepath.Base(name) || strings.Contains(name, "..") {
+			out(fmt.Sprintf("invalid analysis name %q — names are plain file names", name))
+			return 2
+		}
+		f := filepath.Join(root, Dir, name+".md")
+		if _, err := os.Stat(f); err != nil {
+			out("no analysis " + name + " — `procoder analyze list` shows what exists")
+			return 2
+		}
+		files = []string{f}
+	}
+
+	worst := 0
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			out(filepath.Base(path) + ": unreadable — " + err.Error())
+			worst = 2
+			continue
+		}
+		id := strings.TrimSuffix(filepath.Base(path), ".md")
+		gaps := Gaps(string(raw))
+		if len(gaps) == 0 {
+			out("analysis " + id + ": COMPLETE — every section answered")
+			continue
+		}
+		out("analysis " + id + ": NOT ready — the quality controller found:")
+		for _, g := range gaps {
+			out("  - " + g)
+		}
+		if worst < 1 {
+			worst = 1
+		}
+	}
+	return worst
+}
+
+// SpecSource names the analysis a spec came from, when one exists.
+//
+// Matched by name: an analysis and the spec it produced share a slug,
+// which is the convention `procoder analyze brief <name>` and
+// `procoder spec template <name>` already put in place. Empty when there
+// is none, because analysis is available and never required — a spec
+// whose author already knew what to build owes nobody a document
+// recording that they knew.
+func SpecSource(root, specName string) string {
+	path := filepath.Join(root, Dir, specName+".md")
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Join(Dir, specName+".md"))
+}

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -1,0 +1,96 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func write(t *testing.T, root, name, body string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The phase is only worth having if its documents are worth reading. A
+// brief whose sections are still template comments has recorded nothing,
+// and passing it would make the phase a formality that costs time and
+// buys nothing — the same standard `spec check` already holds a spec to,
+// for the same reason.
+// proved by: dropped the StripComments call from Gaps — a document that
+// is nothing but its own template passes as COMPLETE, and the phase
+// becomes a file somebody created once.
+func TestAHollowAnalysisIsRefused(t *testing.T) {
+	hollow := "# probe\n\nStatus: open\n"
+	for _, s := range Sections {
+		hollow += "\n## " + s + "\n\n<!-- the prompt nobody answered -->\n"
+	}
+	gaps := Gaps(hollow)
+	if len(gaps) != len(Sections) {
+		t.Fatalf("every unanswered section is a gap, got %d of %d: %v", len(gaps), len(Sections), gaps)
+	}
+
+	// A heading that is not there at all is a different gap from one that
+	// is there and empty — a reader fixing the first adds a section, the
+	// second fills one.
+	missing := Gaps("# probe\n\nStatus: open\n")
+	for _, g := range missing {
+		if !strings.Contains(g, "section missing") {
+			t.Errorf("an absent section is missing, not empty: %q", g)
+		}
+	}
+
+	filled := "# probe\n\nStatus: open\n"
+	for _, s := range Sections {
+		filled += "\n## " + s + "\n\nSomething a person actually wrote.\n"
+	}
+	if gaps := Gaps(filled); len(gaps) != 0 {
+		t.Errorf("a document somebody filled in passes: %v", gaps)
+	}
+}
+
+// Check reports per document and refuses the tree while any is hollow.
+// proved by: returned 0 from Check whatever the gaps — `analyze check`
+// says NOT ready and exits clean, so nothing downstream can rely on it.
+func TestCheckRefusesWhileAnyDocumentIsHollow(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, Dir+"/hollow.md", "# hollow\n\n## Question\n\n<!-- unanswered -->\n")
+
+	var lines []string
+	if code := Check(root, "all", func(s string) { lines = append(lines, s) }); code != 1 {
+		t.Fatalf("a hollow document refuses: exit %d\n%s", code, strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "NOT ready") {
+		t.Errorf("and says so: %v", lines)
+	}
+
+	// An empty tree is not a fault: the phase is available, never
+	// required, so a repository that never used it is not failing.
+	lines = nil
+	if code := Check(t.TempDir(), "all", func(s string) { lines = append(lines, s) }); code != 0 {
+		t.Errorf("no analysis is not a failure: exit %d %v", code, lines)
+	}
+}
+
+// A spec that came from an analysis says so, and one that did not owes
+// nobody a document recording that its author already knew what to build.
+// proved by: returned the path unconditionally — every spec claims an
+// analysis, including the ones with no such file, and the note points at
+// something that is not there.
+func TestASpecNamesItsAnalysisOnlyWhenThereIsOne(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, Dir+"/thing.md", "# thing\n")
+
+	if got := SpecSource(root, "thing"); !strings.Contains(got, "thing.md") {
+		t.Errorf("a spec with an analysis names it: %q", got)
+	}
+	if got := SpecSource(root, "other"); got != "" {
+		t.Errorf("a spec without one says nothing: %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,13 @@ type Config struct {
 	MaxFileMB int
 	// LintBlock: lint findings block the gate instead of being reported.
 	LintBlock bool
+
+	// PlanningMethod names who owns the planning artifacts: "procoder"
+	// (the default) or "bmad". It moves planning and nothing else — the
+	// gate, the suite, the release controller and the rest read the same
+	// tree and reach the same verdict either way, which is the only reason
+	// a repository that plans elsewhere would install procoder at all.
+	PlanningMethod string
 	// TestBlock: todo and story closes run the test suite and refuse
 	// while it fails (or cannot be verified).
 	TestBlock bool
@@ -178,6 +185,19 @@ func Load(root string) Config {
 			cfg.BlockDefaultBranch = value == "block"
 		case "lint.policy":
 			cfg.LintBlock = value == "block"
+		case "planning.method":
+			// A typo here silently decides which methodology governs the
+			// repository, which is more consequential than most keys: a
+			// mistyped "bmad" would leave a BMad shop being governed by
+			// procoder's own chain and wondering why its artifacts are
+			// ignored.
+			if KnownPlanningMethod(value) {
+				cfg.PlanningMethod = value
+			} else {
+				cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
+					Reason: fmt.Sprintf("not a planning method procoder knows — it has %s",
+						strings.Join(PlanningMethods, ", "))})
+			}
 		case "test.policy":
 			cfg.TestBlock = value == "block"
 		case "sprint.retro":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -336,3 +336,56 @@ func TestAnEmptyDebtMarkerKeepsTheDefault(t *testing.T) {
 		t.Errorf("DebtMarker = %q, want the default %q", got, "debt:")
 	}
 }
+
+// A typo in this key silently decides which methodology governs the
+// repository, which is more consequential than most: a mistyped "bmad"
+// leaves a repository that plans elsewhere being governed by procoder's
+// own chain and wondering why its artifacts are ignored.
+// proved by: accepted any value into cfg.PlanningMethod — "nonsense"
+// becomes the effective method, no Problem names the line, and the
+// repository is governed by a method that does not exist.
+func TestAnUnknownPlanningMethodIsAProblemAndTheDefaultRuns(t *testing.T) {
+	root := t.TempDir()
+	write := func(body string) Config {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(root, ".procoder"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".procoder", "config.toml"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return Load(root)
+	}
+
+	cfg := write("[planning]\nmethod = \"nonsense\"\n")
+	if len(cfg.Problems) != 1 {
+		t.Fatalf("a value procoder cannot act on is exactly one Problem: %+v", cfg.Problems)
+	}
+	if cfg.Problems[0].Line != 2 {
+		t.Errorf("the Problem must name the line: %+v", cfg.Problems[0])
+	}
+	if !strings.Contains(cfg.Problems[0].Reason, "procoder, bmad") {
+		t.Errorf("and say what procoder does know: %q", cfg.Problems[0].Reason)
+	}
+	// The run continues on the default rather than on the typo.
+	if cfg.Planning() != "procoder" {
+		t.Errorf("an unusable value falls back to the default: %q", cfg.Planning())
+	}
+
+	// Both documented values are accepted, and neither is a Problem.
+	for _, m := range PlanningMethods {
+		cfg := write("[planning]\nmethod = \"" + m + "\"\n")
+		if len(cfg.Problems) != 0 {
+			t.Errorf("%s is a method procoder knows: %+v", m, cfg.Problems)
+		}
+		if cfg.Planning() != m {
+			t.Errorf("%s must be the effective method, got %q", m, cfg.Planning())
+		}
+	}
+
+	// And a repository that said nothing gets the default without having
+	// to spell it, so no caller can disagree about what the default is.
+	if got := (Config{}).Planning(); got != "procoder" {
+		t.Errorf("the unset default is procoder: %q", got)
+	}
+}

--- a/internal/config/visibility.go
+++ b/internal/config/visibility.go
@@ -77,3 +77,34 @@ func severityRank(s string) int {
 
 // KnownSeverity reports whether s is a severity procoder can act on.
 func KnownSeverity(s string) bool { return severityRank(s) >= 0 }
+
+// PlanningMethods are the values [planning] method accepts. "procoder" is
+// the default and means the chain under .procoder/; "bmad" means a
+// separately installed BMad Method owns the planning artifacts and
+// procoder reads them.
+//
+// BMad is named here to describe interoperation — which tool wrote the
+// files procoder is about to read — and nowhere as the name of a procoder
+// feature. TestNoProcoderFeatureIsNamedAfterATrademark holds that line.
+var PlanningMethods = []string{"procoder", "bmad"}
+
+// KnownPlanningMethod reports whether s is a planning method procoder can
+// act on.
+func KnownPlanningMethod(s string) bool {
+	for _, m := range PlanningMethods {
+		if s == m {
+			return true
+		}
+	}
+	return false
+}
+
+// Planning is the effective method: the default where the repository said
+// nothing, so callers never have to spell the default themselves and
+// cannot disagree about what it is.
+func (c Config) Planning() string {
+	if c.PlanningMethod == "" {
+		return "procoder"
+	}
+	return c.PlanningMethod
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"procoder/internal/config"
+	"procoder/internal/planning"
 	"procoder/internal/tools"
 )
 
@@ -83,6 +84,8 @@ func Run(root string, stdout io.Writer) int {
 		}
 		fmt.Fprintf(stdout, "  ok  %-14s %-28s %s\n", n, strings.Join(r.exts, " "), version(bin, r.tool))
 	}
+
+	planningLine(root, stdout)
 
 	if len(byTool) == 0 {
 		fmt.Fprintln(stdout, "no files in this tree have a formatter-covered type")
@@ -166,4 +169,26 @@ func Root() string {
 		return "."
 	}
 	return tools.RepoRoot(wd)
+}
+
+// planningLine reports the planning tool a repository named, when it named
+// one procoder does not ship. A repository whose planning depends on
+// something absent needs to know it is absent — and which version is
+// there when it is, because the artifact layout procoder reads is a
+// version fact.
+//
+// Silent under the default. A repository planning in procoder's own chain
+// has no external tool to report, and a line saying so on every doctor run
+// is noise.
+func planningLine(root string, stdout io.Writer) {
+	if config.Load(root).Planning() != "bmad" {
+		return
+	}
+	fmt.Fprintln(stdout)
+	if !planning.Installed(root) {
+		fmt.Fprintf(stdout, " GAP  %-14s %-28s %s\n", "bmad", "[planning] method", "missing")
+		fmt.Fprintln(stdout, "      this repository plans in BMad Method and no installation is here (manual: npx bmad-method install)")
+		return
+	}
+	fmt.Fprintf(stdout, "  ok  %-14s %-28s %s\n", "bmad", "[planning] method", planning.Version(root))
 }

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -21,6 +21,7 @@ import (
 	"procoder/internal/gitx"
 	"procoder/internal/infra"
 	"procoder/internal/lessons"
+	"procoder/internal/planning"
 	"procoder/internal/portability"
 	"procoder/internal/security"
 )
@@ -121,6 +122,12 @@ func collectHygiene(root string, cfg config.Config, changed []string) []gitx.Fin
 	// same, while nothing anywhere asked. A rule file that has drifted
 	// means another host is reading rules this repository no longer holds.
 	out = append(out, portability.AgentsDrift(root)...)
+	// The planning domain answers only whether the method the repository
+	// chose can be honoured — is the tool it named actually here, do its
+	// artifacts parse. It says nothing about the code, which is what keeps
+	// `procoder check` byte-identical across the setting for a repository
+	// that left the method at its default.
+	out = append(out, planning.Check(root, cfg.Planning())...)
 	out = append(out, gitx.ConflictMarkers(changed)...)
 	out = append(out, gitx.JunkFiles(changed)...)
 	out = append(out, gitx.Oversized(changed, cfg.MaxFileMB)...)

--- a/internal/gitcmd/seam_test.go
+++ b/internal/gitcmd/seam_test.go
@@ -1,0 +1,100 @@
+package gitcmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"procoder/internal/config"
+	"procoder/internal/gitx"
+)
+
+// The seam the whole planning setting rests on: it moves planning, and
+// moves nothing else. That is the only reason a repository which plans
+// elsewhere would install procoder at all, and the tempting design — a
+// spectrum where the setting dials procoder back by degrees — erodes it
+// one exception at a time.
+//
+// Asserted by comparing every finding the gate produces about the CODE
+// across both settings. The planning domain's own findings are excluded
+// on purpose: those are the setting doing its job, and including them
+// would make this test assert the two are the same command rather than
+// that governance is untouched.
+// proved by: made any governance leg consult cfg.Planning() — gate the
+// docs obligation on it, or skip lint under "bmad" — and the two lists
+// stop matching, where every other test in the tree stays green because
+// each leg is still correct in isolation.
+func TestGovernanceIsUntouchedByThePlanningMethod(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("no git on PATH")
+	}
+	root := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q", "-b", "main")
+	run("config", "user.email", "t@example.com")
+	run("config", "user.name", "t")
+
+	write := func(name, body string) {
+		t.Helper()
+		p := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A tree with something for the governance legs to find, and a BMad
+	// installation so the "bmad" run is honoured rather than refused.
+	write("a.go", "package x\n\nfunc F() int { return 1 }\n")
+	write("README.md", "# fixture\n\n[missing](./nope.md)\n")
+	write("_bmad/manifest.yaml", "version: \"6.11.0\"\n")
+	write("_bmad-output/implementation-artifacts/sprint-status.yaml",
+		"development_status:\n  1-1: done\n")
+	run("add", "-A")
+	run("commit", "-qm", "first")
+
+	changed := []string{filepath.Join(root, "a.go"), filepath.Join(root, "README.md")}
+
+	// Only the findings that are NOT the planning domain's own. Those are
+	// the setting working; everything else is governance, which must not
+	// notice the setting at all.
+	governance := func(method string) []string {
+		cfg := config.Load(root)
+		cfg.PlanningMethod = method
+		var out []string
+		for _, f := range CollectFor(root, cfg, changed, "") {
+			if isPlanning(f) {
+				continue
+			}
+			out = append(out, f.Message)
+		}
+		return out
+	}
+
+	asProcoder := governance("procoder")
+	asBmad := governance("bmad")
+
+	if len(asProcoder) == 0 {
+		t.Fatal("the fixture must produce findings, or this comparison proves nothing")
+	}
+	if !reflect.DeepEqual(asProcoder, asBmad) {
+		t.Errorf("the planning method must not change what the gate says about the code:\n procoder: %v\n bmad:     %v",
+			asProcoder, asBmad)
+	}
+}
+
+// isPlanning identifies the planning domain's own findings by the tag
+// every domain already puts at the end of its message.
+func isPlanning(f gitx.Finding) bool {
+	return strings.Contains(f.Message, "(planning)")
+}

--- a/internal/planning/bmad.go
+++ b/internal/planning/bmad.go
@@ -75,7 +75,7 @@ func OutputFolder(root string) (string, *gitx.Finding) {
 		if !ok || strings.TrimSpace(k) != "output_folder" {
 			continue
 		}
-		if val := strings.Trim(strings.TrimSpace(v), `"'`); val != "" {
+		if val := scalar(v); val != "" {
 			return val, nil
 		}
 	}
@@ -150,7 +150,7 @@ func parseDevelopmentStatus(src string) (entries []Status, ok bool) {
 		if !cut {
 			continue
 		}
-		value := strings.Trim(strings.TrimSpace(v), `"'`)
+		value := scalar(v)
 		if value == "" {
 			continue
 		}
@@ -187,26 +187,34 @@ func Check(root, method string) []gitx.Finding {
 // the procoder-native report uses: one line for the sprint, then the work
 // that is not finished. A repository reads its own state, not a
 // translation of it.
+//
+// The lines carry the `sprint:` prefix the native report uses rather than
+// a prefix of their own. That prefix is an invariant — the report is
+// searched by it, in this repository's own tests among other places — and
+// a repository that switched methodology would otherwise have no sprint
+// line at all as far as any reader looking for one is concerned. Which
+// methodology produced it goes in the content, where it informs without
+// hiding the line.
 func Report(root, method string) []string {
 	if method != "bmad" {
 		return nil
 	}
 	if !Installed(root) {
-		return []string{"planning: bmad — unknown (no BMad installation found)"}
+		return []string{"sprint: unknown — no BMad installation found, and this repository plans in bmad"}
 	}
 	output, problem := OutputFolder(root)
 	if problem != nil {
-		return []string{"planning: bmad — unknown (" + problem.Message + ")"}
+		return []string{"sprint: unknown — " + problem.Message}
 	}
 	path := StatusFile(root, output)
 	entries, findings := SprintStatus(path)
 	for _, f := range findings {
 		if f.Blocking {
-			return []string{"planning: bmad — unknown (" + f.Message + ")"}
+			return []string{"sprint: unknown — " + f.Message}
 		}
 	}
 	if len(entries) == 0 {
-		return []string{"planning: bmad — no planning artifacts yet"}
+		return []string{"sprint: none — no planning artifacts yet (bmad)"}
 	}
 
 	done, open := 0, []Status{}
@@ -223,7 +231,7 @@ func Report(root, method string) []string {
 		}
 		open = append(open, e)
 	}
-	out := []string{fmt.Sprintf("planning: bmad — %d done, %d open", done, len(open))}
+	out := []string{fmt.Sprintf("sprint: %d done, %d open (bmad)", done, len(open))}
 	for i, e := range open {
 		if i == openCap {
 			out = append(out, fmt.Sprintf("  … %d more open — read %s", len(open)-openCap,
@@ -262,10 +270,39 @@ func Version(root string) string {
 			if key != "version" && key != "bmad_version" {
 				continue
 			}
-			if val := strings.Trim(strings.TrimSpace(v), `"'`); val != "" {
+			if val := scalar(v); val != "" {
 				return val
 			}
 		}
 	}
 	return "present (version unknown)"
+}
+
+// scalar reads the value half of a `key: value` or `key = value` line as
+// the format's own reader would: an unquoted `#` starts a comment, one
+// inside quotes does not, and the surrounding quotes come off last.
+//
+// Written because getting this wrong is silent in both directions. A
+// TOML `output_folder = "planning" # where we put it` parsed naively
+// yields a directory that does not exist, so a repository mid-sprint
+// reads as one that has planned nothing. A YAML `1-1: done # tuesday`
+// yields a status nothing recognises, so a finished story is counted
+// open AND reported as an unknown status. Both look like answers.
+func scalar(v string) string {
+	v = strings.TrimSpace(v)
+	quote := byte(0)
+	for i := 0; i < len(v); i++ {
+		switch {
+		case quote != 0:
+			if v[i] == quote {
+				quote = 0
+			}
+		case v[i] == '"' || v[i] == '\'':
+			quote = v[i]
+		case v[i] == '#':
+			v = strings.TrimSpace(v[:i])
+			i = len(v) // stop: everything after is a comment
+		}
+	}
+	return strings.Trim(v, `"'`)
 }

--- a/internal/planning/bmad.go
+++ b/internal/planning/bmad.go
@@ -1,0 +1,271 @@
+// Package planning reads the planning artifacts a repository keeps, from
+// wherever that repository keeps them.
+//
+// Procoder's governance never needed to know where a plan came from. It
+// asks whether there is one, whether it is complete, and whether a story
+// is done — and a repository planning in BMad Method can answer all three
+// as readily as one planning in .procoder/. This package is the seam that
+// lets it: `[planning] method = "bmad"` moves where those answers are
+// read from, and moves nothing else. The gate, the suite, the release
+// controller and the rest see the same tree and reach the same verdict
+// either way.
+//
+// Nothing here invokes BMad, spawns its skills, or reaches the network.
+// It reads files on disk, because the gate runs on every commit.
+// Procoder also never writes into BMad's directories: BMad owns what it
+// wrote, and a tool that edits the artifacts it judges has no standing to
+// judge them.
+package planning
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// InstallDir is BMad's own marker directory, created by its installer.
+const InstallDir = "_bmad"
+
+// defaultOutput is BMad's default output_folder. A repository that chose
+// another is read from its config rather than assumed — see OutputFolder.
+const defaultOutput = "_bmad-output"
+
+// Status is one entry in BMad's development_status map.
+type Status struct {
+	Key   string
+	Value string
+}
+
+// Known are the statuses BMad's own sprint-status template documents. A
+// status outside this set is reported BY NAME rather than mapped onto the
+// nearest procoder equivalent: deciding that "blocked" is close enough to
+// "open" is how a status machine quietly loses a state, and the report
+// then misrepresents work without anything saying so.
+var Known = map[string]bool{
+	"backlog": true, "ready-for-dev": true, "in-progress": true,
+	"review": true, "done": true, "optional": true,
+}
+
+// Installed reports whether a BMad installation is present in root.
+func Installed(root string) bool {
+	info, err := os.Stat(filepath.Join(root, InstallDir))
+	return err == nil && info.IsDir()
+}
+
+// OutputFolder is where BMad writes, read from its own config rather than
+// assumed. A repository that answered its installer's prompt with
+// something other than the default keeps that answer here, and procoder
+// reporting on a directory the repository is not using would be worse than
+// reporting nothing.
+func OutputFolder(root string) (string, *gitx.Finding) {
+	path := filepath.Join(root, InstallDir, "config.toml")
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return defaultOutput, nil
+	}
+	if err != nil {
+		return "", &gitx.Finding{Blocking: true, File: path,
+			Message: fmt.Sprintf("planning config NOT read — %v; procoder will not guess where the artifacts live (planning)", err)}
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(k) != "output_folder" {
+			continue
+		}
+		if val := strings.Trim(strings.TrimSpace(v), `"'`); val != "" {
+			return val, nil
+		}
+	}
+	return defaultOutput, nil
+}
+
+// StatusFile is where the sprint state lives, given the output folder.
+func StatusFile(root, output string) string {
+	return filepath.Join(root, output, "implementation-artifacts", "sprint-status.yaml")
+}
+
+// SprintStatus reads BMad's development_status map.
+//
+// Three answers, and they are deliberately distinct. A file that is not
+// there is a repository that has planned nothing yet, which is ordinary.
+// A file that cannot be read or parsed is a check that did not run, which
+// blocks. A file that parses is the sprint, whatever its statuses say.
+func SprintStatus(path string) ([]Status, []gitx.Finding) {
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []gitx.Finding{{Blocking: true, File: path,
+			Message: fmt.Sprintf("sprint status NOT read — %v (planning)", err)}}
+	}
+
+	entries, ok := parseDevelopmentStatus(string(raw))
+	if !ok {
+		return nil, []gitx.Finding{{Blocking: true, File: path,
+			Message: "sprint status NOT parsed — no development_status block; procoder will not report a sprint it could not read (planning)"}}
+	}
+
+	var out []Status
+	var findings []gitx.Finding
+	for _, e := range entries {
+		out = append(out, e)
+		if !Known[e.Value] {
+			findings = append(findings, gitx.Finding{File: path,
+				Message: fmt.Sprintf("%s: status %q is not one procoder knows — reporting it by name rather than guessing which of %s it means (planning)",
+					e.Key, e.Value, "backlog, ready-for-dev, in-progress, review, done")})
+		}
+	}
+	return out, findings
+}
+
+// parseDevelopmentStatus pulls the development_status mapping out of the
+// status file. Written by hand rather than with a YAML dependency: the
+// block is a flat map of scalars, procoder adds no dependency for what a
+// few lines cover, and a parser that accepts less than YAML does cannot
+// silently accept something BMad would reject.
+//
+// ok is false when the block is absent — which is a file procoder cannot
+// read as a sprint, distinct from a sprint with nothing in it.
+func parseDevelopmentStatus(src string) (entries []Status, ok bool) {
+	inBlock := false
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			// A key at column zero ends the block and starts another.
+			inBlock = strings.HasPrefix(trimmed, "development_status:")
+			ok = ok || inBlock
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		k, v, cut := strings.Cut(trimmed, ":")
+		if !cut {
+			continue
+		}
+		value := strings.Trim(strings.TrimSpace(v), `"'`)
+		if value == "" {
+			continue
+		}
+		entries = append(entries, Status{Key: strings.TrimSpace(k), Value: value})
+	}
+	return entries, ok
+}
+
+// Check is the planning domain's gate leg: it answers whether the method
+// the repository chose can actually be honoured.
+//
+// A repository that set "bmad" and has no BMad installed gets a blocking
+// finding naming both. Falling back to procoder's own chain would leave
+// it believing BMad governs its planning while procoder quietly governed
+// it instead, and the first they would learn of it is a report that does
+// not match the artifacts on disk.
+func Check(root, method string) []gitx.Finding {
+	if method != "bmad" {
+		return nil
+	}
+	if !Installed(root) {
+		return []gitx.Finding{{Blocking: true, File: filepath.Join(root, InstallDir),
+			Message: "[planning] method = \"bmad\" but no BMad installation is here — procoder did NOT fall back to its own chain, because a repository that chose one methodology must not be governed by the other without being told. Install it, or set the method back to \"procoder\" (planning)"}}
+	}
+	output, problem := OutputFolder(root)
+	if problem != nil {
+		return []gitx.Finding{*problem}
+	}
+	_, findings := SprintStatus(StatusFile(root, output))
+	return findings
+}
+
+// Report renders sprint state for `procoder status`, in the same shape
+// the procoder-native report uses: one line for the sprint, then the work
+// that is not finished. A repository reads its own state, not a
+// translation of it.
+func Report(root, method string) []string {
+	if method != "bmad" {
+		return nil
+	}
+	if !Installed(root) {
+		return []string{"planning: bmad — unknown (no BMad installation found)"}
+	}
+	output, problem := OutputFolder(root)
+	if problem != nil {
+		return []string{"planning: bmad — unknown (" + problem.Message + ")"}
+	}
+	path := StatusFile(root, output)
+	entries, findings := SprintStatus(path)
+	for _, f := range findings {
+		if f.Blocking {
+			return []string{"planning: bmad — unknown (" + f.Message + ")"}
+		}
+	}
+	if len(entries) == 0 {
+		return []string{"planning: bmad — no planning artifacts yet"}
+	}
+
+	done, open := 0, []Status{}
+	for _, e := range entries {
+		if e.Value == "done" {
+			done++
+			continue
+		}
+		// "optional" is a retrospective that may be skipped: counted as
+		// neither done nor outstanding, because listing it as work would
+		// make every epic look permanently unfinished.
+		if e.Value == "optional" {
+			continue
+		}
+		open = append(open, e)
+	}
+	out := []string{fmt.Sprintf("planning: bmad — %d done, %d open", done, len(open))}
+	for i, e := range open {
+		if i == openCap {
+			out = append(out, fmt.Sprintf("  … %d more open — read %s", len(open)-openCap,
+				filepath.ToSlash(strings.TrimPrefix(path, root+string(filepath.Separator)))))
+			break
+		}
+		out = append(out, "  open: "+e.Key+" — "+e.Value)
+	}
+	return out
+}
+
+// openCap is how many outstanding entries the report names before it
+// starts counting: enough to see what the sprint is about, short enough
+// that a large backlog does not bury the rest of the report.
+const openCap = 5
+
+// Version is the installed BMad version, read from the manifest its own
+// installer writes. "present (version unknown)" where the installation is
+// there but does not say — the same wording doctor uses for a tool whose
+// --version it could not read, because it is the same situation.
+func Version(root string) string {
+	for _, name := range []string{"manifest.yaml", "config.toml", "manifest.json"} {
+		raw, err := os.ReadFile(filepath.Join(root, InstallDir, name))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(raw), "\n") {
+			k, v, ok := strings.Cut(line, ":")
+			if !ok {
+				k, v, ok = strings.Cut(line, "=")
+			}
+			if !ok {
+				continue
+			}
+			key := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(k), "-"))
+			if key != "version" && key != "bmad_version" {
+				continue
+			}
+			if val := strings.Trim(strings.TrimSpace(v), `"'`); val != "" {
+				return val
+			}
+		}
+	}
+	return "present (version unknown)"
+}

--- a/internal/planning/bmad_test.go
+++ b/internal/planning/bmad_test.go
@@ -1,0 +1,184 @@
+package planning
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func fixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, body := range files {
+		p := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+const statusYAML = `generated: 08-24-2026 09:00
+project: Fixture
+
+development_status:
+  epic-1: in-progress
+  1-1-auth: done
+  1-2-profile: ready-for-dev
+  epic-1-retrospective: optional
+`
+
+// A repository that named a methodology and does not have it installed
+// must be told. Falling back to procoder's own chain would leave it
+// believing BMad governs its planning while procoder quietly governed it
+// instead, and the first they would learn of it is a report that does not
+// match the artifacts on disk.
+// proved by: returned nil from Check when the install is absent — the
+// gate goes green and the repository is governed by a methodology it did
+// not choose.
+func TestAChosenMethodThatIsNotInstalledBlocks(t *testing.T) {
+	root := fixture(t, map[string]string{"a.txt": "x\n"})
+
+	got := Check(root, "bmad")
+	if len(got) != 1 || !got[0].Blocking {
+		t.Fatalf("a method that cannot be honoured blocks: %+v", got)
+	}
+	if !strings.Contains(got[0].Message, "bmad") {
+		t.Errorf("the finding must name the setting: %q", got[0].Message)
+	}
+
+	// And the default method asks nothing at all — the setting governs
+	// planning, so a repository that left it alone sees no planning
+	// findings whatsoever.
+	if got := Check(root, "procoder"); len(got) != 0 {
+		t.Errorf("the default method has nothing to check: %+v", got)
+	}
+}
+
+// The whole promise of the seam: a repository that plans elsewhere sees
+// its own sprint reflected back, not an empty procoder backlog beside the
+// one being worked.
+// proved by: had Report ignore development_status and return the empty
+// answer — the repository is told it has planned nothing while its status
+// file lists four entries.
+func TestSprintStateComesFromTheArtifactsOnDisk(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"_bmad/manifest.yaml": "version: \"6.11.0\"\n",
+		"_bmad-output/implementation-artifacts/sprint-status.yaml": statusYAML,
+	})
+
+	lines := Report(root, "bmad")
+	joined := strings.Join(lines, "\n")
+	// One done (1-1-auth). Two open: the epic and the ready-for-dev story.
+	// The retrospective is "optional" and counts as neither — listing it
+	// as work would make every epic look permanently unfinished.
+	if !strings.Contains(joined, "1 done, 2 open") {
+		t.Fatalf("the counts must come from the file:\n%s", joined)
+	}
+	for _, want := range []string{"1-2-profile", "epic-1"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("outstanding work is named: %q missing from\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "retrospective") {
+		t.Errorf("an optional retrospective is not outstanding work:\n%s", joined)
+	}
+
+	// The version doctor reports is read from the installation, not guessed.
+	if v := Version(root); v != "6.11.0" {
+		t.Errorf("the installed version is a fact to read: %q", v)
+	}
+}
+
+// Unreadable and absent are different answers, and only one of them is
+// the repository's choice. A parse failure reported as "nothing planned
+// yet" sends somebody to plan work that is already planned.
+// proved by: returned nil findings for a file with no development_status
+// block — the sprint reads as empty, and a repository mid-sprint is told
+// it has not started.
+func TestAStatusFileThatWillNotParseIsNotAnEmptySprint(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"_bmad/manifest.yaml": "version: \"6.11.0\"\n",
+		"_bmad-output/implementation-artifacts/sprint-status.yaml": "generated: 08-24-2026\nproject: Fixture\n",
+	})
+
+	got := Check(root, "bmad")
+	if len(got) != 1 || !got[0].Blocking {
+		t.Fatalf("a file that cannot be read as a sprint blocks: %+v", got)
+	}
+	if !strings.Contains(got[0].File, "sprint-status.yaml") {
+		t.Errorf("the finding must name the file: %q", got[0].File)
+	}
+
+	// Absent is the ordinary case: a fresh install has planned nothing,
+	// and that is not a fault.
+	bare := fixture(t, map[string]string{"_bmad/manifest.yaml": "version: \"6.11.0\"\n"})
+	if got := Check(bare, "bmad"); len(got) != 0 {
+		t.Errorf("no artifacts yet is not a finding: %+v", got)
+	}
+	if lines := Report(bare, "bmad"); !strings.Contains(strings.Join(lines, "\n"), "no planning artifacts yet") {
+		t.Errorf("and the report says so plainly: %v", lines)
+	}
+}
+
+// BMad owns its status vocabulary and may extend it. Deciding that
+// "blocked" is close enough to one of procoder's own is how a status
+// machine quietly loses a state, and the report then misrepresents work
+// with nothing saying so.
+// proved by: dropped the Known check and mapped anything unrecognised to
+// "backlog" — a blocked story is reported as not yet started, and the
+// finding that would have said so never appears.
+func TestAnUnknownStatusIsReportedByName(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"_bmad/manifest.yaml": "version: \"6.11.0\"\n",
+		"_bmad-output/implementation-artifacts/sprint-status.yaml": "development_status:\n  1-1-auth: blocked\n  1-2-profile: done\n",
+	})
+
+	got := Check(root, "bmad")
+	if len(got) != 1 {
+		t.Fatalf("exactly one unknown status, exactly one finding: %+v", got)
+	}
+	if !strings.Contains(got[0].Message, `"blocked"`) {
+		t.Errorf("the status must be quoted by name: %q", got[0].Message)
+	}
+	// Reported, not blocking: BMad extending its own vocabulary is not a
+	// fault in the repository, and blocking every commit over it would
+	// make procoder unusable to anyone tracking a state it has not heard of.
+	if got[0].Blocking {
+		t.Error("an unknown status is news, not a refusal")
+	}
+	// The known one alongside it produces nothing.
+	if strings.Contains(got[0].Message, "1-2-profile") {
+		t.Errorf("a status procoder knows is silent: %q", got[0].Message)
+	}
+}
+
+// A repository that answered BMad's installer with a non-default output
+// folder keeps that answer, and procoder reads it rather than assuming.
+// Reporting on a directory the repository is not using would be worse
+// than reporting nothing, because it looks like an answer.
+// proved by: returned the hardcoded default from OutputFolder — the
+// sprint reads as absent while the real one sits in the configured
+// directory.
+func TestTheOutputFolderIsReadFromTheInstallation(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"_bmad/manifest.yaml": "version: \"6.11.0\"\n",
+		"_bmad/config.toml":   "output_folder = \"planning\"\n",
+		"planning/implementation-artifacts/sprint-status.yaml": statusYAML,
+	})
+
+	folder, problem := OutputFolder(root)
+	if problem != nil {
+		t.Fatalf("a readable config is not a problem: %+v", problem)
+	}
+	if folder != "planning" {
+		t.Fatalf("the repository's own answer wins: %q", folder)
+	}
+	if lines := Report(root, "bmad"); !strings.Contains(strings.Join(lines, "\n"), "1 done, 2 open") {
+		t.Errorf("and the sprint is found there: %v", lines)
+	}
+}

--- a/internal/planning/bmad_test.go
+++ b/internal/planning/bmad_test.go
@@ -182,3 +182,91 @@ func TestTheOutputFolderIsReadFromTheInstallation(t *testing.T) {
 		t.Errorf("and the sprint is found there: %v", lines)
 	}
 }
+
+// Both formats use # for comments and both quote values, and getting
+// that wrong is silent in either direction: a TOML output_folder with a
+// trailing comment points at a directory that does not exist, so a
+// repository mid-sprint reads as one that has planned nothing; a YAML
+// status with a trailing comment matches nothing procoder knows, so a
+// finished story is counted open AND reported as an unknown status. Both
+// look like answers.
+// proved by: replaced scalar() with strings.Trim(strings.TrimSpace(v),
+// `"'`) — the form this fixes — and each case below comes back carrying
+// its comment.
+func TestAnInlineCommentIsNotPartOfTheValue(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"_bmad/manifest.yaml": "version: \"6.11.0\" # pinned\n",
+		"_bmad/config.toml":   "output_folder = \"planning\" # where we put it\n",
+		"planning/implementation-artifacts/sprint-status.yaml": "development_status:\n  1-1-auth: done # finished tuesday\n  1-2-profile: ready-for-dev\n",
+	})
+
+	folder, problem := OutputFolder(root)
+	if problem != nil {
+		t.Fatalf("a readable config is not a problem: %+v", problem)
+	}
+	if folder != "planning" {
+		t.Errorf("the comment is not part of the folder: %q", folder)
+	}
+	if v := Version(root); v != "6.11.0" {
+		t.Errorf("the comment is not part of the version: %q", v)
+	}
+
+	// The commented status is recognised, so it counts as done and
+	// produces no unknown-status finding.
+	if got := Check(root, "bmad"); len(got) != 0 {
+		t.Errorf("a status with a trailing comment is still a status procoder knows: %+v", got)
+	}
+	if lines := Report(root, "bmad"); !strings.Contains(strings.Join(lines, "\n"), "1 done, 1 open") {
+		t.Errorf("and it counts as done: %v", lines)
+	}
+}
+
+// A # inside quotes is part of the value, not the start of a comment.
+// The naive fix for the bug above — cut at the first # — introduces this
+// one, and a repository whose folder legitimately contains a hash would
+// be sent to a directory that does not exist.
+// proved by: cut scalar() at the first # regardless of quoting — the
+// folder comes back truncated at the hash.
+func TestAHashInsideQuotesIsNotAComment(t *testing.T) {
+	if got := scalar(`"c#-services" # the folder`); got != "c#-services" {
+		t.Errorf("a quoted hash belongs to the value: %q", got)
+	}
+	if got := scalar(`  done  `); got != "done" {
+		t.Errorf("an ordinary value is unchanged: %q", got)
+	}
+	if got := scalar(`"quoted"`); got != "quoted" {
+		t.Errorf("quotes come off: %q", got)
+	}
+	if got := scalar(`# only a comment`); got != "" {
+		t.Errorf("a value that is only a comment is empty: %q", got)
+	}
+}
+
+// The report carries the `sprint:` prefix the native report uses. That
+// prefix is an invariant — this repository's own status tests search by
+// it — so a repository that switched methodology would otherwise have no
+// sprint line at all as far as any reader looking for one is concerned.
+// proved by: prefixed these lines with `planning:` instead — every
+// consumer that finds the sprint line by prefix stops finding it, and
+// nothing else in the suite notices.
+func TestTheSprintLineKeepsItsPrefix(t *testing.T) {
+	roots := map[string]string{
+		"installed with a sprint": fixture(t, map[string]string{
+			"_bmad/manifest.yaml": "version: \"6.11.0\"\n",
+			"_bmad-output/implementation-artifacts/sprint-status.yaml": statusYAML,
+		}),
+		"no artifacts":  fixture(t, map[string]string{"_bmad/manifest.yaml": "version: \"6.11.0\"\n"}),
+		"not installed": fixture(t, map[string]string{"a.txt": "x\n"}),
+	}
+
+	for name, root := range roots {
+		lines := Report(root, "bmad")
+		if len(lines) == 0 {
+			t.Errorf("%s: the report must say something", name)
+			continue
+		}
+		if !strings.HasPrefix(lines[0], "sprint:") {
+			t.Errorf("%s: a reader finds the sprint by its prefix, got %q", name, lines[0])
+		}
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"procoder/internal/analysis"
 	"procoder/internal/answers"
 	"regexp"
 	"sort"
@@ -310,6 +311,13 @@ func checkOne(root, path string, out func(string)) int {
 		if vagueRe.MatchString(c) {
 			gaps = append(gaps, "untestable criterion: "+trim(c)+" — say what a reviewer would observe, not how it should feel")
 		}
+	}
+	// The analysis a spec came from, when there is one. A reader asking
+	// why a spec says what it says can follow the link back; a spec whose
+	// author already knew what to build owes nobody such a document, so
+	// nothing is said when none exists.
+	if src := analysis.SpecSource(root, name); src != "" {
+		notes = append(notes, "  note: this spec came from "+src)
 	}
 	if len(gaps) == 0 {
 		out("spec " + name + ": COMPLETE — sections answered, no open questions, criteria testable")

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -19,7 +19,9 @@ import (
 
 	"procoder/internal/backlog"
 	"procoder/internal/codeindex"
+	"procoder/internal/config"
 	"procoder/internal/lessons"
+	"procoder/internal/planning"
 	"procoder/internal/testrun"
 	"procoder/internal/todo"
 )
@@ -66,7 +68,14 @@ func report(root string, budget time.Duration) []string {
 
 	// the file-backed lines are computed while git runs: they read small
 	// local files, and doing them here keeps the total inside the budget
-	project := append(sprintLines(root), taskLine(root), lessonLine(root))
+	// A repository that plans in BMad reads its own sprint state back,
+	// not an empty procoder backlog beside the one being worked.
+	var project []string
+	if cfg := config.Load(root); cfg.Planning() == "bmad" {
+		project = append(planning.Report(root, "bmad"), taskLine(root), lessonLine(root))
+	} else {
+		project = append(sprintLines(root), taskLine(root), lessonLine(root))
+	}
 	if d := deferredLine(root); d != "" {
 		project = append(project, d)
 	}


### PR DESCRIPTION
Closes the epic from #162. **14 of 14 stories done**, and answers #131.

## What ships

**`procoder analyze`** — the phase before the spec. `spec check` judges whether a document is *complete*, never whether the idea in it is *good*; it will pass a thoroughly filled-in specification for the wrong feature. An analysis document asks what's actually undecided, what's known and how, what isn't, what the options cost, and which one and why. `analyze check` refuses a hollow one to the same standard `spec check` refuses a hollow spec. **Never required** — it's the answer to "I don't know what I'm building yet", not a new tollgate.

**`[planning] method = "bmad"`** — procoder reads BMad's artifacts (`sprint-status.yaml`, the installation's own `output_folder`, its manifest for the version) instead of demanding `.procoder/specs|plans|backlog`.

## Three answers, not two

Absent, unreadable and unparseable are distinct throughout:

| State | Answer |
|---|---|
| No artifacts yet | ordinary — "no planning artifacts yet" |
| File won't parse | **blocks**, naming the file |
| Status procoder doesn't know | reported **by name**, non-blocking |
| `method = "bmad"`, no install | **blocks**, naming both |

Deciding `blocked` is close enough to `backlog` is how a status machine quietly loses a state.

## The seam holds because governance never needed to know where a plan came from

`TestGovernanceIsUntouchedByThePlanningMethod` compares every finding the gate makes **about the code** across both settings and requires them identical — the planning domain's own findings excluded, because those are the setting working.

Verified end-to-end too: `procoder check a.go README.md` over one fixture produced byte-identical output under both methods (8 findings, `diff` clean), and it was a *full* gate run — format, lint, hygiene, docs, ask — not an early bail.

Mutation proven: gating the docs obligation on `cfg.Planning()` breaks the comparison while every other test stays green.

## Boundaries kept

Nothing invokes BMad, spawns its skills, or touches the network — it reads files, because the gate runs on every commit. Nothing writes into BMad's directories: BMad owns what it wrote, and a tool that edits the artifacts it judges has no standing to judge them. And the trademark audit from sprint 012 held throughout — `bmad` appears as a config *value* and in doctor output, never as a procoder feature name.

**Ten mutations proven across five packages.**

## The retro records an absence

Nine stories, five packages, no false starts — because the spec had made every hard call before implementation began. The two sprints before this each lost time to a decision that hadn't been made yet. This one lost none, and the difference was in the spec, not the code.

**Worth keeping:** comparing *all* output across both settings is the obvious seam test and a useless one — it fails the moment the setting does anything, so it'd be weakened or deleted within a week. A test that something did not change has to say what *was* allowed to.