### PR TITLE
feat: a turn does not end with a decision buried in prose

### DIFF
--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,20 +1,13 @@
 # What a human decided
 
-Written 2026-08-26 08:50 UTC. procoder reads this
+Written 2026-08-26 13:00 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 0489b93052fa
 Question: Is v3.1.1 tagged once the PRs are merged?
-
-Standing instruction from the maintainer on 2026-08-26: no.
-
-- merge only: land #184 and #187 on main and stop there. The tag is the
-  maintainer's call and waits for them to say so.
-- tag when merged: NOT what was asked. Recorded so a later session cannot
-  read "merge both, then cut v3.1.1" from earlier in the day and act on it.
 
 Answer: merge only — do NOT tag. The maintainer will say when.
 
@@ -25,18 +18,10 @@ Question: Which of #177 and #181 is next, given #172 and #175 are both in review
 
 Answer: #181 (procoder prune) — already specified with guardrails agreed, start immediately
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 3e59374380b3
 Question: Scope of v3.1.1: does it wait for #186 and #188?
-
-Answered by the maintainer on 2026-08-26: yes, all of them, and the tag is
-theirs to make.
-
-- everything first: #186 (specs validated for truth) and #188 (the
-  kubeconform network flake) are fixed before the release is tagged.
-- defer the two: NOT what was asked. Recorded so a later session does not
-  read the earlier recommendation and act on it.
 
 Answer: yes — do #186 and #188 too. The maintainer tags, not me.
 
@@ -47,63 +32,77 @@ Question: Does the decisions queue and its principles change ship in v3.1.1, or 
 
 Answer: in v3.1.1 — ADR 0003 governs major, and 2.0.1 already shipped new enforcement in a patch
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 6617364d8670
 Question: Which of #177 and #181 is next, given #172 and #175 are both in review?
 
-- #181 (`procoder prune`): already specified in the issue with guardrails
-  agreed, so it can start immediately.
-- #177: not yet read this session. Reading it first may change the answer.
-
 Answer: #181 (procoder prune) — already specified with guardrails agreed, start immediately
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: a3f73c3bc2de
 Question: Does the decisions queue and its principles change ship in v3.1.1, or wait?
-
-Context: v3.1.1 was scoped to #172, #175, #177 and #181. This work is none
-of them — it came out of a correction during the sprint.
-
-- in v3.1.1: it is small, tested, and the principles half is worth having
-  in agents' hands sooner rather than later. ADR 0003 governs what makes a
-  change major, and 2.0.1 already shipped new enforcement in a patch.
-- hold for v3.2.0: keeps v3.1.1 exactly the four issues that were scoped,
-  which is easier to describe in a changelog and to review.
 
 Answer: in v3.1.1 — ADR 0003 governs major, and 2.0.1 already shipped new enforcement in a patch
 
 ## [decision] decisions.md
 
+Key: aa8ea1f17c0c
+Question: Do the four large features stay open as a roadmap?
+
+#189 SKILL.md redesign, #190 `procoder learn`, #192 `procoder wizard`, #194
+docs hardening. Each is a release of its own; two add new commands.
+
+- keep open: a roadmap that says what procoder might become.
+- close until wanted: an open issue nobody is going to start reads as a
+  commitment, and twenty-three of them read as a plan.
+
+Answer: keep open, but label them roadmap/large so they stop reading as queued work
+
+## [decision] decisions.md
+
+Key: b55269facb93
+Question: Rescope #198 and #191, and merge #200 with #201 and #204 with #208?
+
+Today's release overtook two of them, and two pairs are the same idea filed
+twice. Left alone, somebody rebuilds what already exists.
+
+- rescope and merge now: #198 loses its unfalsifiable-criteria half (shipped
+  as `CriteriaWithoutFalsifiers`) and keeps fixed-output, hedgy vocabulary
+  and unmeasured thresholds; #191 keeps board visibility and shared
+  blockers and drops "there is no decisions file", because there is one now.
+- leave them: the overlap is discoverable by whoever picks one up, at the
+  cost of them finding out after starting.
+
+Answer: yes — rescope and merge now, before anyone starts on a duplicate
+
+## (no longer asked)
+
 Key: bdef8e3588e5
 Question: Does `procoder prune` delete, or print what it would delete?
-
-P-CONTROL says the binary prints and never modifies files. That rule is
-about repository content, and the plugin cache is not that — but a command
-that removes 1.1 GB irreversibly is the largest exception the tool would
-have, and it is worth being deliberate rather than assuming the rule does
-not reach here.
-
-- deletes, behind an explicit flag: `procoder prune` reports what it would
-  remove and exits; `procoder prune --apply` does it. One command, the
-  reclaim actually happens, and the default is still a report.
-- prints only, strictly: procoder emits the exact `rm -rf` lines and the
-  human or agent runs them. P-CONTROL holds without exception, nothing is
-  ever deleted by procoder, and the user sees precisely what will go.
-- deletes by default with `--dry-run` to preview: shortest path to the
-  reclaim, and the one most likely to surprise somebody.
 
 Answer: report by default, delete on --apply — the safe thing stays the default and the reclaim still happens in one command
 
 ## [decision] decisions.md
 
+Key: c9c26deda0a7
+Question: Which is the next piece of work?
+
+- #193, merge-conflict discipline: the failure happened here today — git
+  split a conflict through a function, "keep both sides" truncated a test,
+  and only the compiler caught it. Concrete evidence, and the fix is prose.
+- #201 + #200, the execute path: verified, not assumed —
+  `internal/runcmd/runcmd.go:172` execs argv the repository declares, so an
+  agent writing a launch command under injection is a live path. The only
+  security-shaped items in the set.
+- #195, the context.md glossary: small, self-contained, pays offevery session.
+
+Answer: #193, merge-conflict discipline
+
+## (no longer asked)
+
 Key: f4733ae6d75a
 Question: How many cached plugin versions does `procoder prune` keep?
-
-- 3 (active + 2 previous): reclaims 1.01 GB here, two rollback targets.
-- 2 (active + 1 previous): reclaims 1.05 GB, one rollback target — the
-  minimum that still counts as a rollback.
-- 5 (active + 4 previous): reclaims 0.92 GB, a longer rollback window.
 
 Answer: 2 — active + 1 previous

--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -96,7 +96,7 @@ Question: Which is the next piece of work?
   `internal/runcmd/runcmd.go:172` execs argv the repository declares, so an
   agent writing a launch command under injection is a live path. The only
   security-shaped items in the set.
-- #195, the context.md glossary: small, self-contained, pays offevery session.
+- #195, the context.md glossary: small, self-contained, pays off every session.
 
 Answer: #193, merge-conflict discipline
 

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -24,7 +24,7 @@ twice. Left alone, somebody rebuilds what already exists.
   `internal/runcmd/runcmd.go:172` execs argv the repository declares, so an
   agent writing a launch command under injection is a live path. The only
   security-shaped items in the set.
