### PR TITLE
fix: a resumed session gets a pointer, not the principles again

### DIFF
--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -638,7 +638,7 @@ func run(args []string) int {
 		return portability.Agents(doctor.Root(), printLine)
 	case "principles":
 		if len(args) > 1 && args[1] == "--hook" {
-			return principles.RunHook(doctor.Root(), printLine)
+			return principles.RunHook(doctor.Root(), os.Stdin, printLine)
 		}
 		return principles.Run(doctor.Root(), printLine)
 	case "templates":

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -604,7 +604,24 @@ auto-reviews to ask about, so the empty answer is real and the exit is 0.
 
 Prints the engineering principles each session starts with (`--hook` is
 how the SessionStart hook asks for them, wrapped in the envelope its host
-reads; without it the same content goes to the terminal): build-ladder first — reuse, stdlib, platform, then the
+reads; without it the same content goes to the terminal).
+
+`--hook` reads the SessionStart payload on stdin and answers differently
+depending on why the session started. A **resume** or a **compact** gets
+one line saying the rules are in force and where to read them, because the
+full text is already in that conversation and re-sending it pays roughly
+7KB to repeat what the model can already see. Every other start gets the
+whole thing — including one whose payload could not be read, could not be
+parsed, or names a source this version does not recognise. Saying too much
+costs tokens; saying too little leaves a session governed by rules nobody
+sent.
+
+The read gives up after two seconds. A SessionStart hook runs before the
+session can begin, so a host that opens the pipe and sends nothing must not
+hold it open — and the fallback there, as everywhere else, is the full
+text.
+
+The principles themselves: build-ladder first — reuse, stdlib, platform, then the
 minimum code that works — the delegation discipline (independent work
 fans out to parallel subagents under a clear contract, nothing started
 that somebody else is already on, watched as it

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -6,8 +6,11 @@
 package host
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 	"strings"
+	"time"
 )
 
 // Host names the running agent.
