### PR TITLE
feat: a spec cannot promise what nothing tests — and the two things that slipped through

### DIFF
--- a/.procoder/specs/planning-methodology.md
+++ b/.procoder/specs/planning-methodology.md
@@ -51,29 +51,29 @@ Two tracks, deliberately separable — each ships value without the other.
 
 **Track 1 — procoder grows the capability in its own code.**
 
-- `procoder review` — multi-lens review over a diff, file, or document.
+- [S-1] `procoder review` — multi-lens review over a diff, file, or document.
   Five lenses, each a distinct stance: adversarial, edge-case,
   verification-gap, structure, prose. Written in procoder's own words, not
   BMad's.
-- An analysis phase ahead of the spec, under `.procoder/analysis/`, for
+- [S-2] An analysis phase ahead of the spec, under `.procoder/analysis/`, for
   getting from a notion to something `spec check` can meaningfully judge.
-- Perspectives — analyst, architect, implementer, reviewer — applied as
+- [S-3] Perspectives — analyst, architect, implementer, reviewer — applied as
   review stances at spec and plan time.
-- Right-sizing: naming which entry point in the chain a change belongs at,
+- [S-4] Right-sizing: naming which entry point in the chain a change belongs at,
   and making every entry point reachable rather than only the seeded one.
-- Every lens, perspective and phase repo-overridable from `.procoder/`,
+- [S-5] Every lens, perspective and phase repo-overridable from `.procoder/`,
   following D-OVERRIDE like every other domain.
 
 **Track 2 — a repository can run the real BMad instead.**
 
-- `[planning] method = "procoder" | "bmad"` in `.procoder/config.toml`,
+- [S-6] `[planning] method = "procoder" | "bmad"` in `.procoder/config.toml`,
   defaulting to `procoder`.
-- Under `bmad`, procoder's planning controllers read and validate BMad's
+- [S-7] Under `bmad`, procoder's planning controllers read and validate BMad's
   artifacts — `planning-artifacts/`, `implementation-artifacts/`,
   `sprint-status.yaml` — instead of `.procoder/specs|plans|backlog`.
-- `procoder status` reports sprint state from `sprint-status.yaml`.
-- `procoder doctor` reports whether BMad is installed and at what version.
-- The governance backbone — gate, test, format, release, debt, scrub,
+- [S-8] `procoder status` reports sprint state from `sprint-status.yaml`.
+- [S-9] `procoder doctor` reports whether BMad is installed and at what version.
+- [S-10] The governance backbone — gate, test, format, release, debt, scrub,
   security, docs — is untouched by the setting and runs identically in both
   modes.
 
@@ -196,41 +196,41 @@ Track 2 adds nothing and owns nothing. It reads, at paths BMad's own
 
 ## Acceptance criteria
 
-- [ ] `procoder review` over a fixture diff prints all five lenses with the
+- [ ] [S-1] `procoder review` over a fixture diff prints all five lenses with the
       content in scope, and leaves every file's bytes unchanged, asserted by
       comparing a digest of the tree before and after.
-- [ ] `procoder review --lens edge-case` prints exactly that lens and exits
+- [ ] [S-1] `procoder review --lens edge-case` prints exactly that lens and exits
       0; an unrecognised name reports the name, prints no lens at all, and
       exits 2 — a usage error, not a finding.
-- [ ] A repository carrying `.procoder/review/lenses/adversarial.md` gets
+- [ ] [S-5] A repository carrying `.procoder/review/lenses/adversarial.md` gets
       that content in place of the shipped lens; without the file it gets the
       shipped one unchanged.
-- [ ] An empty `.procoder/review/lenses/adversarial.md` blocks and names the
+- [ ] [S-5] An empty `.procoder/review/lenses/adversarial.md` blocks and names the
       file rather than falling back to the shipped lens, exiting 1 — a lens
       that could not load is a refusal, and a review that did not happen must
       not exit 0.
-- [ ] `procoder analyze check` refuses a hollow analysis document — a
+- [ ] [S-2] `procoder analyze check` refuses a hollow analysis document — a
       section left as its template comment is not a filled section — and
       passes a filled one.
-- [ ] `procoder spec check` names the analysis document a spec came from when
+- [ ] [S-2] `procoder spec check` names the analysis document a spec came from when
       one exists, and does not require one when it does not.
-- [ ] `[planning] method = "bmad"` with no BMad installed produces a blocking
+- [ ] [S-6] `[planning] method = "bmad"` with no BMad installed produces a blocking
       finding naming both the setting and the missing installation.
-- [ ] `[planning] method = "bmad"` with a fixture BMad install reports sprint
+- [ ] [S-7] [S-8] `[planning] method = "bmad"` with a fixture BMad install reports sprint
       state from `sprint-status.yaml`, with each story's status, and does not
       report from `.procoder/backlog/`.
-- [ ] A `sprint-status.yaml` that will not parse produces a blocking finding
+- [ ] [S-7] A `sprint-status.yaml` that will not parse produces a blocking finding
       naming the file, distinct from the finding for one that is absent.
-- [ ] A status in `sprint-status.yaml` that procoder does not recognise is
+- [ ] [S-7] A status in `sprint-status.yaml` that procoder does not recognise is
       reported by name rather than mapped to a procoder status.
-- [ ] `[planning] method = "nonsense"` is a config Problem naming the line,
+- [ ] [S-6] `[planning] method = "nonsense"` is a config Problem naming the line,
       and the run continues on the default.
-- [ ] Under `method = "bmad"`, `procoder check` produces byte-identical
+- [ ] [S-10] Under `method = "bmad"`, `procoder check` produces byte-identical
       output to the same tree under `method = "procoder"`, asserted on a
       fixture — the setting governs planning and nothing else.
-- [ ] `procoder doctor` under `method = "bmad"` names BMad's installed
+- [ ] [S-9] `procoder doctor` under `method = "bmad"` names BMad's installed
       version, and says plainly that it is absent when it is.
-- [ ] No procoder-owned feature name contains "BMad", asserted by an audit
+- [ ] [S-1] No procoder-owned feature name contains "BMad", asserted by an audit
       over the source and the command table, so the trademark boundary cannot
       erode by accident.
 

--- a/.procoder/specs/planning-methodology.md
+++ b/.procoder/specs/planning-methodology.md
@@ -230,6 +230,14 @@ Track 2 adds nothing and owns nothing. It reads, at paths BMad's own
       fixture — the setting governs planning and nothing else.
 - [ ] [S-9] `procoder doctor` under `method = "bmad"` names BMad's installed
       version, and says plainly that it is absent when it is.