-- #195, the context.md glossary: small, self-contained, pays offevery session.
+- #195, the context.md glossary: small, self-contained, pays off every session.
 
 ## Do the four large features stay open as a roadmap?
 

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -3,68 +3,34 @@
 Written by the agent, read by `procoder ask`. One `## ` heading per
 decision; the lines under it are its options.
 
-## Does the decisions queue and its principles change ship in v3.1.1, or wait?
+## Rescope #198 and #191, and merge #200 with #201 and #204 with #208?
 
-Context: v3.1.1 was scoped to #172, #175, #177 and #181. This work is none
-of them — it came out of a correction during the sprint.
+Today's release overtook two of them, and two pairs are the same idea filed
+twice. Left alone, somebody rebuilds what already exists.
 
-- in v3.1.1: it is small, tested, and the principles half is worth having
-  in agents' hands sooner rather than later. ADR 0003 governs what makes a
-  change major, and 2.0.1 already shipped new enforcement in a patch.
-- hold for v3.2.0: keeps v3.1.1 exactly the four issues that were scoped,
-  which is easier to describe in a changelog and to review.
+- rescope and merge now: #198 loses its unfalsifiable-criteria half (shipped
+  as `CriteriaWithoutFalsifiers`) and keeps fixed-output, hedgy vocabulary
+  and unmeasured thresholds; #191 keeps board visibility and shared
+  blockers and drops "there is no decisions file", because there is one now.
+- leave them: the overlap is discoverable by whoever picks one up, at the
+  cost of them finding out after starting.
 
-## Which of #177 and #181 is next, given #172 and #175 are both in review?
+## Which is the next piece of work?
 
-- #181 (`procoder prune`): already specified in the issue with guardrails
-  agreed, so it can start immediately.
-- #177: not yet read this session. Reading it first may change the answer.
+- #193, merge-conflict discipline: the failure happened here today — git
+  split a conflict through a function, "keep both sides" truncated a test,
+  and only the compiler caught it. Concrete evidence, and the fix is prose.
+- #201 + #200, the execute path: verified, not assumed —
+  `internal/runcmd/runcmd.go:172` execs argv the repository declares, so an
+  agent writing a launch command under injection is a live path. The only
+  security-shaped items in the set.
+- #195, the context.md glossary: small, self-contained, pays offevery session.
 
-## Does `procoder prune` delete, or print what it would delete?
+## Do the four large features stay open as a roadmap?
 
-P-CONTROL says the binary prints and never modifies files. That rule is
-about repository content, and the plugin cache is not that — but a command
-that removes 1.1 GB irreversibly is the largest exception the tool would
-have, and it is worth being deliberate rather than assuming the rule does
-not reach here.
+#189 SKILL.md redesign, #190 `procoder learn`, #192 `procoder wizard`, #194
+docs hardening. Each is a release of its own; two add new commands.
 
-- deletes, behind an explicit flag: `procoder prune` reports what it would
-  remove and exits; `procoder prune --apply` does it. One command, the
-  reclaim actually happens, and the default is still a report.
-- prints only, strictly: procoder emits the exact `rm -rf` lines and the
-  human or agent runs them. P-CONTROL holds without exception, nothing is
-  ever deleted by procoder, and the user sees precisely what will go.
-- deletes by default with `--dry-run` to preview: shortest path to the
-  reclaim, and the one most likely to surprise somebody.
-
-## How many cached plugin versions does `procoder prune` keep?
-
-- 3 (active + 2 previous): reclaims 1.01 GB here, two rollback targets.
-- 2 (active + 1 previous): reclaims 1.05 GB, one rollback target — the
-  minimum that still counts as a rollback.
-- 5 (active + 4 previous): reclaims 0.92 GB, a longer rollback window.
-
-## How is v3.1.1 landed, and does procoder prune --apply run on this machine?
-
-- Landing: merge #184 (#175) and #187 (#172, #181, decisions queue) once CI
-  is green, then tag v3.1.1. #177 already landed via PR #178.
-- The sweep: whether to reclaim the 1.03 GB here, which is irreversible.
-
-## Is v3.1.1 tagged once the PRs are merged?
-
-Standing instruction from the maintainer on 2026-08-26: no.
-
-- merge only: land #184 and #187 on main and stop there. The tag is the
-  maintainer's call and waits for them to say so.
-- tag when merged: NOT what was asked. Recorded so a later session cannot
-  read "merge both, then cut v3.1.1" from earlier in the day and act on it.
-
-## Scope of v3.1.1: does it wait for #186 and #188?
-
-Answered by the maintainer on 2026-08-26: yes, all of them, and the tag is
-theirs to make.
-
-- everything first: #186 (specs validated for truth) and #188 (the
-  kubeconform network flake) are fixed before the release is tagged.
-- defer the two: NOT what was asked. Recorded so a later session does not
-  read the earlier recommendation and act on it.
+- keep open: a roadmap that says what procoder might become.
+- close until wanted: an open issue nobody is going to start reads as a
+  commitment, and twenty-three of them read as a plan.

--- a/.procoder/backlog/epics/an-unasked-decision-does-not-end-the-turn.md
+++ b/.procoder/backlog/epics/an-unasked-decision-does-not-end-the-turn.md
@@ -1,0 +1,12 @@
+# an-unasked-decision-does-not-end-the-turn
+
+Status: done 2026-08-26
+Created: 2026-08-26
+Spec: an-unasked-decision-does-not-end-the-turn @ 6de0bf3d41d5
+
+## Description
+
+<!-- What this epic delivers and why it is one coherent unit of value.
+     Stories reference this epic by its file name. -->
+
+Seeded from .procoder/specs/an-unasked-decision-does-not-end-the-turn.md — one story per acceptance criterion.

--- a/.procoder/backlog/sprints/025-an-unasked-decision-does-not-end-the-turn.md
+++ b/.procoder/backlog/sprints/025-an-unasked-decision-does-not-end-the-turn.md
@@ -1,0 +1,45 @@
+# An unasked decision does not end the turn
+
+Status: done
+Created: 2026-08-26
+
+## Goal
+
+Make the rule bind instead of depending on the agent remembering it.
+
+3.2.0 shipped the rule that a decision is not the agent's to make: record
+it, ask with the host's question tool, do not bury it at the end of a
+report. Hours later the agent that wrote the rule ended a triage report
+with three decisions in prose and carried on. The rule was in the tool and
+not in the agent.
+
+That is every failure this project has already fixed, once more: a rule
+that depends on remembering fails on the day somebody is busy. The credit
+check, the falsifier rule and the release controller each won the same
+argument.
+
+The Stop hook is where it can be caught, because the end of the turn is
+when a decision gets buried.
+
+## The design constraint that shaped everything
+
+A false block fires on ordinary work, at the end of EVERY turn. That is
+the #172 and #185 failure at maximum frequency, and it would discredit
+every other check procoder makes. So the detector errs toward silence: an
+explicit ask rather than a question mark, an interrogative phrase only
+when it carries a question mark in the same sentence, never twice on one
+message, and silence on every uncertain path.
+
+It caught one false positive during development, from a real message in
+the session that built it: "I asked whether you want me to keep it, and
+you said yes" — narration about a decision already taken, in the same
+words as an ask.
+
+## Verified rather than assumed
+
+The first design read the transcript. The host documents the transcript as
+written asynchronously and lagging the current turn, and supplies
+`last_assistant_message` on Stop for exactly this. Blocking is exit 2 with
+stderr, not a JSON decision field. Both were checked against the
+documentation before anything was built, and both would have been
+plausible and wrong.