@@ -45,3 +48,64 @@ func Detect() Host {
 func isVSCodeCopilotRoot(root string) bool {
 	return root != "" && strings.Contains(root, "agent-plugins") && strings.Contains(root, ".vscode")
 }
+
+// SessionSource is why the session started, as the host reports it on the
+// SessionStart hook's stdin: "startup", "resume", "clear" or "compact".
+// Empty when there is no payload, it cannot be read in time, or it does not
+// carry the field.
+//
+// It exists because the principles injection is expensive — roughly 7KB of
+// text, re-sent verbatim on every matched start. On resume and compact that
+// text is already in the conversation, and one working day of resumed
+// sessions was measured at ~187k tokens of repeated injection (#175).
+//
+// The read is deadline-guarded and never fatal. A SessionStart hook that
+// blocks holds the whole session open, and one that fails should fall back
+// to saying too much rather than too little: an unknown source is treated
+// as a fresh start by every caller here, so the rules arrive in full rather
+// than being replaced by a pointer to rules the model has not seen.
+func SessionSource(stdin io.Reader) string {
+	if stdin == nil {
+		return ""
+	}
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		// A SessionStart payload is a few hundred bytes; the cap is only
+		// there so a wedged writer cannot grow this without bound.
+		data, err := io.ReadAll(io.LimitReader(stdin, 1<<20))
+		ch <- readResult{data, err}
+	}()
+	var raw []byte
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return ""
+		}
+		raw = res.data
+	case <-time.After(sessionSourceDeadline):
+		return ""
+	}
+	var payload struct {
+		Source string `json:"source"`
+	}
+	if json.Unmarshal(raw, &payload) != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(payload.Source))
+}
+
+// Resumed reports whether this start already has the session's earlier
+// context in it — the two sources where re-injecting the full text repeats
+// what the model can already see. Anything else, including an unreadable
+// payload, is a fresh start.
+func Resumed(source string) bool {
+	return source == "resume" || source == "compact"
+}
+
+// sessionSourceDeadline is short on purpose: this runs before a session can
+// begin, and a host that sends nothing must cost that session nothing.
+const sessionSourceDeadline = 2 * time.Second

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -68,6 +68,20 @@ func SessionSource(stdin io.Reader) string {
 	if stdin == nil {
 		return ""
 	}
+	// A terminal never sends EOF, so io.ReadAll below would sit there
+	// until the deadline expired — measured at 2.06s — and then return
+	// nothing anyway. That is pure cost: a hook payload always arrives on
+	// a pipe, so a character device means nobody is sending one.
+	//
+	// It matters beyond somebody typing the command to see what it does.
+	// A host that invoked the hook with a terminal attached would pay the
+	// deadline on every single session start, for an answer that was
+	// never coming. Raised in review on #184.
+	if f, ok := stdin.(interface{ Stat() (os.FileInfo, error) }); ok {
+		if info, err := f.Stat(); err == nil && info.Mode()&os.ModeCharDevice != 0 {
+			return ""
+		}
+	}
 	type readResult struct {
 		data []byte
 		err  error

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -195,3 +196,35 @@ func TestSessionSourceDoesNotWaitForeverOnASilentHost(t *testing.T) {
 		t.Fatal("SessionSource did not give up on a host that sent nothing")
 	}
 }
+
+// A terminal never sends EOF, so reading it costs the whole deadline and
+// returns nothing anyway. Raised in review on #184: a host that invoked the
+// hook with a terminal attached would pay 2s on every session start.
+//
+// The fake reports a character-device mode without needing a real tty,
+// which no CI runner reliably has.
+//
+// proved by: the ModeCharDevice check removed from SessionSource — the
+// test then takes the full deadline and fails the elapsed assertion.
+func TestSessionSourceDoesNotReadATerminal(t *testing.T) {
+	start := time.Now()
+	if got := SessionSource(charDevice{}); got != "" {
+		t.Errorf("SessionSource(terminal) = %q, want \"\"", got)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("reading a terminal took %s — the deadline was paid for an answer that was never coming", elapsed)
+	}
+}
+
+// charDevice is a reader that says it is a terminal and blocks forever if
+// anybody actually reads it — so a test that passes cannot be passing by
+// having read it quickly.
+type charDevice struct{}
+
+func (charDevice) Read([]byte) (int, error) { select {} }
+
+func (charDevice) Stat() (os.FileInfo, error) { return charDeviceInfo{}, nil }
+
+type charDeviceInfo struct{ os.FileInfo }
+
+func (charDeviceInfo) Mode() os.FileMode { return os.ModeCharDevice | 0o620 }

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1,6 +1,11 @@
 package host
 
-import "testing"
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
 
 // clear blanks every variable Detect consults, so a case declares its whole
 // world. The test process itself runs under an AI agent that may well export
@@ -117,5 +122,76 @@ func TestHostNamesAreTheWireValues(t *testing.T) {
 		if string(c.got) != c.want {
 			t.Errorf("host constant = %q, want %q", c.got, c.want)
 		}
+	}
+}
+
+// The SessionStart payload carries why the session started. procoder needs
+// it because the principles injection is ~7KB re-sent on every matched
+// start, and on resume/compact that text is already in the conversation —
+// one day of resumed sessions measured ~187k tokens of repetition (#175).
+//
+// proved by: returning the raw payload string instead of the parsed
+// `source` — every case below then reports the whole JSON as the source.
+func TestSessionSourceReadsWhyTheSessionStarted(t *testing.T) {
+	for _, c := range []struct{ name, payload, want string }{
+		{"startup", `{"hook_event_name":"SessionStart","source":"startup"}`, "startup"},
+		{"resume", `{"source":"resume"}`, "resume"},
+		{"compact", `{"source":"compact"}`, "compact"},
+		{"clear", `{"source":"clear"}`, "clear"},
+		{"mixed case", `{"source":"Resume"}`, "resume"},
+		{"padded", `{"source":"  compact  "}`, "compact"},
+		{"no source field", `{"hook_event_name":"SessionStart"}`, ""},
+		{"not json", `this is not a payload`, ""},
+		{"empty", ``, ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SessionSource(strings.NewReader(c.payload)); got != c.want {
+				t.Errorf("SessionSource(%q) = %q, want %q", c.payload, got, c.want)
+			}
+		})
+	}
+	if got := SessionSource(nil); got != "" {
+		t.Errorf("a nil reader is not a source, got %q", got)
+	}
+}
+
+// Only the two starts that already carry the earlier context count as
+// resumed. Everything else — including a source that could not be read —
+// is a fresh start, because the fallback has to be sending the rules
+// rather than a pointer to rules nobody sent.
+//
+// proved by: adding "" to the resumed set — the unknown case then gets a
+// pointer, and a session whose payload failed to parse runs ungoverned.
+func TestOnlyResumeAndCompactCountAsResumed(t *testing.T) {
+	for _, c := range []struct {
+		source string
+		want   bool
+	}{
+		{"resume", true}, {"compact", true},
+		{"startup", false}, {"clear", false}, {"", false}, {"unknown", false},
+	} {
+		if got := Resumed(c.source); got != c.want {
+			t.Errorf("Resumed(%q) = %v, want %v", c.source, got, c.want)
+		}
+	}
+}
+
+// A SessionStart hook runs before the session can begin. A host that opens
+// the pipe and sends nothing must not hold it open.
+//
+// proved by: removing the deadline from SessionSource — this test then
+// hangs instead of returning.
+func TestSessionSourceDoesNotWaitForeverOnASilentHost(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	done := make(chan string, 1)
+	go func() { done <- SessionSource(pr) }()
+	select {
+	case got := <-done:
+		if got != "" {
+			t.Errorf("a silent host has no source, got %q", got)
+		}
+	case <-time.After(sessionSourceDeadline + 3*time.Second):
+		t.Fatal("SessionSource did not give up on a host that sent nothing")
 	}
 }

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -194,13 +194,26 @@ func hookText(root string) string {
 // RunHook prints the principles in the shape the running host's
 // SessionStart hook expects: Claude Code reads raw stdout; Codex, Copilot,
 // and Qoder each want a JSON envelope. One hooks file serves them all.
-func RunHook(root string, out func(string)) int {
+func RunHook(root string, stdin io.Reader, out func(string)) int {
 	// The version check runs alongside the payload, never in front of it:
 	// the hook's stdout is parsed as JSON by three of the four hosts, so the
 	// warning goes to stderr (R-07), and a slow or absent GitHub cannot hold
 	// a session start open (N-02, N-03).
 	done := versionWarning(root)
+
+	// The full text goes out once per session. On a resume or a compact it
+	// is already in the conversation, so sending it again pays ~7KB to tell
+	// the model what it can already read — measured at ~187k tokens across
+	// one day of resumed sessions (#175). Those two starts get a pointer.
+	//
+	// Every other case, including a payload that could not be read, gets
+	// the full text. Saying too much costs tokens; saying too little leaves
+	// a session governed by rules nobody sent, and only one of those is
+	// recoverable by the reader.
 	text := hookText(root)
+	if host.Resumed(host.SessionSource(stdin)) {
+		text = resumeReminder
+	}
 	switch h := host.Detect(); h {
 	case host.Claude:
 		out(strings.TrimRight(text, "\n"))
@@ -219,6 +232,12 @@ func RunHook(root string, out func(string)) int {
 	done()
 	return 0
 }
+
+// resumeReminder is what a resumed session gets instead of the whole text:
+// enough to know the rules are in force and where to read them, and not a
+// second copy of what is already above it in the transcript.
+const resumeReminder = "procoder principles are active for this repository — " +
+	"they were injected earlier in this session. Run `procoder principles` for the full text."
 
 // versionWarning starts the check and returns the function that reports it.
 // Splitting the two is what keeps the check off the session's critical path:

--- a/internal/principles/principles_test.go
+++ b/internal/principles/principles_test.go
@@ -37,7 +37,7 @@ func hookOutput(t *testing.T, want, root string) string {
 	t.Helper()
 	hostEnv(t, want)
 	var got []string
-	if code := RunHook(root, func(s string) { got = append(got, s) }); code != 0 {
+	if code := RunHook(root, nil, func(s string) { got = append(got, s) }); code != 0 {
 		t.Fatalf("hook exit %d — a SessionStart hook must never fail the session", code)
 	}
 	return strings.Join(got, "\n")
@@ -124,7 +124,7 @@ func TestSessionStartStaysInsideTheBudget(t *testing.T) {
 	defer func() { releases.APIHost, Version, Stderr = prevHost, prevVer, prevErr }()
 
 	start := time.Now()
-	RunHook("../..", func(string) {})
+	RunHook("../..", nil, func(string) {})
 	elapsed := time.Since(start)
 	if elapsed > status.Budget {
 		t.Fatalf("SessionStart took %s — the budget is %s", elapsed, status.Budget)
@@ -159,7 +159,7 @@ func TestTheVersionCheckNeverHoldsTheSessionOpen(t *testing.T) {
 	var lines []string
 	var firstOut time.Duration
 	start := time.Now()
-	if code := RunHook(root, func(s string) {
+	if code := RunHook(root, nil, func(s string) {
 		if len(lines) == 0 {
 			firstOut = time.Since(start)
 		}
@@ -202,7 +202,7 @@ func TestTheVersionWarningStaysOutOfTheHookPayload(t *testing.T) {
 	defer func() { Stderr = prevErr }()
 
 	var lines []string
-	RunHook(t.TempDir(), func(s string) { lines = append(lines, s) })
+	RunHook(t.TempDir(), nil, func(s string) { lines = append(lines, s) })
 	if !strings.Contains(buf.String(), "9.9.9") {
 		t.Errorf("the warning must reach stderr: %q", buf.String())
 	}
@@ -234,8 +234,68 @@ func TestTheConfigKnobSilencesTheCheckEntirely(t *testing.T) {
 	prevErr := Stderr
 	Stderr = &buf
 	defer func() { Stderr = prevErr }()
-	RunHook(root, func(string) {})
+	RunHook(root, nil, func(string) {})
 	if buf.Len() != 0 {
 		t.Errorf("check = off says nothing: %q", buf.String())
+	}
+}
+
+// The principles block is ~7KB and SessionStart fires on startup, resume,
+// clear and compact. On resume and compact the text is already in the
+// conversation, so sending it again pays for telling the model what it can
+// already read — ~187k tokens across one day of resumed sessions (#175).
+//
+// proved by: dropping the host.Resumed branch from RunHook — the resumed
+// cases then emit the full text and this test sees it.
+func TestAResumedSessionGetsAPointerNotTheWholeText(t *testing.T) {
+	root := t.TempDir()
+	full := func(payload string) string {
+		var b strings.Builder
+		RunHook(root, strings.NewReader(payload), func(s string) { b.WriteString(s + "\n") })
+		return b.String()
+	}
+
+	startup := full(`{"source":"startup"}`)
+	resumed := full(`{"source":"resume"}`)
+	compacted := full(`{"source":"compact"}`)
+
+	if len(startup) < 1000 {
+		t.Fatalf("a fresh start must carry the whole text, got %d bytes", len(startup))
+	}
+	for name, got := range map[string]string{"resume": resumed, "compact": compacted} {
+		if len(got) >= len(startup) {
+			t.Errorf("%s sent %d bytes against startup's %d — it is not a pointer", name, len(got), len(startup))
+		}
+		if !strings.Contains(got, "procoder principles") {
+			t.Errorf("%s must still say the rules are in force: %q", name, got)
+		}
+		if !strings.Contains(got, "procoder principles`") && !strings.Contains(got, "`procoder principles`") {
+			t.Errorf("%s must say where to read them: %q", name, got)
+		}
+	}
+}
+
+// Everything that is not a resume or a compact gets the whole text,
+// including a payload that could not be read at all. Saying too much costs
+// tokens; saying too little leaves a session governed by rules nobody sent,
+// and only one of those is recoverable by the reader.
+//
+// proved by: treating an unknown source as resumed — the last three cases
+// then get a pointer to rules that were never sent.
+func TestAnythingOtherThanAResumeGetsTheWholeText(t *testing.T) {
+	root := t.TempDir()
+	for _, payload := range []string{
+		`{"source":"startup"}`,
+		`{"source":"clear"}`,
+		`{"source":"something-new"}`,
+		`not json at all`,
+		``,
+	} {
+		var b strings.Builder
+		RunHook(root, strings.NewReader(payload), func(s string) { b.WriteString(s + "\n") })
+		if len(b.String()) < 1000 {
+			t.Errorf("payload %q got %d bytes — the rules must arrive in full when the start is not known to be resumed",
+				payload, b.Len())
+		}
 	}
 }


### PR DESCRIPTION
Fixes #175.

SessionStart fires on `startup`, `resume`, `clear` and `compact`, and the
hook sent the full principles block on all four. On a resume or a compact
that text is already in the conversation, so procoder was paying roughly
7KB to tell the model what it could already read.

The reporter measured it: **~187k tokens across one working day** of
resumed sessions, with the injected block byte-identical from v1.4.0
through v3.0.0.

## What changed

The payload has always carried the reason on stdin. The hook never read
it. It does now:

| start | payload |
| --- | --- |
| `resume`, `compact` | 144 bytes — the rules are in force, and where to read them |
| everything else | 6,870 bytes — the whole text |

"Everything else" deliberately includes a payload that could not be read,
could not be parsed, or names a source this version has never heard of.
Saying too much costs tokens; saying too little leaves a session governed
by rules nobody sent, and only one of those is recoverable by the reader.
The mutation that treats an unknown source as resumed fails the test that
exists for it.

The read gives up after two seconds. A SessionStart hook runs before the
session can begin, so a host that opens the pipe and sends nothing must not
hold it open — and the fallback there is the full text as if no payload had
arrived.

## Where it lives

`internal/host`, not `internal/principles`: reading the host's SessionStart
payload is a host-adapter concern, and `principles` already depends on that
package. Importing `internal/hook` for its stdin reader would have dragged
security, lint, docs and the code index behind it for fifteen lines.

Reported with measurements rather than a guess, which is why this was
quick to fix.