### PR TITLE
release: 3.2.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer. All nine domains shipped: security, best practices, maintainability, performance, documentation, clean code, CI/CD, DevOps, GitOps \u2014 plus the code index. Hooks hand the agent results; the agent stays in control.",
   "author": {
     "name": "Pascal Watteel"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "procoder",
   "metadata": {
     "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
-    "version": "3.2.0"
+    "version": "3.2.1"
   },
   "plugins": [
     {

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,53 @@ Rules that earn their place:
   handle opened none of what its paragraph cites.
 -->
 
+## 3.2.1 — 2026-08-26
+
+_The release controller works out who is owed a credit, and CI enforces it,
+so getting attribution wrong stops depending on whoever remembers to look._
+
+**Fixed — a contributor who should be credited and is not now blocks the
+release.** ([#213](https://github.com/azrtydxb/procoder/pull/213))
+`procoder release` already checked that a credited handle had opened
+something its paragraph cites. That is the loud half — a wrong credit is
+visible, and it caught one while 3.2.0 was being assembled. The quiet half
+was nobody's job: whether somebody who _should_ be credited is missing. The
+person a credit is taken from does not complain, and nothing else was going
+to notice.
+
+The rule is mechanical. A cited issue owes its author a credit. A cited
+pull request owes its author a credit. One person who did both is owed one
+credit, not two. A reporter and a different fixer are both owed, because
+crediting only the pull request quietly erases whoever found the problem.
+The finding hands over the line to paste rather than reporting a fault: a
+check that says "this is wrong" and leaves you to work out the right answer
+is one you satisfy by deleting the credit.
+
+Whose release notes these are comes from `[release] maintainers` in
+`.procoder/config.toml`, not from whoever is running the command. That is
+not a preference. `gh api user` answers only where a person is logged in —
+in CI the token is an app installation token with no user behind it and
+returns 403, which made the check unrunnable in the one place it most
+needed to run.
+
+**Added — CI enforces the credit rule.**
+([#213](https://github.com/azrtydxb/procoder/pull/213)) `procoder release
+--credits` runs the two contributor checks and nothing else, and the gate
+job runs it on every commit. Until now the rule ran only when somebody
+typed `procoder release` on their own machine, which means it ran when they
+remembered — and "remember to check" is exactly what the rule was written
+to replace.
+
+**Fixed — an unrecognised configuration key says which of the two causes it
+is.** ([#213](https://github.com/azrtydxb/procoder/pull/213)) An unknown
+key still blocks; a setting that does nothing while its writer believes it
+is in force is the failure that check exists to prevent. But the finding
+named one cause and the reader usually had the other. A typo is yours to
+fix. A key added in a later release is not — you spelled it correctly, your
+build is older, and no edit to the file will help. The finding now names
+the running build and both routes, because an instruction nobody can follow
+is how `--no-verify` becomes muscle memory.
+
 ## 3.2.0 — 2026-08-26
 
 _procoder stops applying its own conventions to repositories that never

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ turns every escaped bug into a permanently closed class. The agent stays
 in control — nothing ever touches your code behind its back.
 
 ![CI](https://github.com/azrtydxb/procoder/actions/workflows/ci.yml/badge.svg)
-![Version](https://img.shields.io/badge/version-3.2.0-7C3AED)
+![Version](https://img.shields.io/badge/version-3.2.1-7C3AED)
 ![License](https://img.shields.io/badge/license-Apache--2.0-7C3AED)
 ![Agents](https://img.shields.io/badge/works%20with-20%2B%20agents-7C3AED)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ bug's whole class, and one contract that works across every AI coding
 agent. The agent stays in control; nothing ever touches your code behind
 its back.
 
-Current version: **3.2.0**
+Current version: **3.2.1**
 
 ```mermaid
 flowchart LR

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "license": "Apache-2.0",
   "repository": {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: procoder
-version: 3.2.0
+version: 3.2.1
 description: A harness that gives AI coders the tools and skills to work like a senior developer
 entry: __init__.py
 provides_hooks:


### PR DESCRIPTION
## 3.2.1

Getting attribution wrong stops depending on whoever remembers to look.

| | |
| --- | --- |
| **Credits are computed** | the rule works out who is *owed* a credit, not only whether a credited handle is real |
| **CI enforces it** | `procoder release --credits` runs on every commit with a token |
| **Config keys explain themselves** | an unrecognised key names both causes it could have, and the route out of each |

## The rule

A cited issue owes its author. A cited pull request owes its author. One person who did both is owed **one** credit. A reporter and a different fixer are **both** owed — crediting only the PR quietly erases whoever found the problem.

Whose notes these are comes from `[release] maintainers`, not from whoever runs the command. That is not a preference: `gh api user` returns 403 under an app installation token, so the question only has an answer on a laptop. Falling back to `github.actor` would be worse — on a contributor's PR that is the contributor, who would then be excluded from the credit they are owed.

## Reviewing this

The release commit is version bumps and the changelog; everything else landed through #213.

Verified before opening: `procoder release --credits` passes against the 3.2.1 notes — the check running on the entry that describes it.

## After merge

The `v3.2.1` tag triggers the release job, which builds all five platform binaries from the tagged source and publishes them with checksums it generates (ADR 0004).
