### PR TITLE
release: 3.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer. All nine domains shipped: security, best practices, maintainability, performance, documentation, clean code, CI/CD, DevOps, GitOps \u2014 plus the code index. Hooks hand the agent results; the agent stays in control.",
   "author": {
     "name": "Pascal Watteel"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "procoder",
   "metadata": {
     "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
-    "version": "3.1.0"
+    "version": "3.2.0"
   },
   "plugins": [
     {

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Rules that earn their place:
   handle opened none of what its paragraph cites.
 -->
 
-## 3.1.1 — 2026-08-26
+## 3.2.0 — 2026-08-26
 
 _procoder stops applying its own conventions to repositories that never
 adopted it, and reclaims the gigabyte that updating in place left behind._
@@ -131,8 +131,7 @@ files went unchecked rather than "0 clean" over files nothing looked at. A
 quieter gate that does not say it is quieter is indistinguishable from a
 clean one. Force either mode with `[gate] scope` in
 `.procoder/config.toml`, or `PROCODER_GATE_SCOPE` for a fork that cannot
-carry configuration. Reported by
-[@ToberoCat](https://github.com/ToberoCat). The reasoning is in ADR 0005.
+carry configuration. The reasoning is in ADR 0005.
 
 **Added — `procoder prune` reclaims the plugin cache.**
 ([#187](https://github.com/azrtydxb/procoder/pull/187)) `claude plugin

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ turns every escaped bug into a permanently closed class. The agent stays
 in control — nothing ever touches your code behind its back.
 
 ![CI](https://github.com/azrtydxb/procoder/actions/workflows/ci.yml/badge.svg)
-![Version](https://img.shields.io/badge/version-3.1.0-7C3AED)
+![Version](https://img.shields.io/badge/version-3.2.0-7C3AED)
 ![License](https://img.shields.io/badge/license-Apache--2.0-7C3AED)
 ![Agents](https://img.shields.io/badge/works%20with-20%2B%20agents-7C3AED)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ bug's whole class, and one contract that works across every AI coding
 agent. The agent stays in control; nothing ever touches your code behind
 its back.
 
-Current version: **3.1.0**
+Current version: **3.2.0**
 
 ```mermaid
 flowchart LR

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "license": "Apache-2.0",
   "repository": {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: procoder
-version: 3.1.0
+version: 3.2.0
 description: A harness that gives AI coders the tools and skills to work like a senior developer
 entry: __init__.py
 provides_hooks:


### PR DESCRIPTION
## 3.2.0

Seven issues. A minor rather than a patch because one of them changes behaviour for anybody writing a spec: `procoder spec check` now **refuses** a draft whose claims cite nothing and whose criteria name no way to observe them. ADR 0003 governs what makes a change *major* and this is not that — but 3.1.1 would have undersold it.

| Issue | |
| --- | --- |
| #172 | the gate stops applying procoder's conventions to repositories that never adopted it, and narrows its content checks to the lines the commit wrote |
| #175 | a resumed session gets a 144-byte pointer instead of 6,870 bytes of principles it already has |
| #177 | a workspace member is covered by its root lockfile (contributed by @ToberoCat) |
| #181 | `procoder prune` reclaims the plugin cache — 1.1 GB to 62 MB on the maintainer's machine |
| #185 | the attribution finding says which commit carries the trailer, and the trailer is caught on the way in rather than only after it lands |
| #186 | a spec's claims are checked by something other than whoever wrote them |
| #188 | a test whose verdict depended on reaching GitHub |

Plus the decisions queue: a decision the agent cannot make reaches the user, and survives the session that answered it.

## Reviewing this

The release commit is version bumps and the changelog. Everything else already landed through #184 and #187.

One correction worth seeing: the changelog credited @ToberoCat for the gate-scoping fix. `procoder release` checks a credited handle against who actually opened what it cites, and found #172 was filed by @piwi3910. @ToberoCat reported #177 and contributed #178, which is where the credit belongs. It is removed from the gate entry and kept on the workspace one.

## After merge

The `v3.2.0` tag is what triggers the release job — CI builds all five platform binaries from the tagged source and publishes them with checksums it generates. Nothing is built locally (ADR 0004).