+- [ ] [S-3] `procoder review --perspectives` prints four perspectives —
+      analyst, architect, implementer, reviewer — each a distinct stance
+      and none of them a lens under another name, and a repository
+      carrying `.procoder/review/perspectives/architect.md` gets that
+      content instead.
+- [ ] [S-4] `procoder analyze where` names every entry point in the chain
+      with what each is for and what to run, including build, and says
+      plainly that nothing requires starting above the point you need.
 - [ ] [S-1] No procoder-owned feature name contains "BMad", asserted by an audit
       over the source and the command table, so the trademark boundary cannot
       erode by accident.

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -1215,6 +1215,7 @@ func reviewCmd(args []string) int {
 
 	var want []string
 	var paths []string
+	perspectives := false
 	for i := 0; i < len(args); i++ {
 		switch {
 		case args[i] == "--lens" && i+1 < len(args):
@@ -1222,6 +1223,8 @@ func reviewCmd(args []string) int {
 			want = append(want, strings.Split(args[i], ",")...)
 		case strings.HasPrefix(args[i], "--lens="):
 			want = append(want, strings.Split(strings.TrimPrefix(args[i], "--lens="), ",")...)
+		case args[i] == "--perspectives":
+			perspectives = true
 		case strings.HasPrefix(args[i], "-"):
 			fmt.Fprintf(os.Stderr, "procoder review: unknown flag %q\n", args[i])
 			return 2
@@ -1230,7 +1233,14 @@ func reviewCmd(args []string) int {
 		}
 	}
 
-	lenses, problems := review.Resolve(root)
+	// Perspectives are who is reading; lenses are how. A spec or a plan
+	// wants the first — the architectural question is cheapest to answer
+	// before there is a diff to answer it against.
+	resolve := review.Resolve
+	if perspectives {
+		resolve = review.ResolvePerspectives
+	}
+	lenses, problems := resolve(root)
 	// The refusal comes before anything is printed. A lens that could not
 	// be read must not be discovered halfway down a review the reader has
 	// already started acting on.
@@ -1258,7 +1268,11 @@ func reviewCmd(args []string) int {
 		paths = changed
 	}
 
-	review.Print(os.Stdout, paths, lenses)
+	if perspectives {
+		review.PrintPerspectives(os.Stdout, paths, lenses)
+	} else {
+		review.Print(os.Stdout, paths, lenses)
+	}
 	return 0
 }
 
@@ -1268,7 +1282,7 @@ func reviewCmd(args []string) int {
 func analyzeCmd(args []string) int {
 	root := doctor.Root()
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: procoder analyze brief <name> | list | check [name|all]")
+		fmt.Fprintln(os.Stderr, "usage: procoder analyze brief <name> | where | list | check [name|all]")
 		return 2
 	}
 	switch args[0] {
@@ -1296,6 +1310,8 @@ func analyzeCmd(args []string) int {
 			printLine(strings.TrimSuffix(filepath.Base(f), ".md"))
 		}
 		return 0
+	case "where":
+		return analysis.Where(root, printLine)
 	case "check":
 		name := ""
 		if len(args) > 1 {
@@ -1303,7 +1319,7 @@ func analyzeCmd(args []string) int {
 		}
 		return analysis.Check(root, name, printLine)
 	default:
-		fmt.Fprintln(os.Stderr, "usage: procoder analyze brief <name> | list | check [name|all]")
+		fmt.Fprintln(os.Stderr, "usage: procoder analyze brief <name> | where | list | check [name|all]")
 		return 2
 	}
 }

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -1252,8 +1252,16 @@ func reviewCmd(args []string) int {
 	if len(want) > 0 {
 		selected, unknown := review.Select(lenses, want)
 		if len(unknown) > 0 {
-			fmt.Fprintf(os.Stderr, "procoder review: no such lens: %s — procoder has %s\n",
-				strings.Join(unknown, ", "), strings.Join(review.Names(lenses), ", "))
+			// Named for the mode the caller asked for: under
+			// --perspectives these are perspectives, and an error saying
+			// "no such lens" contradicts the flag they just passed while
+			// listing names that are not lenses either.
+			kind := "lens"
+			if perspectives {
+				kind = "perspective"
+			}
+			fmt.Fprintf(os.Stderr, "procoder review: no such %s: %s — procoder has %s\n",
+				kind, strings.Join(unknown, ", "), strings.Join(review.Names(lenses), ", "))
 			return 2
 		}
 		lenses = selected

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -403,6 +403,24 @@ interviews the gaps closed; the binary judges completeness.
   to `complete` — a note, never a gap. A complete spec seeds the todo
   list — one task per criterion group.
 
+**Scope coverage.** Every `## In scope` bullet carries an id — `- [S-1]
+…` — and at least one acceptance criterion must cite it: `- [ ] [S-1]
+…`. One criterion may cite several ids where it genuinely covers them.
+
+Scope no criterion cites is a gap, and a gap makes the spec incomplete,
+and `procoder backlog seed` refuses a spec that is not complete. That is
+the loop: **work cannot be seeded from a spec that promises more than it
+tests.** It exists because a spec here once put five things in scope,
+wrote criteria for three, and passed — `seed` writes one story per
+criterion, so the two untested promises became no stories, got no
+sprint, and the epic closed at "all stories done" with the feature
+half-built.
+
+Coverage is **declared, never inferred**. Matching a bullet to a
+criterion by keyword would fail open, and a bullet wrongly judged
+covered is the exact silence this prevents. A spec whose bullets carry
+no ids is reported NOT CHECKED rather than covered.
+
 #### `procoder plan <sub>`
 
 Implementation plans under `.procoder/plans/`, written from an approved

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -106,6 +106,15 @@ disk changes.
 `--lens` narrows to the named ones. A name that is not a lens is a usage
 error (exit 2), never a silent full review.
 
+`--perspectives` reads with a different set: **who** is reading, where a
+lens is **how**. Analyst (is this the right problem), architect (what
+does this commit the system to), implementer (what will it be like to
+live in), reviewer (what is a reader owed). Meant for a spec or a plan —
+the architectural question is cheapest to answer before there is a diff
+to answer it against. Deliberately stances without names: Procoder has
+no voice by design, so it takes the multi-angle read and leaves the
+cast.
+
 Any lens is replaceable from `.procoder/review/lenses/<name>.md`
 (D-OVERRIDE). An empty or unreadable override **blocks and prints
 nothing** — unlike a template, which falls back to Procoder's version and
@@ -125,6 +134,14 @@ we do not know, Options, Recommendation) for the agent to write under
 `.procoder/analysis/`; `list` shows what exists; `check [name|all]`
 refuses one whose sections are still template comments, to the same
 standard a spec is held to.
+
+`where` names every entry point in the chain — analysis, spec, plan,
+backlog, todo, build — with what each is for and what to run, and says
+which one this repository has already used. **Nothing requires you to
+start above the point you need:** no gate finding asks for a spec, and a
+change that begins at build is gated, tested, formatted and released
+like any other. What the chain refuses is a story closing without
+evidence, and that applies wherever you began.
 
 Never required. Nothing demands an analysis document exist — it is the
 answer to "I do not know what I am building yet", not a new tollgate.

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -94,3 +94,79 @@ func TestASpecNamesItsAnalysisOnlyWhenThereIsOne(t *testing.T) {
 		t.Errorf("a spec without one says nothing: %q", got)
 	}
 }
+
+// Right-sizing is naming which entry point a change belongs at, not
+// removing enforcement — D-5. The premise procoder is often described by,
+// that every change must run spec → plan → backlog → sprint, does not
+// survive contact with the code: no gate finding requires a spec, and
+// this repository routinely lands fixes that never had one. What was
+// missing was anyone saying so.
+// proved by: dropped the build entry from Entries — the report implies
+// the smallest change still starts at a written todo, which is the
+// belief that made the chain feel mandatory when it never was.
+func TestEveryEntryPointIsNamedIncludingTheSmallest(t *testing.T) {
+	var lines []string
+	if code := Where(t.TempDir(), func(s string) { lines = append(lines, s) }); code != 0 {
+		t.Fatalf("a report cannot fail: exit %d", code)
+	}
+	joined := strings.Join(lines, "\n")
+
+	// Matched on the entry's own text, not on its name: the closing prose
+	// mentions "build" too, so a bare substring check passes even with the
+	// build entry removed. That false positive was real — the mutation
+	// this test names sailed through the first version of this assertion.
+	for _, want := range []string{"analysis", "spec", "plan", "backlog", "todo", "build"} {
+		var e Entry
+		for _, c := range Entries {
+			if c.Name == want {
+				e = c
+			}
+		}
+		if e.Name == "" {
+			t.Errorf("entry point %q is missing from the set entirely", want)
+			continue
+		}
+		if e.When == "" || e.Next == "" {
+			t.Errorf("entry %s must say when it fits and what to run", want)
+			continue
+		}
+		if !strings.Contains(joined, e.When) || !strings.Contains(joined, e.Next) {
+			t.Errorf("entry point %q must reach the report with its guidance:\n%s", want, joined)
+		}
+	}
+	// And it says plainly that starting low is allowed, which is the
+	// whole finding: the rigidity was believed, not enforced.
+	if !strings.Contains(joined, "No gate finding") {
+		t.Errorf("the report must say the chain is not mandatory:\n%s", joined)
+	}
+}
+
+// A repository mid-flight is told where it already is, so the advice
+// lands against its own state rather than in the abstract.
+// proved by: returned "" from furthest unconditionally — the report is
+// identical for a fresh repository and one three sprints in.
+func TestTheReportNamesWhereThisRepositoryAlreadyIs(t *testing.T) {
+	bare := t.TempDir()
+	var lines []string
+	Where(bare, func(s string) { lines = append(lines, s) })
+	if strings.Contains(strings.Join(lines, "\n"), "already entered at") {
+		t.Error("a repository with no artifacts has not entered anywhere")
+	}
+
+	root := t.TempDir()
+	write(t, root, ".procoder/specs/thing.md", "# thing\n")
+	lines = nil
+	Where(root, func(s string) { lines = append(lines, s) })
+	if !strings.Contains(strings.Join(lines, "\n"), "already entered at: spec") {
+		t.Errorf("a repository with specs has entered at spec: %v", lines)
+	}
+
+	// The deepest artifact wins: a repository with sprints is past the
+	// point where "start at spec" is useful advice.
+	write(t, root, ".procoder/backlog/sprints/001-x.md", "# x\n")
+	lines = nil
+	Where(root, func(s string) { lines = append(lines, s) })
+	if !strings.Contains(strings.Join(lines, "\n"), "already entered at: sprint") {
+		t.Errorf("the deepest artifact is where it is: %v", lines)
+	}
+}

--- a/internal/analysis/entry.go
+++ b/internal/analysis/entry.go
@@ -1,0 +1,111 @@
+package analysis
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Entry is a point in the quality chain a change can start from.
+type Entry struct {
+	Name string
+	When string
+	Next string
+}
+
+// Entries are the chain's entry points, widest first.
+//
+// D-5: right-sizing is naming which one a change belongs at, not removing
+// enforcement. The premise procoder is often described by — that every
+// change must run spec → plan → backlog → sprint — does not survive
+// contact with the code: no gate finding requires a spec, and this
+// repository routinely lands fixes that never had one. The rigidity is
+// real only inside the backlog system, where it is the point.
+//
+// So what was missing was never permission to start lower down. It was
+// anyone saying so, and the entry points being reachable directly rather
+// than only as a consequence of seeding from a spec.
+var Entries = []Entry{
+	{
+		Name: "analysis",
+		When: "you do not yet know what should be built, or why this and not something else",
+		Next: "procoder analyze brief <name>",
+	},
+	{
+		Name: "spec",
+		When: "you know what to build and the shape is worth agreeing before code exists",
+		Next: "procoder spec template <name>",
+	},
+	{
+		Name: "plan",
+		When: "the what is settled and the how is the part with risk in it",
+		Next: "procoder plan new <name>",
+	},
+	{
+		Name: "backlog",
+		When: "the work is understood and needs splitting so several people or sessions can carry it",
+		Next: "procoder backlog epic <title>",
+	},
+	{
+		Name: "todo",
+		When: "one bounded piece of work, understood, that nobody needs to agree about first",
+		Next: "procoder todo add <title>",
+	},
+	{
+		Name: "build",
+		When: "a fix or a change small enough that writing it down costs more than doing it",
+		Next: "just make the change — the gate still runs, and always did",
+	},
+}
+
+// Where prints the entry points and what each is for.
+//
+// It is a report, not a decision: procoder cannot know how large a change
+// is until it exists, and a tool that guessed would be wrong in the
+// expensive direction — sending somebody to write a spec for a typo, or
+// waving through a redesign because the diff started small.
+func Where(root string, out func(string)) int {
+	out("where to start — the chain is entered at the point that fits, not always at the top")
+	out("")
+	for _, e := range Entries {
+		out(fmt.Sprintf("  %-9s %s", e.Name, e.When))
+		out(fmt.Sprintf("  %-9s   → %s", "", e.Next))
+		out("")
+	}
+	out("Nothing requires you to start above the point you need. No gate finding")
+	out("asks for a spec, and a change that begins at build is still gated, tested,")
+	out("formatted and released like every other. What the chain refuses is a story")
+	out("that closes without evidence — and that refusal applies wherever you began.")
+
+	// A repository mid-flight is told where it already is, so the advice
+	// lands against its own state rather than in the abstract.
+	if at := furthest(root); at != "" {
+		out("")
+		out("this repository has already entered at: " + at)
+	}
+	return 0
+}
+
+// furthest names the deepest point this repository has artifacts for —
+// the entry it has in fact used, which is usually the honest answer to
+// "where should this go" for the next change too.
+func furthest(root string) string {
+	for _, probe := range []struct{ dir, name string }{
+		{".procoder/backlog/sprints", "sprint"},
+		{".procoder/backlog/epics", "backlog"},
+		{".procoder/plans", "plan"},
+		{".procoder/specs", "spec"},
+		{Dir, "analysis"},
+	} {
+		entries, err := os.ReadDir(filepath.Join(root, probe.dir))
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() && filepath.Ext(e.Name()) == ".md" {
+				return probe.name
+			}
+		}
+	}
+	return ""
+}

--- a/internal/backlog/seed.go
+++ b/internal/backlog/seed.go
@@ -99,6 +99,11 @@ func Seed(root, specName, milestone string, out func(string)) int {
 	date := time.Now().UTC().Format("20060102")
 	taken := map[string]bool{}
 	for i, c := range crits {
+		// The scope ids a criterion cites are traceability, not part of
+		// the requirement: leaving them in puts "[S-1]" in the story's
+		// title and its file name, where it means nothing to a reader
+		// and changes the slug if the spec is ever renumbered.
+		c = spec.StripScopeIDs(c)
 		slug := textutil.Slug(c)
 		if slug == "" {
 			// A criterion of pure punctuation still deserves a story; the

--- a/internal/backlog/seed_test.go
+++ b/internal/backlog/seed_test.go
@@ -3,6 +3,7 @@ package backlog
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +29,10 @@ func writeSpec(t *testing.T, root, name, body string) string {
 // completeSpec builds a spec body that spec.Check accepts as COMPLETE, with
 // the given lines as its Acceptance criteria section body.
 func completeSpec(name, criteria string) string {
+	// Every criterion cites the fixture's single scope bullet: spec check
+	// requires scope to be covered, so a fixture that skipped it would be
+	// testing seed against a spec seed is right to refuse.
+	criteria = regexp.MustCompile(`(?m)^(\s*- \[[ xX]\] )`).ReplaceAllString(criteria, "${1}[S-1] ")
 	return "# " + name + `
 
 Status: draft
@@ -42,7 +47,7 @@ Something concrete hurts today and this spec fixes it.
 
 ## In scope
 
-- The one buildable thing.
+- [S-1] The one buildable thing.
 
 ## Out of scope
 
@@ -118,20 +123,35 @@ func TestSeedRefusesPlaceholderOnlyCriteria(t *testing.T) {
 	}
 }
 
-func TestSeedRefusesSpecWithNoRealCriteria(t *testing.T) {
+// A criterion inside an HTML comment is not a criterion, and a spec
+// whose only one is commented out cannot seed anything.
+//
+// This used to be caught by Seed's own zero-criteria guard, after the
+// spec had passed as COMPLETE — the checker scanned raw text, so a
+// commented checkbox satisfied it. Scope coverage catches it a step
+// earlier now: the commented citation does not cover S-1, so the spec is
+// not COMPLETE and Seed refuses before reaching its own guard. That
+// guard stays as defence in depth; what changed is which refusal fires
+// first, and that it fires without the spec ever having read as ready.
+// proved by: let ScopeCoverage scan the criteria section raw instead of
+// stripping comments — the commented citation covers S-1, the spec reads
+// COMPLETE, and a spec with no real criteria is one guard away from
+// seeding an epic with no stories.
+func TestACommentedCriterionCoversNothing(t *testing.T) {
 	root := t.TempDir()
-	// The checker scans raw text, so a checkbox inside an HTML comment
-	// satisfies it — but a commented-out criterion is not a story. This is
-	// exactly the divergence the zero-criteria guard exists for.
-	body := completeSpec("ghost", "Criteria live in the comment below.\n\n<!--\n- [ ] a criterion nobody uncommented\n-->")
-	writeSpec(t, root, "ghost", body)
-	mustBeComplete(t, root, "ghost")
+	writeSpec(t, root, "ghost", completeSpec("ghost",
+		"Criteria live in the comment below.\n\n<!--\n- [ ] a criterion nobody uncommented\n-->"))
+
 	out, lines := collect()
-	if code := Seed(root, "ghost", "", out); code != 1 {
-		t.Fatalf("zero real criteria must refuse with exit 1, got %d: %v", code, *lines)
+	if code := Seed(root, "ghost", "", out); code == 0 {
+		t.Fatalf("a spec whose only criterion is commented out must not seed: %v", *lines)
 	}
-	if !strings.Contains(strings.Join(*lines, "\n"), "an epic with no stories is not a decomposition") {
-		t.Fatalf("refusal must state the rule: %v", *lines)
+	joined := strings.Join(*lines, "\n")
+	if !strings.Contains(joined, "S-1") {
+		t.Errorf("the refusal names the scope nothing tests: %v", *lines)
+	}
+	if !strings.Contains(joined, "not COMPLETE") {
+		t.Errorf("and refuses because the spec is not ready, not merely empty: %v", *lines)
 	}
 }
 

--- a/internal/review/perspectives.go
+++ b/internal/review/perspectives.go
@@ -1,0 +1,84 @@
+package review
+
+// Perspectives are who is reading, where lenses are how.
+//
+// A lens is a method — enumerate paths, trace verification, judge
+// structure. A perspective is a set of concerns somebody brings before
+// any method is applied: the architect asks what this commits the system
+// to, the implementer asks what it will be like to work in, and they
+// reach different conclusions about the same correct code.
+//
+// Deliberately not personalities. BMad's equivalent gives each a name and
+// a voice, which works for a chat-first tool; procoder has no voice by
+// design — the binary reports facts and the agent speaks — so it takes
+// the multi-angle read and leaves the cast. A stance without a name is
+// still a stance.
+//
+// Applied at spec and plan time rather than to a diff. By the time there
+// is a diff the architectural question has been answered, and the cost
+// of answering it differently is the whole change.
+
+const analystPerspective = `# Analyst
+
+You are asking whether this is the right problem, before anyone asks
+whether it is the right solution.
+
+Who has this problem, how often, and what do they do today instead? What
+happens if nothing is built — not "it stays broken", but what the person
+actually does that morning. Which part of the proposal serves the problem
+as stated and which part serves a problem somebody assumed.
+
+The finding worth most here is the one that says the problem is narrower,
+wider, or different than written.`
+
+const architectPerspective = `# Architect
+
+You are asking what this commits the system to.
+
+Which decisions here are cheap to reverse and which are load-bearing for
+years. What this makes easy that was hard, and what it makes hard that
+was easy. Where the seams are, and whether the ones being added are in
+places that will still make sense when the requirement changes.
+
+Name the commitment, not the preference. "I would have used a different
+structure" is taste; "this couples X to Y so changing Y means changing X"
+is a consequence somebody will pay.`
+
+const implementerPerspective = `# Implementer
+
+You are asking what it will be like to build and live in this.
+
+Where is the part that reads clearly and is wrong. What has to be held in
+your head at once to change it safely. Which failure will be reported as
+something else entirely, three layers away from its cause. What a person
+does at 3am when it breaks, and whether the code tells them anything.
+
+The concern here is the second change, not the first: a shape that is
+fine to write once and painful to touch again is a finding.`
+
+const reviewerPerspective = `# Reviewer
+
+You are asking what a reader is owed.
+
+What a person needs to know before this makes sense, and whether they are
+given it or expected to have it. Which claim is asserted where it should
+be shown. What the document says will happen versus what it says will be
+true — a promise and a property are different, and confusing them is how
+scope goes missing.
+
+Ask what is NOT here that its absence would be easy to miss: the
+unmentioned case, the unstated assumption, the section that ends before
+the hard part.`
+
+// PerspectiveSet is the shipped set, in the order a full read applies
+// them: problem before structure, structure before construction,
+// construction before the account given of it.
+var PerspectiveSet = []Lens{
+	{Name: "analyst", Body: analystPerspective},
+	{Name: "architect", Body: architectPerspective},
+	{Name: "implementer", Body: implementerPerspective},
+	{Name: "reviewer", Body: reviewerPerspective},
+}
+
+// PerspectiveDir is where a repository puts its own.
+const PerspectiveDir = ".procoder/review/perspectives"

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -49,11 +49,22 @@ type Lens struct {
 // produce a review claiming to be one thing and being another. Printing
 // nothing leaves nothing to act on by mistake.
 func Resolve(root string) ([]Lens, []gitx.Finding) {
+	return resolveSet(root, Lenses, Dir)
+}
+
+// ResolvePerspectives is Resolve for the perspective set — who is
+// reading, where a lens is how. Same override contract, same refusal:
+// a perspective that could not be read is not replaced by procoder's.
+func ResolvePerspectives(root string) ([]Lens, []gitx.Finding) {
+	return resolveSet(root, PerspectiveSet, PerspectiveDir)
+}
+
+func resolveSet(root string, shippedSet []Lens, dir string) ([]Lens, []gitx.Finding) {
 	var out []Lens
 	var problems []gitx.Finding
-	for _, shipped := range Lenses {
-		path := filepath.Join(root, Dir, shipped.Name+".md")
-		rel := filepath.ToSlash(filepath.Join(Dir, shipped.Name+".md"))
+	for _, shipped := range shippedSet {
+		path := filepath.Join(root, dir, shipped.Name+".md")
+		rel := filepath.ToSlash(filepath.Join(dir, shipped.Name+".md"))
 		data, err := os.ReadFile(path)
 		switch {
 		case os.IsNotExist(err):
@@ -64,10 +75,10 @@ func Resolve(root string) ([]Lens, []gitx.Finding) {
 			// reported as "no override here" runs procoder's lens under the
 			// repository's name.
 			problems = append(problems, gitx.Finding{Blocking: true, File: path,
-				Message: fmt.Sprintf("lens %s NOT read — %v (review)", shipped.Name, err)})
+				Message: fmt.Sprintf("%s %s NOT read — %v (review)", kindOf(dir), shipped.Name, err)})
 		case strings.TrimSpace(string(data)) == "":
 			problems = append(problems, gitx.Finding{Blocking: true, File: path,
-				Message: fmt.Sprintf("lens %s is empty — procoder did NOT fall back to its own, because a review under your lens's name running procoder's words is worse than no review. If it was emptied by accident, `git checkout <ref> -- %s` restores it; if it is meant to go, delete the file (review)", shipped.Name, rel)})
+				Message: fmt.Sprintf("%s %s is empty — procoder did NOT fall back to its own, because a review under your own name running procoder's words is worse than no review. If it was emptied by accident, `git checkout <ref> -- %s` restores it; if it is meant to go, delete the file (review)", kindOf(dir), shipped.Name, rel)})
 		default:
 			out = append(out, Lens{Name: shipped.Name, Body: string(data), Source: rel})
 		}
@@ -115,8 +126,18 @@ func Names(all []Lens) []string {
 // The scope is named rather than quoted. The agent can already read the
 // files; what only procoder knows is which ones the change touched and
 // what the lenses are.
-func Print(w io.Writer, scope []string, lenses []Lens) {
-	fmt.Fprintf(w, "== procoder review — %d lens(es) over %d file(s)\n\n", len(lenses), len(scope))
+func Print(w io.Writer, scope []string, lenses []Lens) { print(w, scope, lenses, "lens(es)", "lens") }
+
+// PrintPerspectives is Print for the perspective set, which reads the
+// same way but is not a lens and must not say it is: a reader told they
+// applied five lenses when they applied four perspectives cannot check
+// the claim against what they did.
+func PrintPerspectives(w io.Writer, scope []string, ps []Lens) {
+	print(w, scope, ps, "perspective(s)", "perspective")
+}
+
+func print(w io.Writer, scope []string, lenses []Lens, plural, singular string) {
+	fmt.Fprintf(w, "== procoder review — %d %s over %d file(s)\n\n", len(lenses), plural, len(scope))
 	if len(scope) == 0 {
 		fmt.Fprintln(w, "no files in scope — pass paths, or make a change for the diff to carry")
 		return
@@ -127,8 +148,8 @@ func Print(w io.Writer, scope []string, lenses []Lens) {
 		fmt.Fprintln(w, "- "+p)
 	}
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Read each file. Then apply every lens below, one at a time — they are")
-	fmt.Fprintln(w, "different stances, not a checklist to merge. Overlap between two lenses is")
+	fmt.Fprintf(w, "Read each file. Then apply every %s below, one at a time — they are\n", singular)
+	fmt.Fprintln(w, "different stances, not a checklist to merge. Overlap between two of them is")
 	fmt.Fprintln(w, "signal rather than duplication: keep both findings and say they agree.")
 	fmt.Fprintln(w)
 	for _, l := range lenses {
@@ -138,4 +159,13 @@ func Print(w io.Writer, scope []string, lenses []Lens) {
 		}
 		fmt.Fprintln(w)
 	}
+}
+
+// kindOf names what a directory holds, so a refusal says "perspective
+// architect is empty" rather than calling everything a lens.
+func kindOf(dir string) string {
+	if dir == PerspectiveDir {
+		return "perspective"
+	}
+	return "lens"
 }

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -295,3 +295,34 @@ func TestAPerspectiveOverrideBehavesLikeALensOverride(t *testing.T) {
 		}
 	}
 }
+
+// The two sets are selected by the same flag, so an error about an
+// unknown name has to say which set it looked in. Under --perspectives
+// the names offered are perspectives, and reporting "no such lens" both
+// contradicts the flag the caller passed and lists names that are not
+// lenses.
+// proved by: hard-coded "lens" in the unknown-name error — the
+// perspective mode reports a lens that does not exist and offers four
+// perspectives as the alternatives.
+func TestTheUnknownNameErrorNamesTheSetItSearched(t *testing.T) {
+	root := t.TempDir()
+
+	lenses, _ := Resolve(root)
+	if _, unknown := Select(lenses, []string{"analyst"}); len(unknown) != 1 {
+		t.Error("a perspective is not a lens, and must come back unknown from the lens set")
+	}
+
+	ps, _ := ResolvePerspectives(root)
+	if _, unknown := Select(ps, []string{"adversarial"}); len(unknown) != 1 {
+		t.Error("a lens is not a perspective, and must come back unknown from the perspective set")
+	}
+
+	// The names each set offers are its own, which is what the error
+	// prints as the alternatives.
+	if got := Names(ps); len(got) != 4 || got[0] != "analyst" {
+		t.Errorf("the perspective set offers perspectives: %v", got)
+	}
+	if got := Names(lenses); len(got) != 5 || got[0] != "adversarial" {
+		t.Errorf("the lens set offers lenses: %v", got)
+	}
+}

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -209,3 +209,89 @@ func TestAnUnreadableOverrideBlocksAndDoesNotFallBack(t *testing.T) {
 		t.Errorf("the other four are unaffected: %v", Names(lenses))
 	}
 }
+
+// Perspectives are who is reading, where lenses are how. A lens is a
+// method — enumerate paths, trace verification; a perspective is a set
+// of concerns brought before any method is applied, and the architect and
+// the implementer reach different conclusions about the same correct
+// code.
+// proved by: pointed PerspectiveSet at Lenses — the two sets become one,
+// and asking for a perspective returns a method instead of a stance.
+func TestPerspectivesAreTheirOwnSetAndTheirOwnStances(t *testing.T) {
+	root := t.TempDir()
+	got, problems := ResolvePerspectives(root)
+	if len(problems) != 0 {
+		t.Fatalf("a repository with no overrides has no problems: %+v", problems)
+	}
+	if len(got) != 4 {
+		t.Fatalf("four shipped perspectives, got %d: %v", len(got), Names(got))
+	}
+
+	// Distinct from each other, for the reason the lenses are: four
+	// wordings of one stance costs four passes and returns one read.
+	seen := map[string]string{}
+	for _, p := range got {
+		if prior, dup := seen[p.Body]; dup {
+			t.Errorf("perspectives %s and %s are the same stance", prior, p.Name)
+		}
+		seen[p.Body] = p.Name
+	}
+
+	// And distinct from the lenses: sharing a body would mean one of the
+	// two sets is not what it claims to be.
+	lensBodies := map[string]bool{}
+	for _, l := range Lenses {
+		lensBodies[l.Body] = true
+	}
+	for _, p := range got {
+		if lensBodies[p.Body] {
+			t.Errorf("perspective %s is a lens wearing another name", p.Name)
+		}
+	}
+}
+
+// The override contract is the same one lenses hold, and for the same
+// reason: a read under your own perspective's name running procoder's
+// words is worse than no read, so nothing is printed to act on.
+// proved by: had ResolvePerspectives read the lens directory instead —
+// a repository's perspective override is ignored and its lens override
+// silently governs a different command.
+func TestAPerspectiveOverrideBehavesLikeALensOverride(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, PerspectiveDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const mine = "# Ours\n\nAsk what our last incident would have asked.\n"
+	if err := os.WriteFile(filepath.Join(dir, "architect.md"), []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, problems := ResolvePerspectives(root)
+	if len(problems) != 0 {
+		t.Fatalf("a readable override is not a problem: %+v", problems)
+	}
+	for _, p := range got {
+		if p.Name == "architect" && p.Body != mine {
+			t.Errorf("the override is what runs:\n%s", p.Body)
+		}
+	}
+
+	// Empty refuses and does not fall back, and the refusal says
+	// "perspective" rather than calling everything a lens.
+	if err := os.WriteFile(filepath.Join(dir, "architect.md"), []byte("  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, problems = ResolvePerspectives(root)
+	if len(problems) != 1 || !problems[0].Blocking {
+		t.Fatalf("an empty override blocks: %+v", problems)
+	}
+	if !strings.Contains(problems[0].Message, "perspective architect") {
+		t.Errorf("the refusal names what it is: %q", problems[0].Message)
+	}
+	for _, p := range got {
+		if p.Name == "architect" {
+			t.Error("procoder must not substitute its own for one the repository replaced")
+		}
+	}
+}

--- a/internal/spec/coverage.go
+++ b/internal/spec/coverage.go
@@ -1,0 +1,88 @@
+package spec
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"procoder/internal/textutil"
+)
+
+// scopeID matches the identifier a scope bullet carries and a criterion
+// cites: `- [S-3] …`. Case-insensitive on the letter so a spec written
+// `[s-3]` is not silently a different item.
+var scopeID = regexp.MustCompile(`\[([Ss]-\d+)\]`)
+
+// ScopeCoverage reports the scope this spec promises and does not test.
+//
+// It exists because a spec can promise five things, write criteria for
+// three, and pass every check procoder had. `backlog seed` generates one
+// story per criterion, so the two untested promises become no stories,
+// get no sprint, and are never missed — the epic closes at "all stories
+// done" while the feature ships half-built. That happened in this
+// repository, to this spec, and nothing anywhere noticed until somebody
+// asked a direct question.
+//
+// Coverage is declared, never inferred. Matching a scope bullet to a
+// criterion by keyword or similarity would fail OPEN — a bullet wrongly
+// judged covered is exactly the silence this exists to break — so the
+// link is an id the author writes on both ends and this function only
+// checks the two sets agree.
+func ScopeCoverage(text string) (uncovered []string, declared bool) {
+	scope := textutil.Section(text, "In scope")
+	criteria := textutil.Section(text, "Acceptance criteria")
+
+	inScope := idsIn(scope)
+	if len(inScope) == 0 {
+		return nil, false
+	}
+	tested := map[string]bool{}
+	for _, id := range idsIn(criteria) {
+		tested[id] = true
+	}
+	for _, id := range inScope {
+		if !tested[id] {
+			uncovered = append(uncovered, id)
+		}
+	}
+	return uncovered, true
+}
+
+// ScopeBullets counts the bullets in the In scope section, so a spec that
+// promises things without giving any of them an id can be told what it
+// would have to label.
+func ScopeBullets(text string) int {
+	n := 0
+	for _, line := range strings.Split(textutil.Section(text, "In scope"), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "- ") {
+			n++
+		}
+	}
+	return n
+}
+
+// idsIn returns the scope ids a section cites, deduplicated and ordered
+// so a report reads the same way twice.
+func idsIn(section string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, m := range scopeID.FindAllStringSubmatch(section, -1) {
+		id := strings.ToUpper(m[1])
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return idLess(out[i], out[j]) })
+	return out
+}
+
+// idLess orders S-2 before S-10, which string order does not.
+func idLess(a, b string) bool {
+	na, nb := 0, 0
+	fmt.Sscanf(a, "S-%d", &na)
+	fmt.Sscanf(b, "S-%d", &nb)
+	return na < nb
+}

--- a/internal/spec/coverage.go
+++ b/internal/spec/coverage.go
@@ -31,7 +31,12 @@ var scopeID = regexp.MustCompile(`\[([Ss]-\d+)\]`)
 // checks the two sets agree.
 func ScopeCoverage(text string) (uncovered []string, declared bool) {
 	scope := textutil.Section(text, "In scope")
-	criteria := textutil.Section(text, "Acceptance criteria")
+	// Comments stripped before the criteria are scanned: a citation
+	// inside an HTML comment is not a criterion, and counting it would
+	// let a spec satisfy coverage with work nobody committed to. The
+	// same divergence the zero-criteria guard in backlog seed exists
+	// for, arriving one check earlier.
+	criteria := textutil.StripComments(textutil.Section(text, "Acceptance criteria"))
 
 	inScope := idsIn(scope)
 	if len(inScope) == 0 {
@@ -49,17 +54,16 @@ func ScopeCoverage(text string) (uncovered []string, declared bool) {
 	return uncovered, true
 }
 
-// ScopeBullets counts the bullets in the In scope section, so a spec that
-// promises things without giving any of them an id can be told what it
-// would have to label.
-func ScopeBullets(text string) int {
-	n := 0
-	for _, line := range strings.Split(textutil.Section(text, "In scope"), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "- ") {
-			n++
-		}
-	}
-	return n
+// ScopePromises reports whether the In scope section says anything at
+// all, so a spec that promises without labelling can be told it is
+// unchecked rather than assumed covered.
+//
+// Any content counts, not only bullets. Counting bullets alone left a
+// bypass: scope written as prose would carry no ids, satisfy nothing,
+// and be reported as fully covered — the same failing-open this check
+// exists to prevent, reachable by writing a paragraph.
+func ScopePromises(text string) bool {
+	return strings.TrimSpace(textutil.StripComments(textutil.Section(text, "In scope"))) != ""
 }
 
 // idsIn returns the scope ids a section cites, deduplicated and ordered
@@ -85,4 +89,12 @@ func idLess(a, b string) bool {
 	fmt.Sscanf(a, "S-%d", &na)
 	fmt.Sscanf(b, "S-%d", &nb)
 	return na < nb
+}
+
+// StripScopeIDs removes the `[S-n]` citations from a criterion, leaving
+// the requirement. The ids link scope to test; they are not part of what
+// the criterion asks for, so anything rendering a criterion for a reader
+// — a story title, a file name — takes this form.
+func StripScopeIDs(s string) string {
+	return strings.TrimSpace(scopeID.ReplaceAllString(s, ""))
 }

--- a/internal/spec/coverage_test.go
+++ b/internal/spec/coverage_test.go
@@ -1,0 +1,113 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+// fullSpec is a spec with every section answered except the two under
+// test, so Check's other gaps do not mask the coverage one.
+func fullSpec(scope, criteria string) string {
+	out := "# probe\n\nStatus: draft\n"
+	for _, s := range Sections {
+		out += "\n## " + s + "\n\n"
+		switch s {
+		case "In scope":
+			out += scope
+		case "Acceptance criteria":
+			out += criteria
+		case "Open questions":
+			out += "<!-- none -->\n"
+		default:
+			out += "Something a person actually wrote.\n"
+		}
+	}
+	return out
+}
+
+func specWith(scope, criteria string) string {
+	return "# probe\n\n## In scope\n\n" + scope +
+		"\n## Acceptance criteria\n\n" + criteria + "\n## Open questions\n\n"
+}
+
+// A spec can promise five things, write criteria for three, and pass. That
+// is not hypothetical: it happened to planning-methodology in this
+// repository. `backlog seed` writes one story per criterion, so the two
+// untested promises became no stories, got no sprint, and were never
+// missed — the epic closed at "all stories done" while the feature
+// shipped half-built, and nothing anywhere noticed until somebody asked.
+// proved by: returned nil from ScopeCoverage — the spec that under-
+// delivered passes again, and so does every future one.
+func TestScopePromisedWithoutACriterionIsAGap(t *testing.T) {
+	s := specWith(
+		"- [S-1] the thing that got built\n- [S-2] the thing that did not\n",
+		"- [ ] [S-1] a criterion citing the first\n")
+
+	uncovered, declared := ScopeCoverage(s)
+	if !declared {
+		t.Fatal("ids are present, so coverage is declared and checkable")
+	}
+	if len(uncovered) != 1 || uncovered[0] != "S-2" {
+		t.Fatalf("the untested promise is named: %v", uncovered)
+	}
+
+	// One criterion may genuinely cover several bullets, and citing both
+	// is how it says so.
+	both := specWith(
+		"- [S-1] one\n- [S-2] two\n",
+		"- [ ] [S-1] [S-2] a criterion that really does cover both\n")
+	if uncovered, _ := ScopeCoverage(both); len(uncovered) != 0 {
+		t.Errorf("a criterion citing both ids covers both: %v", uncovered)
+	}
+}
+
+// Coverage is declared, never inferred. A spec whose bullets carry no ids
+// cannot be checked, and a check that cannot run must not read as one
+// that passed — the rule this repository already applies to every missing
+// tool.
+// proved by: returned declared=true for a spec with no ids at all — an
+// unlabelled spec reports full coverage, which is the exact silence this
+// exists to break.
+func TestAnUnlabelledScopeIsNotCheckedRatherThanCovered(t *testing.T) {
+	s := specWith("- a promise with no id\n- another\n", "- [ ] a criterion with no id\n")
+
+	uncovered, declared := ScopeCoverage(s)
+	if declared {
+		t.Fatal("nothing here can be checked; saying so is the point")
+	}
+	if len(uncovered) != 0 {
+		t.Errorf("an unchecked spec reports no uncovered ids — it reports that it is unchecked: %v", uncovered)
+	}
+	if n := ScopeBullets(s); n != 2 {
+		t.Errorf("and says how many bullets would need labelling, got %d", n)
+	}
+
+	// A spec that promises nothing at all is not unchecked; there is
+	// simply nothing to check, and a report saying otherwise is noise.
+	if n := ScopeBullets(specWith("", "- [ ] one\n")); n != 0 {
+		t.Errorf("no bullets is not a gap: %d", n)
+	}
+}
+
+// The gap must reach the verdict, not merely be computable: `backlog
+// seed` refuses a spec that is not COMPLETE, so a gap that never becomes
+// a gap in Check leaves seed happy to build the half-spec.
+// proved by: dropped the ScopeCoverage call from Check — the spec is
+// COMPLETE again and seeds a backlog covering two thirds of what it
+// promised.
+func TestTheGapReachesTheVerdict(t *testing.T) {
+	root := t.TempDir()
+	writeSpec(t, root, "probe", fullSpec(
+		"- [S-1] built\n- [S-2] forgotten\n",
+		"- [ ] [S-1] a criterion a reviewer could verify\n"))
+
+	var lines []string
+	code := Check(root, "probe", func(s string) { lines = append(lines, s) })
+	joined := strings.Join(lines, "\n")
+	if code == 0 {
+		t.Fatalf("a spec that promises what it does not test is not ready:\n%s", joined)
+	}
+	if !strings.Contains(joined, "S-2") {
+		t.Errorf("and the verdict names which promise: %s", joined)
+	}
+}

--- a/internal/spec/coverage_test.go
+++ b/internal/spec/coverage_test.go
@@ -78,14 +78,25 @@ func TestAnUnlabelledScopeIsNotCheckedRatherThanCovered(t *testing.T) {
 	if len(uncovered) != 0 {
 		t.Errorf("an unchecked spec reports no uncovered ids — it reports that it is unchecked: %v", uncovered)
 	}
-	if n := ScopeBullets(s); n != 2 {
-		t.Errorf("and says how many bullets would need labelling, got %d", n)
+	if !ScopePromises(s) {
+		t.Error("a spec with promises in scope must be seen to have them")
 	}
 
 	// A spec that promises nothing at all is not unchecked; there is
 	// simply nothing to check, and a report saying otherwise is noise.
-	if n := ScopeBullets(specWith("", "- [ ] one\n")); n != 0 {
-		t.Errorf("no bullets is not a gap: %d", n)
+	if ScopePromises(specWith("", "- [ ] one\n")) {
+		t.Error("an empty scope section promises nothing")
+	}
+	if ScopePromises(specWith("<!-- the template prompt nobody replaced -->\n", "")) {
+		t.Error("an unanswered template comment is not a promise")
+	}
+
+	// Prose scope counts too. Counting only bullets left a bypass: a
+	// paragraph carries no ids, so it would satisfy nothing and be
+	// reported fully covered — failing open, reachable by not using a
+	// list.
+	if !ScopePromises(specWith("We will make the thing faster.\n", "")) {
+		t.Error("scope written as prose is still scope, and still unchecked without ids")
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -56,7 +56,12 @@ Status: draft
 
 ## In scope
 
-<!-- What this change WILL do. Bullet points, each one buildable. -->
+<!-- What this change WILL do. Bullet points, each one buildable, each
+     labelled "- [S-1] ...". Every id must be cited by at least one
+     acceptance criterion below: backlog seed writes one story per
+     criterion, so scope no criterion cites becomes no story, no sprint,
+     and ships unbuilt. The check is on the ids, not the prose — guessing
+     whether a criterion covers a bullet would fail open. -->
 
 ## Out of scope
 
@@ -85,7 +90,9 @@ Status: draft
 ## Acceptance criteria
 
 <!-- Each criterion is a testable checkbox: an observable behaviour a
-     reviewer can verify, not a feeling. These seed the todo tasks. -->
+     reviewer can verify, not a feeling. These seed the todo tasks.
+     Each cites the scope it tests — "- [ ] [S-1] ..." — and one
+     criterion may cite several ids where it genuinely covers them. -->
 
 - [ ] ...
 
@@ -297,6 +304,18 @@ func checkOne(root, path string, out func(string)) int {
 		notes = append(notes, fmt.Sprintf("  note: %d question(s) here are answered in %s — rewriting them as decisions is tidier, and no longer required to pass",
 			answered, filepath.ToSlash(filepath.Join(answers.Dir, answers.File))))
 	}
+	// Every promise needs a test, or the story it becomes never exists.
+	// Declared rather than inferred: a bullet wrongly judged covered
+	// would be the same silence this check exists to break.
+	if uncovered, declared := ScopeCoverage(text); !declared {
+		if n := ScopeBullets(text); n > 0 {
+			gaps = append(gaps, fmt.Sprintf("scope coverage NOT checked — the %d In scope bullet(s) carry no [S-n] ids, so nothing can tell which are tested; label each and cite the id from its criteria", n))
+		}
+	} else if len(uncovered) > 0 {
+		gaps = append(gaps, fmt.Sprintf("scope %s promised and untested — `backlog seed` writes one story per criterion, so scope no criterion cites becomes no story, no sprint, and ships unbuilt",
+			strings.Join(uncovered, ", ")))
+	}
+
 	criteria := textutil.Section(text, "Acceptance criteria")
 	boxes := checkboxRe.FindAllStringSubmatch(criteria, -1)
 	if strings.Contains(text, "## Acceptance criteria") && len(boxes) == 0 {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -308,8 +308,8 @@ func checkOne(root, path string, out func(string)) int {
 	// Declared rather than inferred: a bullet wrongly judged covered
 	// would be the same silence this check exists to break.
 	if uncovered, declared := ScopeCoverage(text); !declared {
-		if n := ScopeBullets(text); n > 0 {
-			gaps = append(gaps, fmt.Sprintf("scope coverage NOT checked — the %d In scope bullet(s) carry no [S-n] ids, so nothing can tell which are tested; label each and cite the id from its criteria", n))
+		if ScopePromises(text) {
+			gaps = append(gaps, "scope coverage NOT checked — In scope carries no [S-n] ids, so nothing can tell which promises are tested; label each promise and cite its id from the criterion that covers it")
 		}
 	} else if len(uncovered) > 0 {
 		gaps = append(gaps, fmt.Sprintf("scope %s promised and untested — `backlog seed` writes one story per criterion, so scope no criterion cites becomes no story, no sprint, and ships unbuilt",
@@ -322,7 +322,11 @@ func checkOne(root, path string, out func(string)) int {
 		gaps = append(gaps, "Acceptance criteria carry no checkboxes — each criterion must be a testable `- [ ]` line")
 	}
 	for _, m := range boxes {
-		c := strings.TrimSpace(m[1])
+		// The scope citation is traceability, not the requirement. Every
+		// check below reads what the criterion ASKS FOR, so the ids come
+		// off first — otherwise `- [ ] [S-1] ...` is not the placeholder
+		// it plainly is, and a hollow spec seeds hollow stories.
+		c := StripScopeIDs(m[1])
 		if c == "..." {
 			gaps = append(gaps, "Acceptance criteria still contain the placeholder")
 			continue

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -32,9 +32,12 @@ func completeSpec() string {
 	for _, s := range Sections {
 		b.WriteString("\n## " + s + "\n\n")
 		switch s {
+		case "In scope":
+			b.WriteString("- [S-1] the offline report\n")
+			b.WriteString("- [S-2] the suite it has to keep green\n")
 		case "Acceptance criteria":
-			b.WriteString("- [ ] report renders with the network cable pulled\n")
-			b.WriteString("- [ ] go test ./... exits 0\n")
+			b.WriteString("- [ ] [S-1] report renders with the network cable pulled\n")
+			b.WriteString("- [ ] [S-2] go test ./... exits 0\n")
 		case "Open questions":
 			// none — every decision resolved
 		default:
@@ -72,14 +75,14 @@ func TestCheckBlocksOnGaps(t *testing.T) {
 			return s + "\n- OPEN: which database?\n"
 		}, "unresolved OPEN:"},
 		{"no checkboxes", func(s string) string {
-			s = strings.Replace(s, "- [ ] report renders with the network cable pulled\n", "renders offline\n", 1)
-			return strings.Replace(s, "- [ ] go test ./... exits 0\n", "", 1)
+			s = strings.Replace(s, "- [ ] [S-1] report renders with the network cable pulled\n", "renders offline\n", 1)
+			return strings.Replace(s, "- [ ] [S-2] go test ./... exits 0\n", "", 1)
 		}, "no checkboxes"},
 		{"placeholder criterion", func(s string) string {
-			return strings.Replace(s, "- [ ] report renders with the network cable pulled", "- [ ] ...", 1)
+			return strings.Replace(s, "- [ ] [S-1] report renders with the network cable pulled", "- [ ] ...", 1)
 		}, "placeholder"},
 		{"untestable criterion", func(s string) string {
-			return strings.Replace(s, "- [ ] report renders with the network cable pulled",
+			return strings.Replace(s, "- [ ] [S-1] report renders with the network cable pulled",
 				"- [ ] the UI is user-friendly", 1)
 		}, "untestable criterion"},
 	}


### PR DESCRIPTION
Two things, one cause.

## The gate

`planning-methodology` put **five things in scope, wrote criteria for three, and passed.** `backlog seed` writes one story per criterion, so the two untested promises became no stories, got no sprint, and were never missed. The epic closed at **14 of 14** while two of five promised features had never been built.

The verdict was true and useless: 14 of 14 **criteria**, not 14 of 14 **scope**. Nothing connected the two.

Now every `## In scope` bullet carries an id and at least one criterion must cite it:

```
- [S-1] procoder review — multi-lens review over a diff
- [ ] [S-1] procoder review over a fixture diff prints all five lenses
```

Scope no criterion cites is a gap → the spec isn't COMPLETE → **`backlog seed` refuses**. That's the loop closed: work cannot be seeded from a spec that promises more than it tests. Verified — seeding the offending spec exits 1 naming S-3 and S-4, and nothing else.

**Coverage is declared, never inferred.** Matching a bullet to a criterion by keyword would fail open, and a bullet wrongly judged covered is the exact silence this prevents. A spec with no ids is reported **NOT CHECKED**, not covered.

## The two features it found

**S-3 — `procoder review --perspectives`.** Who is reading, where a lens is how. Analyst, architect, implementer, reviewer. Stances without names per D-3: procoder has no voice by design, so it takes the multi-angle read and leaves the cast.

**S-4 — `procoder analyze where`.** Names every entry point with what it's for and what to run, including build, and says plainly that nothing requires starting higher. Per D-5 this names entry points rather than removing enforcement — the rigidity was *believed*, not enforced.

## Four faults surfaced along the way, each caught by a test rather than by inspection

- Story slugs carried `[S-1]` into their **file names** — seed slugged the citation with the requirement
- The placeholder check stopped recognising `- [ ] ...` once criteria carried ids, so a hollow spec would have seeded hollow stories
- **Coverage counted a citation inside an HTML comment** — the ghost fixture caught it; a commented criterion is not a criterion
- **My own bypass:** counting *bullets* meant scope written as prose carried no ids, satisfied nothing, and read as fully covered. Any content counts now.

Ten mutations proven. One of my own tests had a false positive — `strings.Contains(joined, "build")` was satisfied by unrelated prose, so the mutation dropping the build entry passed; the assertion now matches the rendered entry.

**Scope:** only `planning-methodology` is migrated. The other 21 specs are reported by the gate but deliberately untouched.