--- a/.procoder/backlog/stories/20260826-a-payload-with-no-last-assistant-message-exits-0-per.md
+++ b/.procoder/backlog/stories/20260826-a-payload-with-no-last-assistant-message-exits-0-per.md
@@ -1,0 +1,21 @@
+# A payload with no `last_assistant_message` exits 0, per `TestNoMessageIsNotEvidence`; fails if an absent field is treated as an empty ask.
+
+Status: done
+Created: 2026-08-26
+Epic: an-unasked-decision-does-not-end-the-turn
+Sprint: 025-an-unasked-decision-does-not-end-the-turn
+
+## Description
+
+An older host, another host, or a malformed event. An absent field is not evidence that a decision was buried.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [x] A payload with no `last_assistant_message` exits 0, per `TestNoMessageIsNotEvidence`; fails if an absent field is treated as an empty ask.
+
+## Evidence
+
+`TestNoMessageIsNotEvidence`. Recorded honestly: the empty-message guard is an early return, not the protection — an empty string matches no ask phrase anyway, and removing it fails nothing. The test pins the behaviour so a future detector that treats absence as something fails here.

--- a/.procoder/backlog/stories/20260826-a-stop-payload-whose-last-assistant-message-ends-with-do.md
+++ b/.procoder/backlog/stories/20260826-a-stop-payload-whose-last-assistant-message-ends-with-do.md
@@ -1,0 +1,23 @@
+# A Stop payload whose `last_assistant_message` ends with "Do you want me to X or Y?" and a repository with no unanswered recorded decision exits 2 and names the fix on stderr, per `TestAProseDecisionDoesNotEndTheTurn`; fails if the detector is made to return false.
+
+Status: done
+Created: 2026-08-26
+Epic: an-unasked-decision-does-not-end-the-turn
+Sprint: 025-an-unasked-decision-does-not-end-the-turn
+
+## Description
+
+The failure this exists for. A decision put to the user in the last paragraph of a report, with the work continuing underneath it — which is what the agent that wrote the rule did, hours after shipping it.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [x] A Stop payload whose `last_assistant_message` ends with "Do you want me to X or Y?" and a repository with no unanswered recorded decision exits 2 and names the fix on stderr, per `TestAProseDecisionDoesNotEndTheTurn`; fails if the detector is made to return false.
+
+## Evidence
+
+`hook.unaskedDecision` and `hook.decisionInProse` in `internal/hook/unasked.go`, wired into `Stop`. Proved by `TestAProseDecisionDoesNotEndTheTurn`, which also requires the reason to be actionable — it must name `decisions.md`, the structured question tool, and the fact that it will not fire twice. A block nobody can satisfy is the thing this is meant to prevent, not cause.
+
+Verified against the real binary with a real payload shape: exit 2, reason on stderr.

--- a/.procoder/backlog/stories/20260826-ordinary-reports-a-status-summary-a-report-containing-a.md
+++ b/.procoder/backlog/stories/20260826-ordinary-reports-a-status-summary-a-report-containing-a.md
@@ -1,0 +1,25 @@
+# Ordinary reports — a status summary, a report containing a rhetorical question, a completed-work message — all exit 0, per `TestOrdinaryReportsDoNotBlock`; fails if the detector fires on a question mark.
+
+Status: done
+Created: 2026-08-26
+Epic: an-unasked-decision-does-not-end-the-turn
+Sprint: 025-an-unasked-decision-does-not-end-the-turn
+
+## Description
+
+The criterion that matters most. A false block fires on correct work at the end of every single turn — the #172 and #185 failure at maximum frequency, and it would discredit every other check procoder makes.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [x] Ordinary reports — a status summary, a report containing a rhetorical question, a completed-work message — all exit 0, per `TestOrdinaryReportsDoNotBlock`; fails if the detector fires on a question mark.
+
+## Evidence
+
+`TestOrdinaryReportsDoNotBlock`, whose fixtures are real messages from the session that built this: a status summary, a rhetorical question, a finding report, completed work, and an ask-shaped phrase mid-narration.
+
+One genuine false positive was caught this way — "I asked whether you want me to keep it, and you said yes" is narration about a decision already taken, in the same words as an ask. An interrogative phrase now counts only with a question mark in the same sentence, while a deferring phrase ("say the word", "your call") counts on its own. `TestNarrationAboutAPastDecisionIsNotAnAsk` and `TestADecisionHandedOverWithoutAQuestionMarkStillBlocks` pin both sides.
+
+Killed by matching on a bare question mark, and separately by dropping the question-mark test.

--- a/.procoder/backlog/stories/20260826-the-handoff-note-is-written-on-the-blocking-path-too-per.md
+++ b/.procoder/backlog/stories/20260826-the-handoff-note-is-written-on-the-blocking-path-too-per.md
@@ -1,0 +1,21 @@
+# The handoff note is written on the blocking path too, per `TestTheHandoffNoteSurvivesABlock`; fails if the block returns before the note is written.
+
+Status: done
+Created: 2026-08-26
+Epic: an-unasked-decision-does-not-end-the-turn
+Sprint: 025-an-unasked-decision-does-not-end-the-turn
+
+## Description
+
+A blocked turn must not also lose the note the next session inherits.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [x] The handoff note is written on the blocking path too, per `TestTheHandoffNoteSurvivesABlock`; fails if the block returns before the note is written.
+
+## Evidence
+
+The note is written before any blocking decision is taken. `TestTheHandoffNoteSurvivesABlock` asserts the file exists after a blocking stop, and fails the fixture first if the stop did not block — so it cannot pass by never blocking.

