### PR TITLE
feat: the release controller verifies every credit against GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ Rules that earn their place:
 - Get the name right. A misattributed credit is worse than none — verify
   who actually opened the issue or PR being cited (`gh issue view <n>`,
   `gh pr view <n>`) before writing the handle, rather than recalling it
-  from memory or another entry's context.
+  from memory or another entry's context. `procoder release` checks this
+  against GitHub and refuses to call a release ready when a credited
+  handle opened none of what its paragraph cites.
 -->
 
 ## 2.0.0 — 2026-08-24

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -247,8 +247,17 @@ into it, no story points, no calendar enforcement.
 The pre-tag controller: verifies in one pass that every file in
 `[release] files` (config.toml) carries the version, CHANGELOG.md has
 the `## <version>` entry, the working tree is clean (untracked
-included), the gate is clean, and the suite is green under
-`[test] policy`. Every failure is listed together; on success the
+included), the gate is clean, the suite is green under
+`[test] policy`, and **every contributor the entry credits actually
+opened one of the issues or pull requests that paragraph cites**.
+
+That last one asks GitHub, which the test suite deliberately cannot —
+the suite runs offline on every commit. This controller can, because the
+tag it prepares is published by a job that talks to the same API, so the
+network was already a precondition. A misattributed credit hands one
+person's thanks to another, permanently, in notes GitHub publishes
+verbatim. GitHub not answering is reported as NOT verified and blocks,
+never as a pass. Every failure is listed together; on success the
 `git tag` command is printed for the agent to run — the binary tags
 nothing. Without `[release] files` the version-sync leg says
 it verified nothing. Bare `procoder release` reads the newest changelog

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -1,0 +1,175 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Credit is one contributor named in a changelog paragraph, alongside the
+// issues and pull requests that paragraph cites.
+type Credit struct {
+	Handle string
+	Cites  []int
+}
+
+var (
+	linkedHandle = regexp.MustCompile(`\[@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\]\(https://github\.com/`)
+	citedNumber  = regexp.MustCompile(`\[#(\d+)\]\(https://github\.com/azrtydxb/procoder/(?:pull|issues)/\d+\)`)
+)
+
+// CreditsIn pairs each contributor named in the entry with the issues and
+// pull requests cited in the same paragraph.
+//
+// Paragraph scope is the whole rule: a changelog entry credits somebody
+// FOR something, and the something is whatever that paragraph links. A
+// handle in one paragraph and a number in another are unrelated, and
+// pairing them would invent a claim the entry never made.
+func CreditsIn(entry string) []Credit {
+	var out []Credit
+	for _, para := range strings.Split(entry, "\n\n") {
+		var nums []int
+		for _, m := range citedNumber.FindAllStringSubmatch(para, -1) {
+			var n int
+			fmt.Sscanf(m[1], "%d", &n)
+			nums = append(nums, n)
+		}
+		for _, m := range linkedHandle.FindAllStringSubmatch(para, -1) {
+			out = append(out, Credit{Handle: m[1], Cites: nums})
+		}
+	}
+	return out
+}
+
+// authorOf asks GitHub who opened an issue or pull request. Issues and
+// pull requests share a number space, and `gh issue view` answers for both,
+// so one call covers either.
+func authorOf(root string, number int) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "issue", "view", fmt.Sprint(number),
+		"--json", "author", "--jq", ".author.login") // nosemgrep -- a number, formatted from an int
+	cmd.Dir = root
+	raw, err := cmd.Output()
+	if err != nil {
+		// A pull request that `gh issue view` will not answer for is still
+		// reachable through the pull-request endpoint on some versions.
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel2()
+		alt := exec.CommandContext(ctx2, "gh", "pr", "view", fmt.Sprint(number),
+			"--json", "author", "--jq", ".author.login") // nosemgrep -- a number, formatted from an int
+		alt.Dir = root
+		raw2, err2 := alt.Output()
+		if err2 != nil {
+			return "", fmt.Errorf("%v", firstLine(err))
+		}
+		raw = raw2
+	}
+	return strings.TrimSpace(string(raw)), nil
+}
+
+// VerifyCredits checks that every contributor the newest entry names
+// actually opened one of the issues or pull requests that paragraph cites.
+//
+// It lives in the release controller rather than the test suite on
+// purpose. The suite runs on every commit and offline; this needs GitHub.
+// The release controller already cannot do its job without GitHub — the
+// tag it prepares is published by a job that talks to the API — so a
+// network check costs nothing here that was not already required, and
+// buying correctness with a call that has to happen anyway is a trade
+// worth making.
+//
+// A misattributed credit is worse than none: it takes the thanks owed to
+// one person and hands it to another, permanently, in the release notes
+// GitHub publishes. That happened in this repository. The fix at the time
+// was to write a rule asking the author to check by hand — which is what
+// had just failed.
+//
+// GitHub not answering is NOT a pass. It is reported as unverified and
+// blocks, like every other check here that could not run.
+func VerifyCredits(root, entry string) []string {
+	credits := CreditsIn(entry)
+	if len(credits) == 0 {
+		return nil
+	}
+
+	authors := map[int]string{}
+	var problems []string
+	for _, c := range credits {
+		if len(c.Cites) == 0 {
+			problems = append(problems, fmt.Sprintf(
+				"@%s is credited in a paragraph that links no issue or pull request — a credit a reader cannot trace is one they take on faith", c.Handle))
+			continue
+		}
+		matched := false
+		for _, n := range c.Cites {
+			who, seen := authors[n]
+			if !seen {
+				var err error
+				who, err = authorOf(root, n)
+				if err != nil {
+					problems = append(problems, fmt.Sprintf(
+						"credits NOT verified — GitHub would not say who opened #%d (%v); a name nothing checked is how the wrong one ships", n, err))
+					return problems
+				}
+				authors[n] = who
+			}
+			if strings.EqualFold(who, c.Handle) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			var who []string
+			for _, n := range c.Cites {
+				who = append(who, fmt.Sprintf("#%d by @%s", n, authors[n]))
+			}
+			problems = append(problems, fmt.Sprintf(
+				"@%s is credited but opened none of what that paragraph cites (%s) — verify with `gh issue view <n>` and correct the handle",
+				c.Handle, strings.Join(who, ", ")))
+		}
+	}
+	return problems
+}
+
+func firstLine(err error) string {
+	if ee, ok := err.(*exec.ExitError); ok {
+		for _, l := range strings.Split(string(ee.Stderr), "\n") {
+			if t := strings.TrimSpace(l); t != "" {
+				return t
+			}
+		}
+	}
+	return err.Error()
+}
+
+// EntryFor returns the body of the `## <version>` section of the
+// repository's changelog — the text the release job publishes verbatim.
+func EntryFor(root, version string) string {
+	raw, err := os.ReadFile(filepath.Join(root, changelogName))
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "## "+version) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			return strings.Join(lines[start+1:i], "\n")
+		}
+	}
+	return strings.Join(lines[start+1:], "\n")
+}

