### PR TITLE
fix: the release controller computes who is owed a credit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,16 @@ jobs:
         run: procoder docs --external
         env:
           GH_TOKEN: ${{ github.token }}
+      # Credits, enforced here rather than trusted to whoever cuts the
+      # release. The rule ran only when somebody typed `procoder release`
+      # on their own machine — which means it ran when they remembered,
+      # and "remember to check" is the thing that kept failing and is why
+      # the rule exists at all. Needs the API, so it needs the token; the
+      # step above already established that pattern.
+      - name: every contributor the newest changelog entry owes is credited
+        run: procoder release --credits
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: the whole-tree pass — maintain, debt, deps
         # The gate answers about the change; these answer about the
         # repository. Dependency freshness, the debt ledger and complexity

--- a/.procoder/config.toml
+++ b/.procoder/config.toml
@@ -21,6 +21,12 @@ max_file_mb = 10
 policy = "block"
 
 [release]
+# The handles the changelog's credit rule does not ask about: whose
+# release notes these are. Configured rather than discovered, because
+# `gh api user` answers only where a person is logged in — in CI the
+# token is an app installation token with no user behind it, and asking
+# returns 403.
+maintainers = ["piwi3910"]
 # The version-bearing files `procoder release` verifies stay in sync.
 files = ["plugin.yaml", "package.json", "gemini-extension.json", "README.md", ".claude-plugin/plugin.json", "docs/index.md", ".github/plugin/marketplace.json", ".codex-plugin/plugin.json", ".github/plugin/plugin.json"]
 