--- a/.procoder/backlog/stories/20260826-the-same-message-twice-exits-2-then-0-per.md
+++ b/.procoder/backlog/stories/20260826-the-same-message-twice-exits-2-then-0-per.md
@@ -1,0 +1,23 @@
+# The same message twice exits 2 then 0, per `TestTheSameMessageNeverBlocksTwice`; fails if the state write is removed.
+
+Status: done
+Created: 2026-08-26
+Epic: an-unasked-decision-does-not-end-the-turn
+Sprint: 025-an-unasked-decision-does-not-end-the-turn
+
+## Description
+
+The failure this exists for. A decision put to the user in the last paragraph of a report, with the work continuing underneath it — which is what the agent that wrote the rule did, hours after shipping it.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [x] The same message twice exits 2 then 0, per `TestTheSameMessageNeverBlocksTwice`; fails if the state write is removed.
+
+## Evidence
+
+`hook.unaskedDecision` and `hook.decisionInProse` in `internal/hook/unasked.go`, wired into `Stop`. Proved by `TestAProseDecisionDoesNotEndTheTurn`, which also requires the reason to be actionable — it must name `decisions.md`, the structured question tool, and the fact that it will not fire twice. A block nobody can satisfy is the thing this is meant to prevent, not cause.
+
+Verified against the real binary with a real payload shape: exit 2, reason on stderr.

--- a/.procoder/backlog/stories/20260826-the-same-payload-with-an-unanswered-decision-recorded-exits.md
+++ b/.procoder/backlog/stories/20260826-the-same-payload-with-an-unanswered-decision-recorded-exits.md
@@ -1,0 +1,21 @@
+# The same payload, with an unanswered decision recorded, exits 0 and says nothing, per `TestARecordedDecisionIsSilent`; fails if the recorded-decision check is dropped.
+
+Status: done
+Created: 2026-08-26
+Epic: an-unasked-decision-does-not-end-the-turn
+Sprint: 025-an-unasked-decision-does-not-end-the-turn
+
+## Description
+
+The agent did the thing. Being told about it anyway is how a check stops being read.
+
+## Acceptance criteria
+
+<!-- Each criterion is testable. Check a box ONLY when it is verifiably
+     true — the closer will ask for the evidence. -->
+
+- [x] The same payload, with an unanswered decision recorded, exits 0 and says nothing, per `TestARecordedDecisionIsSilent`; fails if the recorded-decision check is dropped.
+
+## Evidence
+
+`ask.PendingDecisions` — a narrow query rather than `Pending`, which runs git, the lint pass and the secret scan. A hook firing at the end of every turn under a ten-second timeout cannot afford that. Proved by `TestARecordedDecisionIsSilent`; killed by removing the recorded-decision branch.