--- a/internal/release/credits_test.go
+++ b/internal/release/credits_test.go
@@ -1,0 +1,96 @@
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+// A credit belongs to the thing its own paragraph cites. A handle in one
+// paragraph and a number in another are unrelated, and pairing them would
+// invent a claim the entry never made.
+// proved by: gathered handles and numbers across the whole entry instead
+// of per paragraph — every contributor appears to have opened everything,
+// so no misattribution is detectable at all.
+func TestACreditIsPairedWithWhatItsOwnParagraphCites(t *testing.T) {
+	entry := `_summary_
+
+**Fixed — one thing.**
+([#152](https://github.com/azrtydxb/procoder/pull/152)) Reported by
+[@codixio](https://github.com/codixio) in
+[#150](https://github.com/azrtydxb/procoder/issues/150).
+
+**Fixed — another.**
+([#148](https://github.com/azrtydxb/procoder/pull/148)) Contributed by
+[@Acroaticum](https://github.com/Acroaticum).
+`
+	got := CreditsIn(entry)
+	if len(got) != 2 {
+		t.Fatalf("one credit per named contributor: %+v", got)
+	}
+	if got[0].Handle != "codixio" || len(got[0].Cites) != 2 {
+		t.Errorf("the first credit cites its own paragraph's two numbers: %+v", got[0])
+	}
+	if got[1].Handle != "Acroaticum" || len(got[1].Cites) != 1 || got[1].Cites[0] != 148 {
+		t.Errorf("the second cites only 148, not the first paragraph's: %+v", got[1])
+	}
+}
+
+// A contributor named in a paragraph that links nothing cannot be checked
+// by anyone — reader or controller. Saying so is the point: an unverifiable
+// credit is the shape the wrong name hides in.
+// proved by: skipped paragraphs with no citations instead of reporting
+// them — a credit attached to nothing passes, which is exactly where a
+// misattribution would sit unnoticed.
+func TestACreditThatCitesNothingIsReported(t *testing.T) {
+	entry := "_summary_\n\n**Fixed — a thing.** Thanks to [@somebody](https://github.com/somebody).\n"
+	got := VerifyCredits(t.TempDir(), entry)
+	if len(got) != 1 {
+		t.Fatalf("a credit with nothing to check against is reported: %v", got)
+	}
+	if !strings.Contains(got[0], "@somebody") || !strings.Contains(got[0], "links no issue") {
+		t.Errorf("and says why: %q", got[0])
+	}
+}
+
+// An entry naming nobody has nothing to verify, and a controller that
+// reached for GitHub anyway would make every release depend on the network
+// for a question it does not need to ask.
+// proved by: returned a problem for an entry with no credits — every
+// release with no contributors to thank is blocked on a check with no
+// subject.
+func TestAnEntryWithNoCreditsAsksGitHubNothing(t *testing.T) {
+	entry := "_summary_\n\n**Added — a thing.**\n([#1](https://github.com/azrtydxb/procoder/pull/1)) Done.\n"
+	if got := VerifyCredits(t.TempDir(), entry); len(got) != 0 {
+		t.Errorf("nothing to verify is not a problem: %v", got)
+	}
+}
+
+// GitHub not answering is not a pass. This is the one check in the
+// controller that reaches the network, so it is the one most able to fail
+// open — and a credit nothing verified is exactly how the wrong name
+// ships, which is the failure this exists to prevent.
+// proved by: returned nil when the lookup errors — an offline release
+// verifies nothing, says nothing, and publishes whatever handle was
+// written.
+func TestGitHubNotAnsweringBlocksRatherThanPasses(t *testing.T) {
+	// PATH emptied so `gh` cannot be found: the same shape as a machine
+	// without it, a revoked token, or no network.
+	t.Setenv("PATH", t.TempDir())
+
+	entry := `_summary_
+
+**Fixed — a thing.**
+([#1](https://github.com/azrtydxb/procoder/pull/1)) Reported by
+[@somebody](https://github.com/somebody).
+`
+	got := VerifyCredits(t.TempDir(), entry)
+	if len(got) == 0 {
+		t.Fatal("a lookup that could not run must not read as a credit that checked out")
+	}
+	if !strings.Contains(got[0], "NOT verified") {
+		t.Errorf("and must say it did not run, not that it failed: %q", got[0])
+	}
+	if !strings.Contains(got[0], "#1") {
+		t.Errorf("naming what it could not check: %q", got[0])
+	}
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -91,6 +91,16 @@ func Run(root, version string, gateClean func() bool, suite func() (bool, string
 		}
 	}
 
+	// 6. the credits in the entry about to be published. GitHub is asked
+	// who actually opened each cited issue, which the suite cannot do —
+	// it runs offline on every commit — and which this controller can,
+	// because the tag it is preparing gets published by a job that talks
+	// to the same API. A misattributed credit hands one person's thanks
+	// to another, permanently, in notes GitHub publishes verbatim.
+	for _, p := range VerifyCredits(root, EntryFor(root, version)) {
+		failures = append(failures, p)
+	}
+
 	if len(failures) > 0 {
 		out(fmt.Sprintf("release %s is NOT ready:", version))
 		for _, f := range failures {


### PR DESCRIPTION
## I was wrong about this

I said "get the name right" couldn't be enforced because the suite must not need the network. That's true of the *suite* — and irrelevant, because I'd put the check in the wrong place.

`procoder release` prepares a tag that gets published by a job which talks to the GitHub API. **The network was already a precondition.** Refusing to spend one call there bought nothing and cost correctness.

## What it does

Check 6 in the controller: every contributor the entry credits must have opened one of the issues or PRs that **same paragraph** cites.

Paragraph scope is the rule — an entry credits somebody *for* something, and the something is whatever that paragraph links. Pairing a handle in one paragraph with a number in another would invent a claim the entry never made.

## Verified against the actual mistake

Crediting `@Acroaticum` for reporting #149 — the error I made in this repo — now reports:

```
@Acroaticum is credited but opened none of what that paragraph cites
(#151 by @piwi3910, #149 by @codixio) — verify with `gh issue view <n>`
and correct the handle
```

The message names who actually opened each one, so the correction is *in the error* rather than another lookup away.

## GitHub not answering is not a pass

Reported as **NOT verified** and blocks, naming what it couldn't check. This is the only check in the controller that reaches the network, which makes it the one most able to fail open — and a credit nothing verified is precisely how the wrong name ships.

## Verification

- The real 1.5.0 and 2.0.0 entries both verify **clean against the live API**
- Three mutations proven: gathering credits entry-wide rather than per paragraph; skipping a credit that cites nothing; swallowing a failed lookup
- The offline half (extraction, pairing, unverifiable-credit reporting) is unit-tested and needs no network

The split now: **linked form** checked by the suite on every commit, offline. **Name correctness** checked by the release controller, where GitHub is a given.