### PR TITLE
release: 3.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer. All nine domains shipped: security, best practices, maintainability, performance, documentation, clean code, CI/CD, DevOps, GitOps \u2014 plus the code index. Hooks hand the agent results; the agent stays in control.",
   "author": {
     "name": "Pascal Watteel"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "procoder",
   "metadata": {
     "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "plugins": [
     {

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,57 @@ Rules that earn their place:
   handle opened none of what its paragraph cites.
 -->
 
+## 3.1.0 — 2026-08-26
+
+_The per-platform binaries are no longer committed. CI builds them at the
+tag and the launcher fetches the one your machine needs, once._
+
+**Changed — procoder's binaries are built by CI and fetched on first
+use.** ([#176](https://github.com/azrtydxb/procoder/pull/176)) They used to
+be committed: five binaries, 39MB, rewritten at every release and
+permanent in history — which is most of why `.git` had reached 690MB. They
+were also built by hand, and that failed twice in a single day: 3.0.0 was
+tagged carrying 2.0.1's binaries with every manifest, the gate and the
+suite green, and the corrected build then failed the reproducibility check
+because it predated its own source.
+
+Now the release job builds all five from the tagged source and publishes
+them with checksums it generated, and `hooks/launcher.sh` fetches the one
+binary for your platform on first use, verifies it against those
+checksums, caches it beside the plugin and execs it. Every run after that
+execs the cached binary directly, with no network — the path that fires on
+every session start, every Bash call and every write is unchanged.
+
+Nothing is built locally any more, by anyone.
+
+**Changed — a first run now needs the network, and fails gracefully when
+it cannot.** ([#176](https://github.com/azrtydxb/procoder/pull/176)) This
+replaces a stated property: the launcher's own comment used to read
+"marketplace install, no runtime, no network". A hook that cannot fetch
+warns on stderr, writes nothing to stdout and exits 0, so the session
+stays usable and you can see the gate is not running. Every other
+invocation refuses and exits non-zero, because a launcher that exited 0
+having run nothing would be a silent green underneath every check in the
+tool.
+
+Set `PROCODER_BIN` to an absolute path to use your own binary and skip all
+of this — it is your file, and nothing about it is checked. `PROCODER_NO_FETCH`
+disables the download entirely.
+
+**Removed — the checks whose subject was a committed binary.**
+([#176](https://github.com/azrtydxb/procoder/pull/176)) CI's
+reproducibility job rebuilt the committed binaries and compared digests;
+`procoder release` refused to tag when the shipped binary reported a
+different version; a test compared the committed checksums to the
+committed files. All three answered questions about a thing that no longer
+exists, and all three are gone with their tests rather than left asserting
+a world that has ended.
+
+What that spends is written down in ADR 0004 rather than discovered later:
+with nothing committed there is nothing to rebuild against, so nobody
+outside CI can independently confirm the published bytes. That is the
+trust already extended to every other CI-published artifact.
+
 ## 3.0.0 — 2026-08-24
 
 _Procoder was run against a repository it had never seen, and against a

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ turns every escaped bug into a permanently closed class. The agent stays
 in control — nothing ever touches your code behind its back.
 
 ![CI](https://github.com/azrtydxb/procoder/actions/workflows/ci.yml/badge.svg)
-![Version](https://img.shields.io/badge/version-3.0.0-7C3AED)
+![Version](https://img.shields.io/badge/version-3.1.0-7C3AED)
 ![License](https://img.shields.io/badge/license-Apache--2.0-7C3AED)
 ![Agents](https://img.shields.io/badge/works%20with-20%2B%20agents-7C3AED)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ bug's whole class, and one contract that works across every AI coding
 agent. The agent stays in control; nothing ever touches your code behind
 its back.
 
-Current version: **3.0.0**
+Current version: **3.1.0**
 
 ```mermaid
 flowchart LR

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "license": "Apache-2.0",
   "repository": {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: procoder
-version: 3.0.0
+version: 3.1.0
 description: A harness that gives AI coders the tools and skills to work like a senior developer
 entry: __init__.py
 provides_hooks:


### PR DESCRIPTION
The per-platform binaries stop being committed. CI builds all five at the
tag and publishes them with checksums it generated; `hooks/launcher.sh`
fetches the one this machine needs on first use, verifies it, caches it
beside the plugin, and execs it.

## What this costs, stated plainly

A first run needs the network. That replaces a property the launcher's own
comment used to state: "marketplace install, no runtime, no network".

A hook that cannot fetch warns on stderr, writes nothing to stdout and
exits 0 — the session stays usable and the user can see the gate is not
running. Every other invocation refuses, because a launcher exiting 0
having run nothing is a silent green underneath every check in the tool.

Third-party verifiability goes with the reproducibility job: with nothing
committed there is nothing to rebuild against. ADR 0004 records both.

## What it buys

`.git` stops growing by 39MB a release. Nobody builds a release binary by
hand again — which failed twice in one day: 3.0.0 tagged carrying 2.0.1's
binaries with every check green, and the corrected build failing the
reproducibility check because it predated its own source.

## Verification

Fifteen stories across two sprints, eleven tested against a stub server.
Fourteen mutations run; three did not fail their test and each exposed a
test asserting something true for the wrong reason.

Copilot's review of #176 found a release-breaking bug this PR depends on
not having: on a tag build the test job runs before the release job
publishes, and the step that runs the launcher would have looked for a
release that does not exist yet — failing every release from the next one
on, while passing on pull requests because the previous version's release
happens to exist. That step now plants a stub and runs with fetching
disabled.