--- a/.procoder/specs/an-unasked-decision-does-not-end-the-turn.md
+++ b/.procoder/specs/an-unasked-decision-does-not-end-the-turn.md
@@ -1,0 +1,151 @@
+# An unasked decision does not end the turn
+
+Status: complete
+
+## Problem
+
+3.2.0 shipped the rule that a decision is not the agent's to make: stop,
+record it in `.procoder/ask/decisions.md`, put it to the user with the
+host's structured question tool, do not bury it at the end of a report.
+
+Hours later, in this repository, the agent that wrote the rule ended a
+triage report with three decisions in prose and continued. The rule was in
+the tool and not in the agent. `procoder ask` can make a recorded decision
+visible; nothing makes an agent record one.
+
+That is the shape of every other failure this project has fixed. A rule
+that depends on remembering is a rule that fails on the day somebody is
+busy — which is the argument the credit check, the falsifier rule and the
+release controller each already won.
+
+The moment it fails is identifiable: the end of the turn. An unasked
+decision is one the agent is about to hand back inside prose, having done
+the work around it.
+
+## Users
+
+The person, who is currently asked for decisions in the last paragraph of
+a long report and has to notice, scroll back, and reconstruct what is
+being decided.
+
+The agent, which has a rule it cannot check itself.
+
+## In scope
+
+- [S-1] The Stop hook reads `last_assistant_message` from the host payload
+  and detects a decision put to the user in prose — `internal/hook/stop.go`.
+- [S-2] When one is found and `.procoder/ask/decisions.md` holds no
+  unanswered decision, the turn does not end: the hook exits 2 with a
+  reason on stderr, which is the documented way a Stop hook continues the
+  conversation.
+- [S-3] When a decision IS recorded, the hook is silent. The agent did the
+  thing; being told about it anyway is how a check stops being read.
+- [S-4] The detector is conservative. It fires on an explicit ask —
+  "should I", "do you want", "let me know", "your call" — not on a
+  question mark, because a report containing a rhetorical question is not
+  a decision put to anybody.
+- [S-5] The same message never blocks twice. A block the agent cannot
+  satisfy would end the session in a loop, which is worse than the failure
+  it is preventing.
+- [S-6] The handoff note this hook already writes is unaffected on every
+  path, including the blocking one.
+
+## Out of scope
+
+- Reading the transcript. The host documents it as written asynchronously
+  and lagging the current turn, and names `last_assistant_message` as the
+  field for exactly this. Parsing it anyway would be building on the thing
+  the documentation warns about.
+- Making the agent ask WELL. The hook can see that a decision was buried;
+  it cannot judge whether the options offered are the right ones.
+- Any other host. The Stop event and its payload are Claude Code's; a host
+  without them gets the rule as prose, as today.
+
+## Constraints
+
+- **A false block teaches bypass.** This is the failure behind #172 and
+  #185, and a Stop hook that fires on ordinary reports would be the worst
+  instance of it yet. The detector errs toward silence.
+- **A session must never fail to end.** Every path exits 0 unless it is
+  deliberately blocking, and no message blocks twice.
+- **The handoff note is not sacrificed.** It is written before any
+  blocking decision is taken.
+
+## Interfaces
+
+| Surface                                                 | Behaviour                                                    |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| Stop payload with a prose decision, nothing recorded    | exit 2, reason on stderr, the turn continues                 |
+| Stop payload with a prose decision, a decision recorded | silent, exit 0                                               |
+| Stop payload with no decision-shaped ask                | silent, exit 0                                               |
+| The same message a second time                          | silent, exit 0                                               |
+| No `last_assistant_message` in the payload              | silent, exit 0 — an absent field is not evidence of anything |
+
+## Data
+
+One line of state under `.procoder/state/`: a hash of the message this
+hook last blocked on, so the same message cannot block twice.
+
+## Edge cases
+
+- **The payload has no `last_assistant_message`.** Older host, another
+  host, or a malformed event. Silence: an absent field is not evidence a
+  decision was buried.
+- **A decision is recorded but already answered.** Not outstanding, so it
+  does not excuse a new one buried in prose. The check asks for an
+  UNANSWERED decision.
+- **The agent asks properly AND writes a summary containing "let me
+  know".** A recorded decision makes the hook silent, so asking properly
+  is always the way out.
+- **`.procoder/ask/decisions.md` is unreadable.** Silence rather than a
+  block: procoder cannot tell whether a decision was recorded, and
+  blocking on not-knowing would be a block nobody can act on.
+- **A repository that never adopted procoder.** The hook writes no note
+  and blocks nothing there, as today.
+
+## Failure modes
+
+- **It fires on an ordinary report.** The one that matters. Held by an
+  explicit-ask detector rather than a question mark, and by a test over
+  real reports that must stay silent.
+- **It blocks in a loop.** Held by the one-block-per-message state, and by
+  a test that runs the same message twice.
+- **It swallows the handoff note.** Held by writing the note first and
+  asserting it on the blocking path.
+
+## Acceptance criteria
+
+- [ ] [S-1] [S-2] A Stop payload whose `last_assistant_message` ends with
+      "Do you want me to X or Y?" and a repository with no unanswered
+      recorded decision exits 2 and names the fix on stderr, per
+      `TestAProseDecisionDoesNotEndTheTurn`; fails if the detector is
+      made to return false.
+- [ ] [S-3] The same payload, with an unanswered decision recorded, exits
+      0 and says nothing, per `TestARecordedDecisionIsSilent`; fails if
+      the recorded-decision check is dropped.
+- [ ] [S-4] Ordinary reports — a status summary, a report containing a
+      rhetorical question, a completed-work message — all exit 0, per
+      `TestOrdinaryReportsDoNotBlock`; fails if the detector fires on a
+      question mark.
+- [ ] [S-5] The same message twice exits 2 then 0, per
+      `TestTheSameMessageNeverBlocksTwice`; fails if the state write is
+      removed.
+- [ ] [S-6] The handoff note is written on the blocking path too, per
+      `TestTheHandoffNoteSurvivesABlock`; fails if the block returns
+      before the note is written.
+- [ ] [S-1] A payload with no `last_assistant_message` exits 0, per
+      `TestNoMessageIsNotEvidence`; fails if an absent field is treated as
+      an empty ask.
+
+## Open questions
+
+## Decisions
+
+- **`last_assistant_message`, not the transcript.** The host documents the
+  transcript as lagging the current turn and names this field as the one
+  for it. Checked against the documentation rather than assumed, after the
+  first design read the transcript.
+- **Exit 2 with stderr, not a JSON decision.** That is what the host
+  documents as the Stop hook's blocking mechanism.
+- **Conservative detection.** A missed burial costs one prose question. A
+  false block costs the credibility of every check procoder makes.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -647,6 +647,19 @@ under it are its options:
 ```
 
 Procoder never writes that file — the agent does, and procoder reads it.
+
+The Stop hook makes the rule bind rather than depend on remembering. A turn
+ending with a decision put to the user in prose, and none recorded here,
+does not end: the hook reads `last_assistant_message` from the host and
+exits 2, which is the documented way a Stop hook continues the
+conversation. `ask.PendingDecisions` is the cheap query behind it — the
+whole collection runs git, the lint pass and the secret scan, which a hook
+firing at the end of every turn under a ten-second timeout cannot afford.
+
+It fires on an explicit ask, never on a question mark, and never twice on
+the same message. That asymmetry is deliberate: a missed burial costs one
+prose question, while a check that interrupts correct work at the end of
+every turn is one people route around.
 That is P-CONTROL, and it is why there is no `--raise` flag: it would read
 better on the command line and break the rule the tool rests on.
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -97,7 +97,9 @@ it carries; the repository is judged on all of it.
 <p class="procoder-stop__why">The handoff. What the next session inherits is written down rather than reconstructed from scrollback.</p>
 <ul class="procoder-checks">
 <li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>handoff note</b><i>Written to state. A note that cannot be written is a lost note, never a broken session.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--block">Blocks</span><span><b>an unasked decision</b><i>A turn ending with a decision put to the user in prose, and none recorded in <code>.procoder/ask/decisions.md</code>, does not end. The hook reads <code>last_assistant_message</code> from the host and exits 2, which continues the conversation.</i></span></li>
 </ul>
+<p class="procoder-stop__why">The detector is deliberately conservative: an explicit ask, never a bare question mark, and an interrogative phrase only counts with a question mark in the same sentence — otherwise narration about a decision already taken reads as a new one. The same message never blocks twice, and the handoff note is written first, on every path including the blocking one.</p>
 </div>
 </section>
 

--- a/internal/ask/decisions.go
+++ b/internal/ask/decisions.go
@@ -101,14 +101,23 @@ func decisionQuestions(root string) ([]Question, []string) {
 // cannot afford that: it runs at the end of every turn, under a ten-second
 // timeout, and a check that makes a session hang is worse than the rule it
 // enforces.
-func PendingDecisions(root string) ([]Question, error) {
-	qs, _ := decisionQuestions(root)
+// The notes are returned, not discarded. decisionQuestions produces one
+// when the file exists and cannot be read, or holds content in a shape it
+// does not recognise — cases where "no decisions were recorded" is not a
+// fact, it is an absence of information.
+//
+// Dropping them made a caller unable to tell the two apart, and the Stop
+// hook then blocked a turn because it could not read a file. That is
+// unknown treated as none, which is the failure this project keeps
+// finding. Raised in review on #215.
+func PendingDecisions(root string) (qs []Question, notes []string, err error) {
+	qs, notes = decisionQuestions(root)
 	if len(qs) == 0 {
-		return nil, nil
+		return nil, notes, nil
 	}
-	store, err := answers.Load(root)
-	if err != nil {
-		return nil, err
+	store, loadErr := answers.Load(root)
+	if loadErr != nil {
+		return nil, notes, loadErr
 	}
-	return Unanswered(qs, store), nil
+	return Unanswered(qs, store), notes, nil
 }

--- a/internal/ask/decisions.go
+++ b/internal/ask/decisions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"procoder/internal/answers"
 	"strings"
 )
 
@@ -89,4 +90,25 @@ func decisionQuestions(root string) ([]Question, []string) {
 			filepath.ToSlash(filepath.Join(Dir, DecisionsFile)))}
 	}
 	return qs, nil
+}
+
+// PendingDecisions is the decisions the agent recorded and nobody has
+// answered yet.
+//
+// Deliberately narrow. Pending() runs the whole collection — git, the lint
+// pass, the secret scan — because it answers "what is outstanding
+// anywhere". A Stop hook asking only "did the agent write a decision down"
+// cannot afford that: it runs at the end of every turn, under a ten-second
+// timeout, and a check that makes a session hang is worse than the rule it
+// enforces.
+func PendingDecisions(root string) ([]Question, error) {
+	qs, _ := decisionQuestions(root)
+	if len(qs) == 0 {
+		return nil, nil
+	}
+	store, err := answers.Load(root)
+	if err != nil {
+		return nil, err
+	}
+	return Unanswered(qs, store), nil
 }

--- a/internal/hook/stop.go
+++ b/internal/hook/stop.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -39,6 +40,11 @@ const notesHint = `<!-- Yours. What you were doing, what you decided, what comes
 // repository state only.
 type stopPayload struct {
 	Cwd string `json:"cwd"`
+	// LastAssistantMessage is the final assistant text of the turn. The
+	// host supplies it on Stop precisely so a hook does not read the
+	// transcript, which it documents as written asynchronously and lagging
+	// the current turn.
+	LastAssistantMessage string `json:"last_assistant_message"`
 }
 
 // Stop writes the handoff note at the end of a session (or before a