--- a/cmd/procoder/flags.go
+++ b/cmd/procoder/flags.go
@@ -33,6 +33,7 @@ var knownFlags = map[string][]string{
 	"lint":         {"--types"},
 	"principles":   {"--hook"},
 	"prune":        {"--apply"},
+	"release":      {"--credits"},
 	"review":       {"--lens", "--perspectives"},
 	"run":          {"--exec"},
 	"security":     {"--deep"},

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -394,6 +394,7 @@ func main() {
 	// The principles hook reports what is newer than this build; the version
 	// is stamped here at link time, so this is the only place that knows it.
 	principles.Version = version
+	config.Version = version
 	releases.Running = version
 
 	os.Exit(run(os.Args[1:]))

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -334,10 +334,13 @@ const usage = `usage: procoder <command> [args]
                        as analyst, architect, implementer and reviewer in
                        turn; a lens that could not be loaded is a refusal,
                        never a review that silently happened
-  release [<version>]  the pre-tag controller: version-sync across [release]
+  release [<version>] [--credits]
+                       the pre-tag controller: version-sync across [release]
                        files, the changelog entry, a clean tree, the gate, and
                        the suite under [test] policy — every failure listed,
-                       and on success the tag command printed, never run
+                       and on success the tag command printed, never run.
+                       --credits runs only the contributor checks, which is
+                       what CI enforces on every commit
   run [--exec]         how to run this project: the launch command(s) it
                        declares, with the file that declared each; --exec runs
                        a single non-server candidate for you
@@ -507,8 +510,21 @@ func run(args []string) int {
 	case "release":
 		root := doctor.Root()
 		version := ""
-		if len(args) > 1 {
-			version = args[1]
+		creditsOnly := false
+		for _, a := range args[1:] {
+			if a == "--credits" {
+				creditsOnly = true
+				continue
+			}
+			version = a
+		}
+		if creditsOnly {
+			// The credit checks alone, so CI can enforce them. The rest of
+			// the controller asks about the working tree, the tag and the
+			// version files — all of which are meaningless on a pull
+			// request and would fail for reasons that have nothing to do
+			// with whether somebody is credited.
+			return release.Credits(root, version, printLine)
 		}
 		return release.Run(root, version, func() bool {
 			return gate.Run(nil, root, io.Discard) == 0

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -283,6 +283,16 @@ The report names the handle and hands over the line to paste, because a
 check that says "this is wrong" and leaves you to work out the right answer
 is one you satisfy by deleting the credit.
 
+Who counts as "yours" comes from `[release] maintainers` in
+`.procoder/config.toml`, not from who is running the command. `gh api user`
+answers only where a person is logged in — in CI the token is an app
+installation token with no user behind it and returns 403, which made the
+check unrunnable in the one place it most needed to run. Falling back to
+whoever triggered the workflow would be worse: on a contributor's pull
+request that is the contributor, who would then be excluded from the credit
+they are owed. With nothing configured it asks `gh` locally, so a
+repository that has set nothing still gets the rule by hand.
+
 `procoder release --credits` runs those two checks and nothing else, and CI
 runs it on every commit with a token. That is the difference between a rule
 and a habit: until it ran in CI it ran only when whoever cut the release

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -263,7 +263,27 @@ not committed any more: CI builds them at the tag and the launcher fetches
 what it needs (ADR 0004), so there is nothing local for this controller to
 find stale.
 
-That last one asks GitHub, which the test suite deliberately cannot —
+**Credits are computed, not proofread.** Two questions, and the second is
+the one that used to be nobody's job:
+
+- a handle credited in a paragraph must have opened something that
+  paragraph cites, or the credit is wrong;
+- everybody a paragraph OWES a credit must have one, or somebody's work is
+  going unacknowledged.
+
+The rule for who is owed is mechanical. A cited **issue** owes its author a
+credit. A cited **pull request** owes its author a credit. When one person
+did both, that is one credit and not two. When the reporter and the fixer
+are different people, **both** are owed — crediting only the pull request
+quietly erases whoever found the problem. Whoever is cutting the release is
+excluded; thanking yourself in your own notes is noise, and a rule that
+demanded it would be ignored within one release.
+
+The report names the handle and hands over the line to paste, because a
+check that says "this is wrong" and leaves you to work out the right answer
+is one you satisfy by deleting the credit.
+
+That last pair asks GitHub, which the test suite deliberately cannot —
 the suite runs offline on every commit. This controller can, because the
 tag it prepares is published by a job that talks to the same API, so the
 network was already a precondition. A misattributed credit hands one

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -283,6 +283,14 @@ The report names the handle and hands over the line to paste, because a
 check that says "this is wrong" and leaves you to work out the right answer
 is one you satisfy by deleting the credit.
 
+`procoder release --credits` runs those two checks and nothing else, and CI
+runs it on every commit with a token. That is the difference between a rule
+and a habit: until it ran in CI it ran only when whoever cut the release
+remembered to type the command — and "remember to check" is exactly what
+kept failing, which is why the rule exists. The rest of the controller asks
+about the working tree, the tag and the version files, none of which mean
+anything on a pull request.
+
 That last pair asks GitHub, which the test suite deliberately cannot —
 the suite runs offline on every commit. This controller can, because the
 tag it prepares is published by a job that talks to the same API, so the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,23 @@ policy = "report"
 check = "warn"
 ```
 
+## A setting procoder does not know
+
+An unrecognised key blocks. A key that does nothing while its writer
+believes it is in force is the failure this whole feature would otherwise
+introduce, so silence is not an option.
+
+The finding names both reasons a key can be unrecognised, because only one
+of them is yours to fix. A **typo** is: correct the spelling. A key **added
+in a later release** is not — you spelled it correctly, this build is
+simply older, and no edit to the file will help. The finding says which
+build is doing the not-knowing and points at `procoder self-upgrade`.
+
+That distinction is not cosmetic. An instruction nobody can follow is how
+`--no-verify` becomes muscle memory, which is the failure behind both #172
+and #185 — and it happened here, with a key added in one commit reported
+unknown by the plugin binary from the release before it.
+
 ## Adopted and universal repositories
 
 Procoder runs two gates, and which one you get is decided from the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,16 @@ policy = "report"
 retro = "off"
 
 [release]
+# The handles the changelog's credit rule does not ask about: whose
+# release notes these are. Thanking yourself in your own notes is noise.
+#
+# Configured rather than discovered. `gh api user` answers only where a
+# person is logged in; in CI the token is an app installation token with
+# no user behind it and returns 403, which made the check unrunnable in
+# the one place it most needed to run. "Whoever triggered the workflow"
+# is worse — on a contributor's pull request that is the contributor,
+# who would then be excluded from the credit they are owed.
+maintainers = ["your-handle"]
 # The version-bearing files `procoder release` verifies stay in sync.
 # Unset, the version-sync leg reports that it verified nothing.
 files = ["README.md", "docs/index.md"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,19 @@ type Config struct {
 	// SprintRetroOff disables the retro gate: without it, opening a new
 	// sprint refuses while the last closed sprint's retro is empty.
 	SprintRetroOff bool
+	// Maintainers are the handles excluded from the changelog's credit
+	// rule — the people whose own release notes these are. Thanking
+	// yourself in them is noise.
+	//
+	// Configured rather than discovered. `gh api user` answers only where
+	// a person is logged in: in CI the token is an app installation token
+	// with no user behind it at all, which returns 403 and made the check
+	// unrunnable exactly where it most needed to run. And "whoever
+	// triggered the workflow" is worse than useless — on a contributor's
+	// pull request that is the contributor, who would then be excluded
+	// from the credit they are owed.
+	Maintainers []string
+
 	// ReleaseFiles are the version-bearing files `procoder release`
 	// verifies; unset means the version-sync leg verifies nothing (said).
 	ReleaseFiles []string
@@ -215,6 +228,8 @@ func Load(root string) Config {
 			cfg.TestBlock = value == "block"
 		case "sprint.retro":
 			cfg.SprintRetroOff = value == "off"
+		case "release.maintainers":
+			cfg.Maintainers = parseList(value)
 		case "release.files":
 			cfg.ReleaseFiles = parseList(value)
 		case "bench.threshold":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,8 +280,19 @@ func Load(root string) Config {
 		default:
 			// A key procoder does not know is a key that does nothing, and
 			// a writer who mistypes `policy` believes their policy is set.
+			// So it still blocks.
+			//
+			// But "procoder does not know it" has TWO causes, and the
+			// finding used to name only one. A typo is the writer's to
+			// fix. A key added in a later release is not: the reader has
+			// spelled it correctly, this build is simply older, and
+			// telling them the name does not exist is an instruction
+			// nobody can follow — which is how `--no-verify` becomes
+			// muscle memory (#172, #185). It happened here: a key added
+			// in one commit was reported unknown by the installed plugin
+			// binary from the release before it.
 			cfg.Problems = append(cfg.Problems, Problem{Line: lineNo, Text: line,
-				Reason: "no setting by this name — it has no effect"})
+				Reason: unknownKeyReason()})
 			continue
 		}
 		seen[key] = Setting{Key: key, Value: value,
@@ -361,4 +372,19 @@ func atoiOr(s string, fallback int) int {
 		return fallback
 	}
 	return n
+}
+
+// Version is the build's version, set by main so the config layer can say
+// which procoder is doing the not-knowing. Empty in tests and in a dev
+// build, where the sentence simply omits it.
+var Version string
+
+// unknownKeyReason names both causes and the route out of each.
+func unknownKeyReason() string {
+	running := ""
+	if Version != "" {
+		running = " (this build is " + Version + ")"
+	}
+	return "no setting by this name — it has no effect" + running +
+		"; if it is a typo, fix the spelling — if the setting was added in a later release, `procoder self-upgrade` and re-run, because a correctly spelled key an older build does not know is not something you can fix in the file"
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -389,3 +389,61 @@ func TestAnUnknownPlanningMethodIsAProblemAndTheDefaultRuns(t *testing.T) {
 		t.Errorf("the unset default is procoder: %q", got)
 	}
 }
+
+// An unknown key still blocks — a writer who mistypes `policy` believes
+// their policy is in force, and that is the failure this whole feature
+// would otherwise introduce.
+//
+// But "procoder does not know it" has two causes and the finding used to
+// name one. A typo is the writer's to fix. A key added in a later release
+// is not: they spelled it correctly, this build is older, and telling them
+// the name does not exist is an instruction nobody can follow — which is
+// how `--no-verify` becomes muscle memory (#172, #185).
+//
+// It happened in this repository: a key added in one commit was reported
+// unknown by the installed plugin binary from the release before it, and
+// the only way past was to skip the gate.
+//
+// proved by: unknownKeyReason reverted to the bare "no setting by this
+// name — it has no effect" — the upgrade route disappears and this names
+// which half is missing.
+func TestAnUnknownKeyNamesBothCausesAndTheirRoutes(t *testing.T) {
+	dir := writeConfig(t, "[git]\nmaintainerz = [\"x\"]\n")
+	cfg := Load(dir)
+	if len(cfg.Problems) != 1 {
+		t.Fatalf("an unknown key must still block, got %+v", cfg.Problems)
+	}
+	reason := cfg.Problems[0].Reason
+	// The typo half, which was already there.
+	if !strings.Contains(reason, "typo") {
+		t.Errorf("the finding does not offer the typo route: %q", reason)
+	}
+	// The half that was missing, and the one the reader cannot work out.
+	if !strings.Contains(reason, "self-upgrade") {
+		t.Errorf("the finding does not offer the upgrade route, so a correctly spelled newer key is unfixable: %q", reason)
+	}
+	// And it still says what is true right now.
+	if !strings.Contains(reason, "no effect") {
+		t.Errorf("the finding no longer says the setting is not applied: %q", reason)
+	}
+}
+
+// The running version is named, so a reader can tell whether their build
+// is plausibly older than the key.
+//
+// proved by: the `Version != ""` guard inverted — the version is never
+// named and a reader cannot judge which cause applies.
+func TestTheUnknownKeyFindingNamesTheRunningBuild(t *testing.T) {
+	prev := Version
+	Version = "9.9.9"
+	defer func() { Version = prev }()
+
+	dir := writeConfig(t, "[git]\nnosuchkey = 1\n")
+	cfg := Load(dir)
+	if len(cfg.Problems) != 1 {
+		t.Fatalf("want one problem, got %+v", cfg.Problems)
+	}
+	if !strings.Contains(cfg.Problems[0].Reason, "9.9.9") {
+		t.Errorf("the finding does not say which build does not know the key: %q", cfg.Problems[0].Reason)
+	}
+}

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"procoder/internal/config"
 	"regexp"
 	"strings"
 	"time"
@@ -203,30 +204,38 @@ func resolveOrigin(root string, number int) (origin, error) {
 	return origin{number: number, login: parts[0], isPR: parts[1] == "true"}, nil
 }
 
-// releaser is whoever is cutting this release. They are excluded from the
-// credits: thanking yourself in your own release notes is noise, and a
-// rule that demanded it would be ignored within one release.
+// excluded is the handles the credit rule does not ask about: the people
+// whose release notes these are. Thanking yourself in your own notes is
+// noise, and a rule that demanded it would be ignored inside one release.
 //
-// The error is returned rather than swallowed. An empty handle excludes
-// nobody, so a `gh` that cannot answer would quietly turn the exclusion
-// off and start demanding the maintainer credit themselves — the rule
-// silently not applying, which is the failure this file exists to end.
-// Raised in review on #213: the policy was already "unknown is not a
-// pass", and it was applied to the citation lookup and not to this one.
-func releaser(root string) (string, error) {
+// Configuration first, and configuration is the answer that works
+// everywhere. `gh api user` answers only where a person is logged in — in
+// CI the token is an app installation token with no user behind it, and
+// asking returns 403. That made the check unrunnable in the one place it
+// most needed to run, which is how it was found. And "whoever triggered
+// the workflow" is worse than useless: on a contributor's pull request
+// that is the contributor, who would then be excluded from the credit
+// they are owed.
+//
+// The local fallback stays, so a repository that has configured nothing
+// still gets the rule when a person runs it by hand.
+func excluded(root string) ([]string, error) {
+	if names := config.Load(root).Maintainers; len(names) > 0 {
+		return names, nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "gh", "api", "user", "--jq", ".login")
 	cmd.Dir = root
 	raw, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("%v", firstLine(err))
+		return nil, fmt.Errorf("%v — set `[release] maintainers` in .procoder/config.toml, which is the answer that works in CI too", firstLine(err))
 	}
 	login := strings.TrimSpace(string(raw))
 	if login == "" {
-		return "", fmt.Errorf("gh answered with no login")
+		return nil, fmt.Errorf("gh answered with no login — set `[release] maintainers` in .procoder/config.toml")
 	}
-	return login, nil
+	return []string{login}, nil
 }
 
 // MissingCredits reports contributors a paragraph OWES a credit and does
@@ -252,7 +261,7 @@ func releaser(root string) (string, error) {
 // not run.
 func MissingCredits(root, entry string) []string {
 	return missingCreditsWith(entry,
-		func() (string, error) { return releaser(root) },
+		func() ([]string, error) { return excluded(root) },
 		func(n int) (origin, error) { return resolveOrigin(root, n) })
 }
 
@@ -260,7 +269,7 @@ func MissingCredits(root, entry string) []string {
 // so the logic can be tested without a network — the suite runs offline on
 // every commit, and a rule this fiddly is exactly the kind that needs
 // tests rather than one live run that happened to look right.
-func missingCreditsWith(entry string, who func() (string, error), resolve func(int) (origin, error)) []string {
+func missingCreditsWith(entry string, who func() ([]string, error), resolve func(int) (origin, error)) []string {
 	// Nothing cited anywhere means nothing is owed, and asking GitHub who
 	// is releasing would be a network call to answer a question nobody
 	// asked. VerifyCredits returns early for the same reason — and without
@@ -274,13 +283,17 @@ func missingCreditsWith(entry string, who func() (string, error), resolve func(i
 	// would quietly turn the exclusion off and start demanding the
 	// maintainer credit themselves — the rule silently not applying, which
 	// is the failure this file exists to end.
-	me, meErr := who()
-	if meErr != nil || me == "" {
-		reason := "gh returned no login"
+	mine, meErr := who()
+	if meErr != nil || len(mine) == 0 {
+		reason := "no maintainer handle available"
 		if meErr != nil {
 			reason = meErr.Error()
 		}
-		return []string{fmt.Sprintf("who is cutting this release could not be determined (%s) — the exclusion cannot be applied, and a credit rule that silently stops applying is worse than none", reason)}
+		return []string{fmt.Sprintf("who these release notes belong to could not be determined (%s) — the exclusion cannot be applied, and a credit rule that silently stops applying is worse than none", reason)}
+	}
+	isMine := map[string]bool{}
+	for _, m := range mine {
+		isMine[strings.ToLower(m)] = true
 	}
 	var gaps []string
 	for _, para := range strings.Split(entry, "\n\n") {
@@ -307,7 +320,7 @@ func missingCreditsWith(entry string, who func() (string, error), resolve func(i
 				gaps = append(gaps, fmt.Sprintf("#%d could not be resolved (%v) — who to credit is unknown, and unknown is not a pass", n, err))
 				continue
 			}
-			if o.login == "" || strings.EqualFold(o.login, me) || seen[strings.ToLower(o.login)] {
+			if o.login == "" || isMine[strings.ToLower(o.login)] || seen[strings.ToLower(o.login)] {
 				// Same person for issue and PR collapses here: one credit,
 				// not two.
 				seen[strings.ToLower(o.login)] = true

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -173,3 +173,128 @@ func EntryFor(root, version string) string {
 	}
 	return strings.Join(lines[start+1:], "\n")
 }
+
+// origin is one cited number, resolved: who opened it, and whether it is a
+// pull request or an issue.
+type origin struct {
+	number int
+	login  string
+	isPR   bool
+}
+
+// resolveOrigin asks GitHub who opened a number and which kind it is.
+// One API call answers both: the issues endpoint serves pull requests too
+// and carries a `pull_request` key when it is one.
+func resolveOrigin(root string, number int) (origin, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "api",
+		fmt.Sprintf("repos/azrtydxb/procoder/issues/%d", number), // nosemgrep -- a number, formatted from an int
+		"--jq", `[.user.login, (.pull_request != null)] | @tsv`)
+	cmd.Dir = root
+	raw, err := cmd.Output()
+	if err != nil {
+		return origin{}, fmt.Errorf("%v", firstLine(err))
+	}
+	parts := strings.Fields(strings.TrimSpace(string(raw)))
+	if len(parts) < 2 {
+		return origin{}, fmt.Errorf("unreadable answer for #%d", number)
+	}
+	return origin{number: number, login: parts[0], isPR: parts[1] == "true"}, nil
+}
+
+// releaser is whoever is cutting this release. They are excluded from the
+// credits: thanking yourself in your own release notes is noise, and a
+// rule that demanded it would be ignored within one release.
+func releaser(root string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "api", "user", "--jq", ".login")
+	cmd.Dir = root
+	raw, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// MissingCredits reports contributors a paragraph OWES a credit and does
+// not give, and names the handle to add.
+//
+// VerifyCredits already catches a handle that opened none of what its
+// paragraph cites. That is only half the question, and the cheaper half: a
+// wrong credit is loud, and the person it was taken from is silent. This
+// is the other half — who should be here and is not — and it is what makes
+// the rule mechanical rather than a reminder to be careful.
+//
+// The rule, which is the maintainer's:
+//
+//   - a cited ISSUE owes its author a credit;
+//   - a cited PULL REQUEST owes its author a credit;
+//   - when the same person did both, that is one credit, not two;
+//   - when they are different people, BOTH are owed one — the report and
+//     the fix are separate contributions and crediting only the second
+//     quietly erases the first.
+//
+// Whoever is cutting the release is excluded. GitHub not answering is not
+// a pass: it is reported and blocks, like everything else here that could
+// not run.
+func MissingCredits(root, entry string) []string {
+	return missingCreditsWith(entry, releaser(root), func(n int) (origin, error) {
+		return resolveOrigin(root, n)
+	})
+}
+
+// missingCreditsWith is the rule with its two GitHub questions injected,
+// so the logic can be tested without a network — the suite runs offline on
+// every commit, and a rule this fiddly is exactly the kind that needs
+// tests rather than one live run that happened to look right.
+func missingCreditsWith(entry, me string, resolve func(int) (origin, error)) []string {
+	var gaps []string
+	for _, para := range strings.Split(entry, "\n\n") {
+		var nums []int
+		for _, m := range citedNumber.FindAllStringSubmatch(para, -1) {
+			var n int
+			fmt.Sscanf(m[1], "%d", &n)
+			nums = append(nums, n)
+		}
+		if len(nums) == 0 {
+			continue
+		}
+		credited := map[string]bool{}
+		for _, m := range linkedHandle.FindAllStringSubmatch(para, -1) {
+			credited[strings.ToLower(m[1])] = true
+		}
+		// Owed, in the order the numbers appear, so the report reads the
+		// way the paragraph does.
+		var owed []origin
+		seen := map[string]bool{}
+		for _, n := range nums {
+			o, err := resolve(n)
+			if err != nil {
+				gaps = append(gaps, fmt.Sprintf("#%d could not be resolved (%v) — who to credit is unknown, and unknown is not a pass", n, err))
+				continue
+			}
+			if o.login == "" || strings.EqualFold(o.login, me) || seen[strings.ToLower(o.login)] {
+				// Same person for issue and PR collapses here: one credit,
+				// not two.
+				seen[strings.ToLower(o.login)] = true
+				continue
+			}
+			seen[strings.ToLower(o.login)] = true
+			owed = append(owed, o)
+		}
+		for _, o := range owed {
+			if credited[strings.ToLower(o.login)] {
+				continue
+			}
+			kind := "reported"
+			if o.isPR {
+				kind = "contributed"
+			}
+			gaps = append(gaps, fmt.Sprintf("@%s %s #%d and is not credited in the paragraph citing it — add `%s by [@%s](https://github.com/%s)`",
+				o.login, kind, o.number, kind[:1]+kind[1:], o.login, o.login))
+		}
+	}
+	return gaps
+}

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -251,22 +251,30 @@ func releaser(root string) (string, error) {
 // a pass: it is reported and blocks, like everything else here that could
 // not run.
 func MissingCredits(root, entry string) []string {
-	me, err := releaser(root)
-	return missingCreditsWith(entry, me, err, func(n int) (origin, error) {
-		return resolveOrigin(root, n)
-	})
+	return missingCreditsWith(entry,
+		func() (string, error) { return releaser(root) },
+		func(n int) (origin, error) { return resolveOrigin(root, n) })
 }
 
 // missingCreditsWith is the rule with its two GitHub questions injected,
 // so the logic can be tested without a network — the suite runs offline on
 // every commit, and a rule this fiddly is exactly the kind that needs
 // tests rather than one live run that happened to look right.
-func missingCreditsWith(entry, me string, meErr error, resolve func(int) (origin, error)) []string {
+func missingCreditsWith(entry string, who func() (string, error), resolve func(int) (origin, error)) []string {
+	// Nothing cited anywhere means nothing is owed, and asking GitHub who
+	// is releasing would be a network call to answer a question nobody
+	// asked. VerifyCredits returns early for the same reason — and without
+	// this, every offline release test started failing on a guard that was
+	// working exactly as intended. Found by CI.
+	if !citedNumber.MatchString(entry) {
+		return nil
+	}
 	// The releaser guard lives HERE rather than in the networked caller, so
 	// a test can reach it. An empty handle excludes nobody, so proceeding
 	// would quietly turn the exclusion off and start demanding the
 	// maintainer credit themselves — the rule silently not applying, which
 	// is the failure this file exists to end.
+	me, meErr := who()
 	if meErr != nil || me == "" {
 		reason := "gh returned no login"
 		if meErr != nil {
@@ -321,4 +329,42 @@ func missingCreditsWith(entry, me string, meErr error, resolve func(int) (origin
 		}
 	}
 	return gaps
+}
+
+// Credits runs the two credit checks alone and nothing else.
+//
+// It exists so CI can ENFORCE them. Until now the rule ran only when
+// somebody typed `procoder release` on their own machine, which means it
+// ran when they remembered — and "remember to check" is precisely what
+// kept failing, which is why the rule was written in the first place.
+//
+// The rest of the controller asks about the working tree, the tag and the
+// version files. None of that means anything on a pull request, and all of
+// it would fail for reasons unrelated to whether anybody is credited.
+func Credits(root, version string, out func(string)) int {
+	if version == "" {
+		v, err := newestChangelogVersion(root)
+		if err != nil {
+			out("no version to check — " + err.Error())
+			return 2
+		}
+		version = v
+	}
+	entry := EntryFor(root, version)
+	if strings.TrimSpace(entry) == "" {
+		out(fmt.Sprintf("no changelog entry for %s — nothing to check credits against", version))
+		return 2
+	}
+	var problems []string
+	problems = append(problems, VerifyCredits(root, entry)...)
+	problems = append(problems, MissingCredits(root, entry)...)
+	if len(problems) == 0 {
+		out(fmt.Sprintf("credits for %s: every contributor the entry cites is credited, and every credit traces to something they opened", version))
+		return 0
+	}
+	out(fmt.Sprintf("credits for %s are NOT right:", version))
+	for _, p := range problems {
+		out("  " + p)
+	}
+	return 1
 }

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -206,16 +206,27 @@ func resolveOrigin(root string, number int) (origin, error) {
 // releaser is whoever is cutting this release. They are excluded from the
 // credits: thanking yourself in your own release notes is noise, and a
 // rule that demanded it would be ignored within one release.
-func releaser(root string) string {
+//
+// The error is returned rather than swallowed. An empty handle excludes
+// nobody, so a `gh` that cannot answer would quietly turn the exclusion
+// off and start demanding the maintainer credit themselves — the rule
+// silently not applying, which is the failure this file exists to end.
+// Raised in review on #213: the policy was already "unknown is not a
+// pass", and it was applied to the citation lookup and not to this one.
+func releaser(root string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "gh", "api", "user", "--jq", ".login")
 	cmd.Dir = root
 	raw, err := cmd.Output()
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("%v", firstLine(err))
 	}
-	return strings.TrimSpace(string(raw))
+	login := strings.TrimSpace(string(raw))
+	if login == "" {
+		return "", fmt.Errorf("gh answered with no login")
+	}
+	return login, nil
 }
 
 // MissingCredits reports contributors a paragraph OWES a credit and does
@@ -240,7 +251,8 @@ func releaser(root string) string {
 // a pass: it is reported and blocks, like everything else here that could
 // not run.
 func MissingCredits(root, entry string) []string {
-	return missingCreditsWith(entry, releaser(root), func(n int) (origin, error) {
+	me, err := releaser(root)
+	return missingCreditsWith(entry, me, err, func(n int) (origin, error) {
 		return resolveOrigin(root, n)
 	})
 }
@@ -249,7 +261,19 @@ func MissingCredits(root, entry string) []string {
 // so the logic can be tested without a network — the suite runs offline on
 // every commit, and a rule this fiddly is exactly the kind that needs
 // tests rather than one live run that happened to look right.
-func missingCreditsWith(entry, me string, resolve func(int) (origin, error)) []string {
+func missingCreditsWith(entry, me string, meErr error, resolve func(int) (origin, error)) []string {
+	// The releaser guard lives HERE rather than in the networked caller, so
+	// a test can reach it. An empty handle excludes nobody, so proceeding
+	// would quietly turn the exclusion off and start demanding the
+	// maintainer credit themselves — the rule silently not applying, which
+	// is the failure this file exists to end.
+	if meErr != nil || me == "" {
+		reason := "gh returned no login"
+		if meErr != nil {
+			reason = meErr.Error()
+		}
+		return []string{fmt.Sprintf("who is cutting this release could not be determined (%s) — the exclusion cannot be applied, and a credit rule that silently stops applying is worse than none", reason)}
+	}
 	var gaps []string
 	for _, para := range strings.Split(entry, "\n\n") {
 		var nums []int

--- a/internal/release/credits_missing_test.go
+++ b/internal/release/credits_missing_test.go
@@ -39,7 +39,7 @@ func fake(m map[int]origin) func(int) (origin, error) {
 func TestAnUncreditedIssueAuthorIsReported(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{42}),
-		"maintainer",
+		"maintainer", nil,
 		fake(map[int]origin{42: {number: 42, login: "reporter", isPR: false}}),
 	)
 	if len(got) != 1 {
@@ -63,7 +63,7 @@ func TestAnUncreditedIssueAuthorIsReported(t *testing.T) {
 func TestOnePersonWhoDidBothIsCreditedOnce(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{7, 8}),
-		"maintainer",
+		"maintainer", nil,
 		fake(map[int]origin{
 			7: {number: 7, login: "tobero", isPR: false},
 			8: {number: 8, login: "tobero", isPR: true},
@@ -83,7 +83,7 @@ func TestOnePersonWhoDidBothIsCreditedOnce(t *testing.T) {
 func TestAReporterAndADifferentFixerAreBothOwed(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{10, 11}),
-		"maintainer",
+		"maintainer", nil,
 		fake(map[int]origin{
 			10: {number: 10, login: "finder", isPR: false},
 			11: {number: 11, login: "fixer", isPR: true},
@@ -112,7 +112,7 @@ func TestAReporterAndADifferentFixerAreBothOwed(t *testing.T) {
 func TestAnAlreadyCreditedContributorIsSilent(t *testing.T) {
 	if got := missingCreditsWith(
 		para("a thing", []int{9}, "tobero"),
-		"maintainer",
+		"maintainer", nil,
 		fake(map[int]origin{9: {number: 9, login: "tobero", isPR: true}}),
 	); len(got) != 0 {
 		t.Fatalf("a paragraph that already credits its contributor was refused: %v", got)
@@ -128,7 +128,7 @@ func TestAnAlreadyCreditedContributorIsSilent(t *testing.T) {
 func TestTheReleaserIsNotOwedACredit(t *testing.T) {
 	if got := missingCreditsWith(
 		para("a thing", []int{1}),
-		"maintainer",
+		"maintainer", nil,
 		fake(map[int]origin{1: {number: 1, login: "maintainer", isPR: false}}),
 	); len(got) != 0 {
 		t.Fatalf("the releaser was asked to credit themselves: %v", got)
@@ -143,7 +143,7 @@ func TestTheReleaserIsNotOwedACredit(t *testing.T) {
 func TestAnUnresolvableNumberBlocks(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{99}),
-		"maintainer",
+		"maintainer", nil,
 		fake(map[int]origin{}),
 	)
 	if len(got) != 1 {
@@ -165,9 +165,44 @@ func TestAnUnresolvableNumberBlocks(t *testing.T) {
 func TestAParagraphCitingNothingOwesNothing(t *testing.T) {
 	if got := missingCreditsWith(
 		"**Changed — something.** Prose with no citations at all.",
-		"maintainer",
+		"maintainer", nil,
 		fake(map[int]origin{}),
 	); len(got) != 0 {
 		t.Fatalf("a paragraph citing nothing produced findings: %v", got)
 	}
+}
+
+// Raised in review on #213: if `gh` cannot say who is cutting the release,
+// the exclusion cannot be applied. An empty handle excludes nobody, so the
+// rule would quietly start demanding the maintainer credit themselves in
+// every entry — the rule silently not applying, which is the failure this
+// file exists to end.
+//
+// The policy was already "unknown is not a pass". It was applied to the
+// citation lookup and not to this one.
+//
+// proved by: the `meErr != nil || me == ""` guard removed — the fixture
+// then reports the maintainer as owed a credit instead of blocking.
+func TestAnUnknownReleaserBlocks(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		me   string
+		err  error
+	}{
+		{"gh failed", "", fmt.Errorf("gh: not authenticated")},
+		{"gh answered with nothing", "", nil},
+	} {
+		got := missingCreditsWith(
+			para("a thing", []int{1}),
+			tc.me, tc.err,
+			fake(map[int]origin{1: {number: 1, login: "maintainer", isPR: false}}),
+		)
+		if len(got) != 1 {
+			t.Fatalf("%s: want a blocking finding, got %v", tc.name, got)
+		}
+		if !strings.Contains(got[0], "could not be determined") {
+			t.Errorf("%s: the finding does not say why it blocks: %q", tc.name, got[0])
+		}
+	}
+	// Which is why MissingCredits refuses before calling this at all.
 }

--- a/internal/release/credits_missing_test.go
+++ b/internal/release/credits_missing_test.go
@@ -39,7 +39,7 @@ func fake(m map[int]origin) func(int) (origin, error) {
 func TestAnUncreditedIssueAuthorIsReported(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{42}),
-		func() (string, error) { return "maintainer", nil },
+		func() ([]string, error) { return []string{"maintainer"}, nil },
 		fake(map[int]origin{42: {number: 42, login: "reporter", isPR: false}}),
 	)
 	if len(got) != 1 {
@@ -63,7 +63,7 @@ func TestAnUncreditedIssueAuthorIsReported(t *testing.T) {
 func TestOnePersonWhoDidBothIsCreditedOnce(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{7, 8}),
-		func() (string, error) { return "maintainer", nil },
+		func() ([]string, error) { return []string{"maintainer"}, nil },
 		fake(map[int]origin{
 			7: {number: 7, login: "tobero", isPR: false},
 			8: {number: 8, login: "tobero", isPR: true},
@@ -83,7 +83,7 @@ func TestOnePersonWhoDidBothIsCreditedOnce(t *testing.T) {
 func TestAReporterAndADifferentFixerAreBothOwed(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{10, 11}),
-		func() (string, error) { return "maintainer", nil },
+		func() ([]string, error) { return []string{"maintainer"}, nil },
 		fake(map[int]origin{
 			10: {number: 10, login: "finder", isPR: false},
 			11: {number: 11, login: "fixer", isPR: true},
@@ -112,7 +112,7 @@ func TestAReporterAndADifferentFixerAreBothOwed(t *testing.T) {
 func TestAnAlreadyCreditedContributorIsSilent(t *testing.T) {
 	if got := missingCreditsWith(
 		para("a thing", []int{9}, "tobero"),
-		func() (string, error) { return "maintainer", nil },
+		func() ([]string, error) { return []string{"maintainer"}, nil },
 		fake(map[int]origin{9: {number: 9, login: "tobero", isPR: true}}),
 	); len(got) != 0 {
 		t.Fatalf("a paragraph that already credits its contributor was refused: %v", got)
@@ -128,7 +128,7 @@ func TestAnAlreadyCreditedContributorIsSilent(t *testing.T) {
 func TestTheReleaserIsNotOwedACredit(t *testing.T) {
 	if got := missingCreditsWith(
 		para("a thing", []int{1}),
-		func() (string, error) { return "maintainer", nil },
+		func() ([]string, error) { return []string{"maintainer"}, nil },
 		fake(map[int]origin{1: {number: 1, login: "maintainer", isPR: false}}),
 	); len(got) != 0 {
 		t.Fatalf("the releaser was asked to credit themselves: %v", got)
@@ -143,7 +143,7 @@ func TestTheReleaserIsNotOwedACredit(t *testing.T) {
 func TestAnUnresolvableNumberBlocks(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{99}),
-		func() (string, error) { return "maintainer", nil },
+		func() ([]string, error) { return []string{"maintainer"}, nil },
 		fake(map[int]origin{}),
 	)
 	if len(got) != 1 {
@@ -165,7 +165,7 @@ func TestAnUnresolvableNumberBlocks(t *testing.T) {
 func TestAParagraphCitingNothingOwesNothing(t *testing.T) {
 	if got := missingCreditsWith(
 		"**Changed — something.** Prose with no citations at all.",
-		func() (string, error) { return "maintainer", nil },
+		func() ([]string, error) { return []string{"maintainer"}, nil },
 		fake(map[int]origin{}),
 	); len(got) != 0 {
 		t.Fatalf("a paragraph citing nothing produced findings: %v", got)
@@ -181,20 +181,26 @@ func TestAParagraphCitingNothingOwesNothing(t *testing.T) {
 // The policy was already "unknown is not a pass". It was applied to the
 // citation lookup and not to this one.
 //
-// proved by: the `meErr != nil || me == ""` guard removed — the fixture
-// then reports the maintainer as owed a credit instead of blocking.
-func TestAnUnknownReleaserBlocks(t *testing.T) {
+// The 403 in the fixture is the real one: in CI the token is an app
+// installation token with no user behind it, so `gh api user` cannot
+// answer. That is why the handles are configured rather than discovered —
+// and why this test uses the error CI actually produced.
+//
+// proved by: the `meErr != nil || len(mine) == 0` guard removed — the
+// fixture then reports the maintainer as owed a credit instead of
+// blocking.
+func TestAnUnknownMaintainerSetBlocks(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		me   string
+		me   []string
 		err  error
 	}{
-		{"gh failed", "", fmt.Errorf("gh: not authenticated")},
-		{"gh answered with nothing", "", nil},
+		{"lookup failed", nil, fmt.Errorf("gh: Resource not accessible by integration (HTTP 403)")},
+		{"lookup answered with nothing", nil, nil},
 	} {
 		got := missingCreditsWith(
 			para("a thing", []int{1}),
-			func() (string, error) { return tc.me, tc.err },
+			func() ([]string, error) { return tc.me, tc.err },
 			fake(map[int]origin{1: {number: 1, login: "maintainer", isPR: false}}),
 		)
 		if len(got) != 1 {
@@ -223,10 +229,48 @@ func TestAnUnknownReleaserBlocks(t *testing.T) {
 func TestNothingCitedAsksGitHubNothing(t *testing.T) {
 	got := missingCreditsWith(
 		"# changelog\n\n## 0.2.0\n\n- a thing with no citations at all\n",
-		func() (string, error) { panic("the releaser was looked up with nothing to check") },
+		func() ([]string, error) { panic("the maintainer set was looked up with nothing to check") },
 		func(int) (origin, error) { panic("a citation was resolved when none exist") },
 	)
 	if len(got) != 0 {
 		t.Fatalf("an entry citing nothing produced findings: %v", got)
+	}
+}
+
+// Several maintainers, because a project can have more than one and the
+// rule must not credit any of them in their own notes.
+//
+// proved by: `isMine` built from only the first handle — the second
+// maintainer is reported as owed a credit.
+func TestEveryConfiguredMaintainerIsExcluded(t *testing.T) {
+	got := missingCreditsWith(
+		para("a thing", []int{1, 2}),
+		func() ([]string, error) { return []string{"alice", "bob"}, nil },
+		fake(map[int]origin{
+			1: {number: 1, login: "alice", isPR: false},
+			2: {number: 2, login: "bob", isPR: true},
+		}),
+	)
+	if len(got) != 0 {
+		t.Fatalf("a configured maintainer was asked to credit themselves: %v", got)
+	}
+}
+
+// And an outside contributor is still owed, or the exclusion has swallowed
+// the rule.
+//
+// proved by: `isMine` made to return true for everything — nobody is ever
+// owed and the check does nothing.
+func TestAContributorIsStillOwedAlongsideMaintainers(t *testing.T) {
+	got := missingCreditsWith(
+		para("a thing", []int{1, 2}),
+		func() ([]string, error) { return []string{"alice"}, nil },
+		fake(map[int]origin{
+			1: {number: 1, login: "alice", isPR: false},
+			2: {number: 2, login: "outsider", isPR: true},
+		}),
+	)
+	if len(got) != 1 || !strings.Contains(got[0], "@outsider") {
+		t.Fatalf("the outside contributor was not reported as owed: %v", got)
 	}
 }

--- a/internal/release/credits_missing_test.go
+++ b/internal/release/credits_missing_test.go
@@ -1,0 +1,173 @@
+package release
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// para builds a changelog paragraph citing the given numbers, optionally
+// crediting handles.
+func para(text string, cites []int, credits ...string) string {
+	var b strings.Builder
+	b.WriteString("**Fixed — " + text + ".**\n")
+	for _, n := range cites {
+		fmt.Fprintf(&b, "([#%d](https://github.com/azrtydxb/procoder/pull/%d)) ", n, n)
+	}
+	b.WriteString("Prose about it.")
+	for _, c := range credits {
+		fmt.Fprintf(&b, " Reported by [@%s](https://github.com/%s).", c, c)
+	}
+	return b.String()
+}
+
+func fake(m map[int]origin) func(int) (origin, error) {
+	return func(n int) (origin, error) {
+		o, ok := m[n]
+		if !ok {
+			return origin{}, fmt.Errorf("no such number")
+		}
+		return o, nil
+	}
+}
+
+// The maintainer's rule, case 1: a cited issue owes its author a credit,
+// and the report names the handle to add rather than saying "wrong".
+//
+// proved by: the `credited[...]` skip inverted — the owed credit is
+// reported as satisfied and the gap disappears.
+func TestAnUncreditedIssueAuthorIsReported(t *testing.T) {
+	got := missingCreditsWith(
+		para("a thing", []int{42}),
+		"maintainer",
+		fake(map[int]origin{42: {number: 42, login: "reporter", isPR: false}}),
+	)
+	if len(got) != 1 {
+		t.Fatalf("want the uncredited reporter named, got %v", got)
+	}
+	if !strings.Contains(got[0], "@reporter") || !strings.Contains(got[0], "reported #42") {
+		t.Errorf("the report does not name who and for what: %q", got[0])
+	}
+	// It must hand over the text, not just the complaint.
+	if !strings.Contains(got[0], "https://github.com/reporter") {
+		t.Errorf("the report does not give the line to add: %q", got[0])
+	}
+}
+
+// Case 2: the same person opened the issue and the pull request. That is
+// ONE credit, not two — a rule that demanded both would produce changelog
+// entries thanking somebody twice in one paragraph.
+//
+// proved by: the `seen[...]` collapse removed — the same handle is
+// reported twice.
+func TestOnePersonWhoDidBothIsCreditedOnce(t *testing.T) {
+	got := missingCreditsWith(
+		para("a thing", []int{7, 8}),
+		"maintainer",
+		fake(map[int]origin{
+			7: {number: 7, login: "tobero", isPR: false},
+			8: {number: 8, login: "tobero", isPR: true},
+		}),
+	)
+	if len(got) != 1 {
+		t.Fatalf("want exactly one credit owed, got %d: %v", len(got), got)
+	}
+}
+
+// Case 3, the one that erases people: the reporter and the fixer are
+// different. Both are owed. Crediting only the pull request quietly drops
+// whoever found the problem.
+//
+// proved by: the loop over `owed` made to stop after the first — the
+// second contributor vanishes and the test names them.
+func TestAReporterAndADifferentFixerAreBothOwed(t *testing.T) {
+	got := missingCreditsWith(
+		para("a thing", []int{10, 11}),
+		"maintainer",
+		fake(map[int]origin{
+			10: {number: 10, login: "finder", isPR: false},
+			11: {number: 11, login: "fixer", isPR: true},
+		}),
+	)
+	if len(got) != 2 {
+		t.Fatalf("want both owed, got %d: %v", len(got), got)
+	}
+	joined := strings.Join(got, "\n")
+	for _, who := range []string{"@finder", "@fixer"} {
+		if !strings.Contains(joined, who) {
+			t.Errorf("%s is owed a credit and was not named:\n%s", who, joined)
+		}
+	}
+	// And each is described by what they actually did.
+	if !strings.Contains(joined, "reported #10") || !strings.Contains(joined, "contributed #11") {
+		t.Errorf("the report does not distinguish reporting from contributing:\n%s", joined)
+	}
+}
+
+// A credit already present is not reported again, or the rule is
+// unsatisfiable and gets switched off.
+//
+// proved by: the `credited` lookup dropped — a correct paragraph is
+// refused.
+func TestAnAlreadyCreditedContributorIsSilent(t *testing.T) {
+	if got := missingCreditsWith(
+		para("a thing", []int{9}, "tobero"),
+		"maintainer",
+		fake(map[int]origin{9: {number: 9, login: "tobero", isPR: true}}),
+	); len(got) != 0 {
+		t.Fatalf("a paragraph that already credits its contributor was refused: %v", got)
+	}
+}
+
+// Whoever is cutting the release is excluded. Thanking yourself in your
+// own release notes is noise, and a rule that demanded it would be ignored
+// within one release — which is how a check stops being read at all.
+//
+// proved by: the `strings.EqualFold(o.login, me)` skip removed — the
+// maintainer is owed a credit in every entry they write.
+func TestTheReleaserIsNotOwedACredit(t *testing.T) {
+	if got := missingCreditsWith(
+		para("a thing", []int{1}),
+		"maintainer",
+		fake(map[int]origin{1: {number: 1, login: "maintainer", isPR: false}}),
+	); len(got) != 0 {
+		t.Fatalf("the releaser was asked to credit themselves: %v", got)
+	}
+}
+
+// GitHub not answering is not a pass. Who to credit is then unknown, and
+// unknown must block like every other check here that could not run.
+//
+// proved by: the resolve-error branch made to `continue` — an
+// unreachable API reads as "nobody is owed anything".
+func TestAnUnresolvableNumberBlocks(t *testing.T) {
+	got := missingCreditsWith(
+		para("a thing", []int{99}),
+		"maintainer",
+		fake(map[int]origin{}),
+	)
+	if len(got) != 1 {
+		t.Fatalf("an unresolvable citation must block, got %v", got)
+	}
+	if !strings.Contains(got[0], "not a pass") {
+		t.Errorf("the report does not say why it blocks: %q", got[0])
+	}
+}
+
+// A paragraph citing nothing owes nothing — the rule is about crediting
+// people for the things a paragraph names.
+//
+// The `len(nums) == 0` skip is an early return, not the protection — with
+// no numbers the loop below has nothing to resolve and owes nothing
+// anyway. Verified: removing it does not fail this test. What this pins is
+// the behaviour, so a future version that starts scanning prose for
+// handles fails here.
+func TestAParagraphCitingNothingOwesNothing(t *testing.T) {
+	if got := missingCreditsWith(
+		"**Changed — something.** Prose with no citations at all.",
+		"maintainer",
+		fake(map[int]origin{}),
+	); len(got) != 0 {
+		t.Fatalf("a paragraph citing nothing produced findings: %v", got)
+	}
+}

--- a/internal/release/credits_missing_test.go
+++ b/internal/release/credits_missing_test.go
@@ -39,7 +39,7 @@ func fake(m map[int]origin) func(int) (origin, error) {
 func TestAnUncreditedIssueAuthorIsReported(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{42}),
-		"maintainer", nil,
+		func() (string, error) { return "maintainer", nil },
 		fake(map[int]origin{42: {number: 42, login: "reporter", isPR: false}}),
 	)
 	if len(got) != 1 {
@@ -63,7 +63,7 @@ func TestAnUncreditedIssueAuthorIsReported(t *testing.T) {
 func TestOnePersonWhoDidBothIsCreditedOnce(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{7, 8}),
-		"maintainer", nil,
+		func() (string, error) { return "maintainer", nil },
 		fake(map[int]origin{
 			7: {number: 7, login: "tobero", isPR: false},
 			8: {number: 8, login: "tobero", isPR: true},
@@ -83,7 +83,7 @@ func TestOnePersonWhoDidBothIsCreditedOnce(t *testing.T) {
 func TestAReporterAndADifferentFixerAreBothOwed(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{10, 11}),
-		"maintainer", nil,
+		func() (string, error) { return "maintainer", nil },
 		fake(map[int]origin{
 			10: {number: 10, login: "finder", isPR: false},
 			11: {number: 11, login: "fixer", isPR: true},
@@ -112,7 +112,7 @@ func TestAReporterAndADifferentFixerAreBothOwed(t *testing.T) {
 func TestAnAlreadyCreditedContributorIsSilent(t *testing.T) {
 	if got := missingCreditsWith(
 		para("a thing", []int{9}, "tobero"),
-		"maintainer", nil,
+		func() (string, error) { return "maintainer", nil },
 		fake(map[int]origin{9: {number: 9, login: "tobero", isPR: true}}),
 	); len(got) != 0 {
 		t.Fatalf("a paragraph that already credits its contributor was refused: %v", got)
@@ -128,7 +128,7 @@ func TestAnAlreadyCreditedContributorIsSilent(t *testing.T) {
 func TestTheReleaserIsNotOwedACredit(t *testing.T) {
 	if got := missingCreditsWith(
 		para("a thing", []int{1}),
-		"maintainer", nil,
+		func() (string, error) { return "maintainer", nil },
 		fake(map[int]origin{1: {number: 1, login: "maintainer", isPR: false}}),
 	); len(got) != 0 {
 		t.Fatalf("the releaser was asked to credit themselves: %v", got)
@@ -143,7 +143,7 @@ func TestTheReleaserIsNotOwedACredit(t *testing.T) {
 func TestAnUnresolvableNumberBlocks(t *testing.T) {
 	got := missingCreditsWith(
 		para("a thing", []int{99}),
-		"maintainer", nil,
+		func() (string, error) { return "maintainer", nil },
 		fake(map[int]origin{}),
 	)
 	if len(got) != 1 {
@@ -165,7 +165,7 @@ func TestAnUnresolvableNumberBlocks(t *testing.T) {
 func TestAParagraphCitingNothingOwesNothing(t *testing.T) {
 	if got := missingCreditsWith(
 		"**Changed — something.** Prose with no citations at all.",
-		"maintainer", nil,
+		func() (string, error) { return "maintainer", nil },
 		fake(map[int]origin{}),
 	); len(got) != 0 {
 		t.Fatalf("a paragraph citing nothing produced findings: %v", got)
@@ -194,7 +194,7 @@ func TestAnUnknownReleaserBlocks(t *testing.T) {
 	} {
 		got := missingCreditsWith(
 			para("a thing", []int{1}),
-			tc.me, tc.err,
+			func() (string, error) { return tc.me, tc.err },
 			fake(map[int]origin{1: {number: 1, login: "maintainer", isPR: false}}),
 		)
 		if len(got) != 1 {
@@ -205,4 +205,28 @@ func TestAnUnknownReleaserBlocks(t *testing.T) {
 		}
 	}
 	// Which is why MissingCredits refuses before calling this at all.
+}
+
+// Nothing cited anywhere means nothing is owed, and asking GitHub who is
+// releasing would be a network call to answer a question nobody asked.
+//
+// This is not a nicety. Without it, every offline release test failed on a
+// guard that was working exactly as designed — the releaser lookup ran
+// before anything had established there was a credit to check, and CI has
+// no `gh` auth. Found by CI, not by me.
+//
+// The releaser lookup here panics if called, so the test asserts the call
+// does not happen rather than merely that the result looks right.
+//
+// proved by: the `!citedNumber.MatchString(entry)` early return removed —
+// the lookup runs and the panic fires.
+func TestNothingCitedAsksGitHubNothing(t *testing.T) {
+	got := missingCreditsWith(
+		"# changelog\n\n## 0.2.0\n\n- a thing with no citations at all\n",
+		func() (string, error) { panic("the releaser was looked up with nothing to check") },
+		func(int) (origin, error) { panic("a citation was resolved when none exist") },
+	)
+	if len(got) != 0 {
+		t.Fatalf("an entry citing nothing produced findings: %v", got)
+	}
 }

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -112,6 +112,13 @@ func Run(root, version string, gateClean func() bool, suite func() (bool, string
 	for _, p := range VerifyCredits(root, EntryFor(root, version)) {
 		failures = append(failures, p)
 	}
+	// And the other half: who is OWED a credit and does not have one.
+	// VerifyCredits catches a wrong handle, which is the loud failure —
+	// the person it was taken from says nothing, and neither did anything
+	// else until this. See MissingCredits for the rule.
+	for _, p := range MissingCredits(root, EntryFor(root, version)) {
+		failures = append(failures, p)
+	}
 
 	if len(failures) > 0 {
 		out(fmt.Sprintf("release %s is NOT ready:", version))

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -109,14 +109,17 @@ func Run(root, version string, gateClean func() bool, suite func() (bool, string
 	// because the tag it is preparing gets published by a job that talks
 	// to the same API. A misattributed credit hands one person's thanks
 	// to another, permanently, in notes GitHub publishes verbatim.
-	for _, p := range VerifyCredits(root, EntryFor(root, version)) {
+	// One read of the changelog entry for both credit checks. Raised in
+	// review on #213.
+	entry := EntryFor(root, version)
+	for _, p := range VerifyCredits(root, entry) {
 		failures = append(failures, p)
 	}
 	// And the other half: who is OWED a credit and does not have one.
 	// VerifyCredits catches a wrong handle, which is the loud failure —
 	// the person it was taken from says nothing, and neither did anything
 	// else until this. See MissingCredits for the rule.
-	for _, p := range MissingCredits(root, EntryFor(root, version)) {
+	for _, p := range MissingCredits(root, entry) {
 		failures = append(failures, p)
 	}
 


### PR DESCRIPTION
## Why this exists

The release controller already checked that a credited handle had opened something its paragraph cites. That is the loud half — a wrong credit is visible, and it did catch one while v3.2.0 was being assembled.

The quiet half was nobody's job: whether somebody who *should* be credited is missing. The person a credit is taken from does not complain, and nothing else was going to notice. So the same mistake arrived each release, and the only guard was the author remembering to check by hand — which is precisely what had failed.

## The rule

The maintainer's, and entirely mechanical:

| Cited | Owed |
| --- | --- |
| an issue | its author |
| a pull request | its author |
| both, same person | **one** credit, not two |
| both, different people | **both** — crediting only the PR erases whoever found the problem |

Whoever is cutting the release is excluded. Thanking yourself in your own release notes is noise, and a rule demanding it would be ignored inside one release — which is how a check stops being read at all.

## What makes it hold

**It hands over the text.** Not "this credit is wrong" but:

```
@ToberoCat reported #177 and is not credited in the paragraph citing it —
add `reported by [@ToberoCat](https://github.com/ToberoCat)`
```

A check that reports a fault and leaves you to work out the answer is one you satisfy by deleting the credit.

**Unresolvable blocks.** If GitHub will not answer, who is owed is unknown, and unknown has never been a pass here.

## Verification

Seven tests, offline — the two GitHub questions are injected, so the suite stays network-free like the rest of it. Six mutations applied and watched to fail, including the two that matter most: collapsing one person's issue and PR into a single credit, and reporting *both* when the reporter and fixer differ.

Verified live too: given a paragraph citing #177 and #178 and crediting nobody, it names @ToberoCat once — correctly collapsing them, since they opened both.

One `proved by:` corrected rather than left standing: the empty-citation skip is an early return, not the protection, and removing it fails nothing.