@@ -59,8 +65,26 @@ func Stop(stdin io.Reader, root string) int {
 	old, _ := os.ReadFile(path) // absent is the first handoff, not an error
 	// a note that could not be written is a lost note, never a broken session
 	_ = os.WriteFile(path, []byte(handoff(root, string(old))), 0o644)
+
+	// The note is written first, on every path including this one: a
+	// blocked turn must not also lose its handoff.
+	//
+	// A decision put to the user in prose does not end the turn. The rule
+	// shipped in 3.2.0 and was broken the same day by the agent that wrote
+	// it, which is the whole argument — a rule that depends on remembering
+	// fails on the day somebody is busy.
+	var p stopPayload
+	_ = json.Unmarshal(raw, &p)
+	if blocked, reason := unaskedDecision(root, p.LastAssistantMessage); blocked {
+		fmt.Fprintln(Stderr, reason)
+		return 2 // the host's documented way for a Stop hook to continue the conversation
+	}
 	return 0
 }
+
+// Stderr is where a blocking reason goes, and a variable so a test can
+// read it. The host feeds this back to the model.
+var Stderr io.Writer = os.Stderr
 
 // rootFromPayload falls back to the host's working directory, then the
 // process's, so a caller with no root still writes the note in the right

--- a/internal/hook/unasked.go
+++ b/internal/hook/unasked.go
@@ -94,10 +94,17 @@ func unaskedDecision(root, message string) (bool, string) {
 	if !decisionInProse(message) {
 		return false, ""
 	}
-	pending, err := ask.PendingDecisions(root)
-	if err != nil || len(pending) > 0 {
-		// Unreadable, or the agent already recorded one. Either way this
-		// hook has nothing to add.
+	pending, notes, err := ask.PendingDecisions(root)
+	if err != nil || len(notes) > 0 || len(pending) > 0 {
+		// Three reasons to say nothing, and only one of them is "the agent
+		// already recorded a decision".
+		//
+		// A note means the decisions file exists and could not be read, or
+		// holds something in a shape procoder does not recognise. Whether a
+		// decision was recorded is then UNKNOWN, and blocking a turn on not
+		// knowing is a block nobody can act on — the thing this hook exists
+		// to prevent, not to cause. Raised in review on #215, where the
+		// notes were being discarded and unknown read as none.
 		return false, ""
 	}
 	if alreadyBlocked(root, message) {

--- a/internal/hook/unasked.go
+++ b/internal/hook/unasked.go
@@ -1,0 +1,149 @@
+package hook
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"procoder/internal/ask"
+)
+
+// blockedFile remembers the message this hook last refused to end the turn
+// on, so the same one cannot block twice. A block the agent cannot satisfy
+// would loop the session, which is worse than the failure being prevented.
+const blockedFile = "last-unasked-decision"
+
+// Two shapes of ask, because they are recognised differently.
+//
+// interrogative phrases are only an ask when they are actually asked. "Do
+// you want me to keep it?" is a decision; "I asked whether you want me to
+// keep it, and you said yes" is narration about one already taken. The
+// difference is the question mark in the same sentence, and without that
+// test this fired on the second — found by a fixture taken from a real
+// message in the session that built this.
+var interrogative = regexp.MustCompile(`(?i)\b(` + strings.Join([]string{
+	`should i\b`,
+	`shall i\b`,
+	`do you want\b`,
+	`would you (like|prefer|rather)\b`,
+	`which (one )?(would|do) you\b`,
+	`want me to\b`,
+	`do you want me to\b`,
+}, "|") + `)`)
+
+// deferring phrases hand the choice over outright. They are an ask with or
+// without a question mark — "say the word and I'll tag it" is a decision
+// put to somebody just as much as "shall I tag it?".
+var deferring = regexp.MustCompile(`(?i)\b(` + strings.Join([]string{
+	`let me know (if|which|whether|what)\b`,
+	`your call\b`,
+	`say the word\b`,
+	`up to you\b`,
+	`tell me (which|whether|if|what) you\b`,
+}, "|") + `)`)
+
+// sentences splits on terminators, keeping each terminator with its
+// sentence so a question mark can be tested against the clause it belongs
+// to rather than against the whole message.
+var sentences = regexp.MustCompile(`[^.!?\n]*[.!?\n]|[^.!?\n]+$`)
+
+// decisionInProse reports whether a message puts a decision to the reader
+// rather than reporting work.
+//
+// The tail, not the whole message. A decision buried at the end of a long
+// report is the failure this exists for, and an ask-shaped phrase in the
+// middle of narration is usually prose about a decision already taken.
+//
+// The asymmetry is the whole design. A missed burial costs one prose
+// question, which is what happens today anyway. A false block fires on
+// ordinary reports at the end of every single turn, and a check that
+// interrupts correct work is one people route around — the failure behind
+// #172 and #185. So this errs toward silence.
+func decisionInProse(message string) bool {
+	lines := strings.Split(strings.TrimRight(message, "\n"), "\n")
+	from := 0
+	if len(lines) > 12 {
+		from = len(lines) - 12
+	}
+	tail := strings.Join(lines[from:], "\n")
+	for _, s := range sentences.FindAllString(tail, -1) {
+		if deferring.MatchString(s) {
+			return true
+		}
+		if interrogative.MatchString(s) && strings.Contains(s, "?") {
+			return true
+		}
+	}
+	return false
+}
+
+// unaskedDecision reports whether the turn is ending with a decision put
+// to the reader in prose and none recorded, and the reason to say so.
+//
+// Every uncertain path returns false. procoder not being able to tell
+// whether a decision was recorded is not grounds for refusing to let a
+// session end — that would be a block nobody can act on, which is the
+// thing this is meant to prevent, not cause.
+func unaskedDecision(root, message string) (bool, string) {
+	if strings.TrimSpace(message) == "" {
+		return false, "" // an absent field is not evidence of anything
+	}
+	if !decisionInProse(message) {
+		return false, ""
+	}
+	pending, err := ask.PendingDecisions(root)
+	if err != nil || len(pending) > 0 {
+		// Unreadable, or the agent already recorded one. Either way this
+		// hook has nothing to add.
+		return false, ""
+	}
+	if alreadyBlocked(root, message) {
+		return false, ""
+	}
+	// Only block if the guard can be recorded. A block this hook cannot
+	// remember is one it will repeat on the next stop, and a session that
+	// cannot end is worse than a decision that went unasked.
+	if !rememberBlocked(root, message) {
+		return false, ""
+	}
+	return true, "This turn ends with a decision put to the user in prose, and " +
+		"`.procoder/ask/decisions.md` records none.\n\n" +
+		"A question at the end of a report has not been asked — it has been " +
+		"mentioned. The user has to notice it, scroll back, and reconstruct " +
+		"what is being decided.\n\n" +
+		"Write the decision to `.procoder/ask/decisions.md` — one `## ` heading, " +
+		"its options as a list beneath — then put it to the user with the host's " +
+		"structured question tool, on its own, before continuing.\n\n" +
+		"If what you wrote is not a decision, record it anyway or reword it: this " +
+		"fires on an explicit ask, and it will not fire twice on the same message."
+}
+
+func blockedPath(root string) string {
+	return filepath.Join(root, filepath.FromSlash(StateDir), blockedFile)
+}
+
+func fingerprint(message string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(message)))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func alreadyBlocked(root, message string) bool {
+	raw, err := os.ReadFile(blockedPath(root))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(raw)) == fingerprint(message)
+}
+
+// rememberBlocked records the fingerprint and reports whether it stuck.
+// The caller blocks only when it did — see unaskedDecision.
+func rememberBlocked(root, message string) bool {
+	dir := filepath.Dir(blockedPath(root))
+	if os.MkdirAll(dir, 0o755) != nil {
+		return false
+	}
+	return os.WriteFile(blockedPath(root), []byte(fingerprint(message)), 0o644) == nil
+}

--- a/internal/hook/unasked_test.go
+++ b/internal/hook/unasked_test.go
@@ -186,3 +186,42 @@ func TestADecisionHandedOverWithoutAQuestionMarkStillBlocks(t *testing.T) {
 		}
 	}
 }
+
+// Unknown is not none. A decisions file that exists and cannot be read, or
+// holds content in a shape procoder does not recognise, means whether a
+// decision was recorded is UNKNOWN — and blocking a turn on not knowing is
+// a block nobody can act on, which is the thing this hook exists to
+// prevent rather than to cause.
+//
+// The spec said so in its edge cases and the first implementation did the
+// opposite: PendingDecisions discarded the notes decisionQuestions
+// produces for exactly these cases, so unknown arrived as none and the
+// turn was blocked. Raised in review on #215; reproduced before fixing.
+//
+// proved by: the `len(notes) > 0` test dropped from unaskedDecision — the
+// malformed file blocks again.
+func TestAnUnreadableDecisionsFileDoesNotBlock(t *testing.T) {
+	root := askRepo(t)
+	recordDecision(t, root, "I need to decide whether to merge first.\n")
+	if code, reason := runStop(t, root, "Done. Should I tag it now?"); code != 0 {
+		t.Errorf("an unparseable decisions file blocked the turn (exit %d) — procoder cannot tell whether a decision was recorded:\n%s", code, reason)
+	}
+}
+
+// And the neighbouring case, which is NOT unknown: a file that exists and
+// is empty says plainly that nothing was recorded. That is a fact, and the
+// turn should still block.
+//
+// Written after the first version of the test above lumped the two
+// together and failed — an empty file is not an unreadable one.
+//
+// proved by: the `strings.TrimSpace(string(raw)) != ""` test in
+// decisionQuestions inverted, so an empty file produces a note — the turn
+// then stops blocking and a buried decision gets through.
+func TestAnEmptyDecisionsFileStillBlocks(t *testing.T) {
+	root := askRepo(t)
+	recordDecision(t, root, "   \n")
+	if code, _ := runStop(t, root, "Done. Should I tag it now?"); code != 2 {
+		t.Fatalf("an empty decisions file did not block (exit %d) — empty means nothing was recorded", code)
+	}
+}

--- a/internal/hook/unasked_test.go
+++ b/internal/hook/unasked_test.go
@@ -1,0 +1,188 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// askRepo is a bare directory with a .procoder/ask/ — no git, because
+// nothing here needs it and a Stop hook that required a repository would
+// be one more way for a session to fail to end.
+func askRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".procoder", "ask"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func recordDecision(t *testing.T, root, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, ".procoder", "ask", "decisions.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// runStop feeds a Stop payload and returns the exit code and whatever the
+// hook wrote as its reason.
+func runStop(t *testing.T, root, message string) (int, string) {
+	t.Helper()
+	payload, err := json.Marshal(stopPayload{Cwd: root, LastAssistantMessage: message})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var errOut bytes.Buffer
+	prev := Stderr
+	Stderr = &errOut
+	defer func() { Stderr = prev }()
+	return Stop(bytes.NewReader(payload), root), errOut.String()
+}
+
+// S-1, S-2: the failure this exists for. The rule shipped in 3.2.0 and was
+// broken the same day by the agent that wrote it — three decisions in the
+// last paragraph of a triage report, work continuing underneath them.
+//
+// proved by: `decisionInProse` made to return false — the turn ends and
+// the decision stays buried.
+func TestAProseDecisionDoesNotEndTheTurn(t *testing.T) {
+	root := askRepo(t)
+	code, reason := runStop(t, root, `Triage done. Twelve issues reviewed.
+
+Decisions I need from you:
+1. Should I rescope the two that overlap?
+2. Do you want me to start on the merge-conflict one?`)
+	if code != 2 {
+		t.Fatalf("exit %d, want 2 — the turn ended with the decision buried\n%s", code, reason)
+	}
+	// The reason has to be actionable, or it is a block nobody can satisfy.
+	for _, want := range []string{"decisions.md", "structured question tool", "not fire twice"} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("the reason does not contain %q:\n%s", want, reason)
+		}
+	}
+}
+
+// S-3: the agent did the thing. Being told about it anyway is how a check
+// stops being read.
+//
+// proved by: the `len(pending) > 0` branch removed — a correctly recorded
+// decision blocks anyway.
+func TestARecordedDecisionIsSilent(t *testing.T) {
+	root := askRepo(t)
+	recordDecision(t, root, "## Should the two overlapping issues be rescoped?\n\n- yes\n- no\n")
+	code, reason := runStop(t, root, "Triage done. Should I start on the merge-conflict one?")
+	if code != 0 {
+		t.Fatalf("exit %d with a decision recorded, want 0\n%s", code, reason)
+	}
+}
+
+// S-4, and the criterion that matters most: a false block fires on
+// ordinary work, at the end of every turn, and a check that interrupts
+// correct work is one people route around — the failure behind #172 and
+// #185.
+//
+// The fixtures are real messages from the session that built this.
+//
+// proved by: askPhrases replaced with `\?` — every one of these blocks.
+func TestOrdinaryReportsDoNotBlock(t *testing.T) {
+	for name, msg := range map[string]string{
+		"a status summary":         "v3.2.1 published and verified. All five binaries plus SHA256SUMS, checksum matches, the binary reports 3.2.1.",
+		"a rhetorical question":    `Why did this fail? Because the token is an app installation token and there is no user behind it. Fixed by making the exclusion configuration.`,
+		"a finding report":         "The gate caught a real defect: a decision carries its options as a markdown list, and a list opening directly under a paragraph makes a formatter reflow what follows.",
+		"work completed":           "Both PRs merged. main is at 7b3bd37, zero open PRs, all seven issues closed.",
+		"a question in the middle": "I asked whether you want me to keep it, and you said yes, so it stays. The suite is green and the gate is clean.",
+	} {
+		root := askRepo(t)
+		if code, reason := runStop(t, root, msg); code != 0 {
+			t.Errorf("%s blocked the turn (exit %d):\n%s\n--- message:\n%s", name, code, reason, msg)
+		}
+	}
+}
+
+// S-5: a block the agent cannot satisfy would loop the session, which is
+// worse than the failure being prevented.
+//
+// proved by: the rememberBlocked call removed — the second stop blocks
+// again and the session cannot end.
+func TestTheSameMessageNeverBlocksTwice(t *testing.T) {
+	root := askRepo(t)
+	msg := "Done. Should I cut the release now?"
+	if code, _ := runStop(t, root, msg); code != 2 {
+		t.Fatalf("the first stop must block, got %d", code)
+	}
+	if code, reason := runStop(t, root, msg); code != 0 {
+		t.Fatalf("the same message blocked twice (exit %d) — the session cannot end\n%s", code, reason)
+	}
+}
+
+// S-6: a blocked turn must not also lose its handoff note.
+//
+// proved by: the block moved above the note write — the note is missing
+// on the blocking path.
+func TestTheHandoffNoteSurvivesABlock(t *testing.T) {
+	root := askRepo(t)
+	if code, _ := runStop(t, root, "Done. Should I tag it?"); code != 2 {
+		t.Fatalf("the fixture did not block, so this proves nothing (exit %d)", code)
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(StateDir), HandoffFile)); err != nil {
+		t.Fatalf("the handoff note was lost on the blocking path: %v", err)
+	}
+}
+
+// An absent field is not evidence of anything — an older host, another
+// host, or a malformed event must not end up blocking.
+//
+// The empty-message guard in unaskedDecision is an early return, not the
+// protection — an empty string matches no ask phrase anyway. Verified:
+// removing it does not fail this test. What this pins is the behaviour, so
+// a future detector that treats absence as something fails here.
+func TestNoMessageIsNotEvidence(t *testing.T) {
+	root := askRepo(t)
+	if code, reason := runStop(t, root, ""); code != 0 {
+		t.Fatalf("a payload with no message blocked (exit %d)\n%s", code, reason)
+	}
+}
+
+// The distinction that cost a false positive: an interrogative phrase is
+// an ask only when it is actually asked. Narration about a decision
+// already taken uses the same words.
+//
+// proved by: the `strings.Contains(s, "?")` test dropped from the
+// interrogative branch — the narration blocks, which is what it did before
+// this test existed.
+func TestNarrationAboutAPastDecisionIsNotAnAsk(t *testing.T) {
+	for name, msg := range map[string]string{
+		"past tense":  "I asked whether you want me to keep it, and you said yes, so it stays.",
+		"reported":    "You told me which one you would prefer, so that is what shipped.",
+		"conditional": "If you had said you want me to hold it, I would have.",
+	} {
+		root := askRepo(t)
+		if code, reason := runStop(t, root, msg); code != 0 {
+			t.Errorf("%s was read as an ask (exit %d):\n%s", name, code, reason)
+		}
+	}
+}
+
+// And a decision handed over without a question mark is still a decision.
+// "Say the word and I'll tag it" puts the choice to somebody exactly as
+// much as "shall I tag it?" does.
+//
+// proved by: the deferring branch removed — these end the turn with the
+// decision buried.
+func TestADecisionHandedOverWithoutAQuestionMarkStillBlocks(t *testing.T) {
+	for name, msg := range map[string]string{
+		"say the word": "Everything is verified and ready. Say the word and I'll tag it.",
+		"your call":    "Both options work. Your call.",
+		"up to you":    "I would keep it open, but it is up to you.",
+	} {
+		root := askRepo(t)
+		if code, _ := runStop(t, root, msg); code != 2 {
+			t.Errorf("%s did not block (exit %d) — the decision ends the turn unasked", name, code)
+		}
+	}
+}


### PR DESCRIPTION
## Why

3.2.0 shipped the rule that a decision is not the agent's to make: record it in `.procoder/ask/decisions.md`, put it to the user with the host's structured question tool, don't bury it at the end of a report.

Hours later the agent that wrote the rule ended a triage report with three decisions in prose and carried on. **The rule was in the tool and not in the agent.** `procoder ask` could make a recorded decision visible; nothing made an agent record one.

That is every failure this project has already fixed, once more — a rule that depends on remembering fails on the day somebody is busy.

## What it does

| Stop payload | |
| --- | --- |
| decision in prose, none recorded | **exit 2** — the turn continues, the reason names the fix |
| decision recorded | silent |
| the same message again | silent |
| an ordinary report | silent |
| no `last_assistant_message` | silent |

The handoff note is written first, on every path including the blocking one.

## Verified, not assumed

The first design was wrong twice, and the host's documentation said so:

- **The transcript lags.** It is written asynchronously and may not include the current turn — which is why `last_assistant_message` exists on Stop. The docs say explicitly to use it instead.
- **Blocking is exit 2 with stderr**, not a JSON decision field.

Both would have looked plausible and worked intermittently.

## The design constraint

A false block fires on correct work **at the end of every turn**. That is the #172 and #185 failure at maximum frequency, and it would discredit every other check procoder makes. So the detector errs toward silence:

- an explicit ask, never a bare question mark
- an interrogative phrase only with a question mark in the same sentence
- a deferring phrase (`say the word`, `your call`) counts on its own
- never twice on one message — and a block that cannot be recorded is not taken, because a session that cannot end is worse than a decision that went unasked

It caught one real false positive in development: *"I asked whether you want me to keep it, and you said yes"* — narration about a decision already taken, in the words of an ask. Both sides are now pinned by tests.

**The fixtures for "must stay silent" are real messages from the session that built this**, because that is the failure that matters.

## Verification

Seven mutations applied and watched to fail. One survived and the claim was corrected rather than a mutation invented — the empty-message guard is an early return, not the protection.

Exercised end to end against the built binary: blocks, then stays silent on the repeat, then stays silent once a decision is recorded, with the handoff note present throughout.

## Honest limit

This catches a decision that was *buried*. It cannot judge whether the options offered are the right ones, and it cannot make an agent ask *well*.
