### PR TITLE
feat: merge-conflict discipline, and how to relay a procoder report

### DIFF
--- a/.agents/rules/procoder.md
+++ b/.agents/rules/procoder.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.clinerules/procoder.md
+++ b/.clinerules/procoder.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.cursor/rules/procoder.mdc
+++ b/.cursor/rules/procoder.mdc
@@ -31,6 +31,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kilo/rules/procoder.md
+++ b/.kilo/rules/procoder.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kilocode/rules/procoder.md
+++ b/.kilocode/rules/procoder.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kiro/steering/procoder.md
+++ b/.kiro/steering/procoder.md
@@ -30,6 +30,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,6 +1,6 @@
 # What a human decided
 
-Written 2026-08-26 13:00 UTC. procoder reads this
+Written 2026-08-26 14:01 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
 
@@ -32,12 +32,55 @@ Question: Does the decisions queue and its principles change ship in v3.1.1, or 
 
 Answer: in v3.1.1 — ADR 0003 governs major, and 2.0.1 already shipped new enforcement in a patch
 
+## [decision] decisions.md
+
+Key: 612a37231e9b
+Question: Label #209 and #211 roadmap alongside #194?
+
+All three are documentation-positioning work: an evidence bibliography, a
+comparable-projects doc, and the docs-hardening issue already labelled
+roadmap. They are one cluster and none is small.
+
+- label both roadmap: the cluster reads as direction rather than queued
+  work, which is what the label was created for.
+- leave them unlabelled: they stay in the ordinary queue.
+
+Answer: yes, label both
+
 ## (no longer asked)
 
 Key: 6617364d8670
 Question: Which of #177 and #181 is next, given #172 and #175 are both in review?
 
 Answer: #181 (procoder prune) — already specified with guardrails agreed, start immediately
+
+## [decision] decisions.md
+
+Key: 815c92a8de33
+Question: Close #206, whose premise does not hold for procoder?
+
+#206 asks for ReDoS defence — bounded, sandboxed regex evaluation — because
+procoder "evaluates regex in several places that ultimately read
+repo-controlled or config-controlled text".
+
+Checked rather than taken on trust, the way #201's premise was:
+
+- there is no `regexp.Compile` anywhere in the tree;
+- the only two `MustCompile` calls with a non-literal argument build their
+  pattern from constants in source (`gitx.aiIdentities`,
+  `security.pyDeps`);
+- `.procoder/lint/RULES.md`'s `checks` list is passed to clang-tidy as its
+  `--checks` value. It never reaches a Go regex engine.
+
+So no repository- or config-controlled text becomes a pattern procoder
+compiles. The exposure the issue describes is not there.
+
+- close it, with the evidence recorded, and reopen if a runtime-compiled
+  pattern is ever introduced.
+- keep it open as a standing constraint on future work — a reminder not to
+  add one.
+
+Answer: not yet — do a deep analysis first, and close only if it is 100% certain
 
 ## (no longer asked)
 
@@ -46,34 +89,17 @@ Question: Does the decisions queue and its principles change ship in v3.1.1, or 
 
 Answer: in v3.1.1 — ADR 0003 governs major, and 2.0.1 already shipped new enforcement in a patch
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: aa8ea1f17c0c
 Question: Do the four large features stay open as a roadmap?
 
-#189 SKILL.md redesign, #190 `procoder learn`, #192 `procoder wizard`, #194
-docs hardening. Each is a release of its own; two add new commands.
-
-- keep open: a roadmap that says what procoder might become.
-- close until wanted: an open issue nobody is going to start reads as a
-  commitment, and twenty-three of them read as a plan.
-
 Answer: keep open, but label them roadmap/large so they stop reading as queued work
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: b55269facb93
 Question: Rescope #198 and #191, and merge #200 with #201 and #204 with #208?
-
-Today's release overtook two of them, and two pairs are the same idea filed
-twice. Left alone, somebody rebuilds what already exists.
-
-- rescope and merge now: #198 loses its unfalsifiable-criteria half (shipped
-  as `CriteriaWithoutFalsifiers`) and keeps fixed-output, hedgy vocabulary
-  and unmeasured thresholds; #191 keeps board visibility and shared
-  blockers and drops "there is no decisions file", because there is one now.
-- leave them: the overlap is discoverable by whoever picks one up, at the
-  cost of them finding out after starting.
 
 Answer: yes — rescope and merge now, before anyone starts on a duplicate
 
@@ -84,21 +110,31 @@ Question: Does `procoder prune` delete, or print what it would delete?
 
 Answer: report by default, delete on --apply — the safe thing stays the default and the reclaim still happens in one command
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: c9c26deda0a7
 Question: Which is the next piece of work?
 
-- #193, merge-conflict discipline: the failure happened here today — git
-  split a conflict through a function, "keep both sides" truncated a test,
-  and only the compiler caught it. Concrete evidence, and the fix is prose.
-- #201 + #200, the execute path: verified, not assumed —
-  `internal/runcmd/runcmd.go:172` execs argv the repository declares, so an
-  agent writing a launch command under injection is a live path. The only
-  security-shaped items in the set.
-- #195, the context.md glossary: small, self-contained, pays off every session.
-
 Answer: #193, merge-conflict discipline
+
+## [decision] decisions.md
+
+Key: e721d4e97e3f
+Question: Do #210 now, before #193?
+
+`docs/influences.md` credits superpowers, ponytail and serena. BMad appears
+in it zero times, while `internal/planning/bmad.go` has shipped since 2.0.0
+and `[planning] method = "bmad"` reads BMad's own artifacts. Verified: the
+integration is real and the doc gap is real.
+
+Small, factual, and the trademark constraint is already understood — BMad
+is named to describe interoperation, never as a procoder feature name.
+
+- do it now: ten minutes, and it closes a verified gap in a provenance
+  record that is currently wrong by omission.
+- after #193: #193 was already chosen as the next piece of work.
+
+Answer: no — #193 as planned
 
 ## (no longer asked)
 

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -1,36 +1,48 @@
 # Decisions waiting on a human
 
-Written by the agent, read by `procoder ask`. One `## ` heading per
-decision; the lines under it are its options.
+## Close #206, whose premise does not hold for procoder?
 
-## Rescope #198 and #191, and merge #200 with #201 and #204 with #208?
+#206 asks for ReDoS defence — bounded, sandboxed regex evaluation — because
+procoder "evaluates regex in several places that ultimately read
+repo-controlled or config-controlled text".
 
-Today's release overtook two of them, and two pairs are the same idea filed
-twice. Left alone, somebody rebuilds what already exists.
+Checked rather than taken on trust, the way #201's premise was:
 
-- rescope and merge now: #198 loses its unfalsifiable-criteria half (shipped
-  as `CriteriaWithoutFalsifiers`) and keeps fixed-output, hedgy vocabulary
-  and unmeasured thresholds; #191 keeps board visibility and shared
-  blockers and drops "there is no decisions file", because there is one now.
-- leave them: the overlap is discoverable by whoever picks one up, at the
-  cost of them finding out after starting.
+- there is no `regexp.Compile` anywhere in the tree;
+- the only two `MustCompile` calls with a non-literal argument build their
+  pattern from constants in source (`gitx.aiIdentities`,
+  `security.pyDeps`);
+- `.procoder/lint/RULES.md`'s `checks` list is passed to clang-tidy as its
+  `--checks` value. It never reaches a Go regex engine.
 
-## Which is the next piece of work?
+So no repository- or config-controlled text becomes a pattern procoder
+compiles. The exposure the issue describes is not there.
 
-- #193, merge-conflict discipline: the failure happened here today — git
-  split a conflict through a function, "keep both sides" truncated a test,
-  and only the compiler caught it. Concrete evidence, and the fix is prose.
-- #201 + #200, the execute path: verified, not assumed —
-  `internal/runcmd/runcmd.go:172` execs argv the repository declares, so an
-  agent writing a launch command under injection is a live path. The only
-  security-shaped items in the set.
-- #195, the context.md glossary: small, self-contained, pays off every session.
+- close it, with the evidence recorded, and reopen if a runtime-compiled
+  pattern is ever introduced.
+- keep it open as a standing constraint on future work — a reminder not to
+  add one.
 
-## Do the four large features stay open as a roadmap?
+## Do #210 now, before #193?
 
-#189 SKILL.md redesign, #190 `procoder learn`, #192 `procoder wizard`, #194
-docs hardening. Each is a release of its own; two add new commands.
+`docs/influences.md` credits superpowers, ponytail and serena. BMad appears
+in it zero times, while `internal/planning/bmad.go` has shipped since 2.0.0
+and `[planning] method = "bmad"` reads BMad's own artifacts. Verified: the
+integration is real and the doc gap is real.
 
-- keep open: a roadmap that says what procoder might become.
-- close until wanted: an open issue nobody is going to start reads as a
-  commitment, and twenty-three of them read as a plan.
+Small, factual, and the trademark constraint is already understood — BMad
+is named to describe interoperation, never as a procoder feature name.
+
+- do it now: ten minutes, and it closes a verified gap in a provenance
+  record that is currently wrong by omission.
+- after #193: #193 was already chosen as the next piece of work.
+
+## Label #209 and #211 roadmap alongside #194?
+
+All three are documentation-positioning work: an evidence bibliography, a
+comparable-projects doc, and the docs-hardening issue already labelled
+roadmap. They are one cluster and none is small.
+
+- label both roadmap: the cluster reads as direction rather than queued
+  work, which is what the label was created for.
+- leave them unlabelled: they stay in the ordinary queue.

--- a/.qoder/rules/procoder.md
+++ b/.qoder/rules/procoder.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.roo/rules/procoder.md
+++ b/.roo/rules/procoder.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.windsurf/rules/procoder.md
+++ b/.windsurf/rules/procoder.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -73,6 +73,15 @@ Rules:
 - Which points at the real guard: a feature whose only trace is a comment
   is untested by definition, and untested code can vanish between two
   green runs without anything saying so. Write the test with the code.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do — not by which lines differ. ` + "`--abort`" + ` is not a resolution: it
+  erases the attempt and the next person starts from nothing. Stuck is a
+  thing to say, not a thing to undo. Say which side's intent won where it
+  is not obvious, so a reviewer does not have to work it out from the
+  result. Read the resolved file rather than trusting its shape: git
+  splits a conflict wherever the texts diverge, including through the
+  middle of a function, so "keep both sides" can leave one of them without
+  its closing lines and still look plausible.
 - Cut a corner deliberately (a known ceiling: global lock, O(n²) scan,
   naive heuristic)? Mark it in a comment with the configured debt marker
   (default ` + "`debt:`" + `), naming the ceiling AND the condition to
@@ -197,6 +206,13 @@ the ND formatting for that response and answer in plain prose.
   explicit versions rather than one compromise
 - Code: full blocks only, not partial snippets with "add this part"
 - Tables for comparisons; prose where structure does not add value
+- Relaying a procoder report: lead with what blocks and how to clear it,
+  not with which command ran. Past about five findings, give the count and
+  the command that lists the rest instead of pasting all of them. No
+  preamble before the answer and no offer of further help after it.
+- Those caps come off for anything destructive or irreversible, and for a
+  finding a person has already asked to see in full: brevity is for
+  reports, never for consequences.
 `
 
 // Effective returns the principles text for this repo: the override file

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -74,11 +74,12 @@ Rules:
   is untested by definition, and untested code can vanish between two
   green runs without anything saying so. Write the test with the code.
 - A merge conflict is resolved hunk by hunk, by what each side was trying
-  to do — not by which lines differ. ` + "`--abort`" + ` is not a resolution: it
-  erases the attempt and the next person starts from nothing. Stuck is a
-  thing to say, not a thing to undo. Say which side's intent won where it
-  is not obvious, so a reviewer does not have to work it out from the
-  result. Read the resolved file rather than trusting its shape: git
+  to do — not by which lines differ. ` + "`git merge --abort`" + ` and
+  ` + "`git rebase --abort`" + ` are not resolutions: they erase the attempt
+  and the next person starts from nothing. Stuck is a thing to say, not a
+  thing to undo. Say which side's intent won where it is not obvious, so a
+  reviewer does not have to work it out from the result.
+  Read the resolved file rather than trusting its shape: git
   splits a conflict wherever the texts diverge, including through the
   middle of a function, so "keep both sides" can leave one of them without
   its closing lines and still look plausible.

--- a/internal/principles/principles_test.go
+++ b/internal/principles/principles_test.go
@@ -281,6 +281,12 @@ func TestThePrinciplesCarryTheDecisionRule(t *testing.T) {
 		// the middle of a function, "keep both sides" truncated a test,
 		// and only the compiler noticed.
 		"resolved hunk by hunk",
+		// Both commands named, not a bare --abort: the shipped text must
+		// be as specific as AGENTS.md and the generated rule files, or the
+		// same rule says two different things depending where it is read.
+		// Raised in review on #216.
+		"git merge --abort",
+		"git rebase --abort",
 		"middle of a function",
 		// Relaying procoder's own findings, and the override that keeps
 		// brevity away from consequences.

--- a/internal/principles/principles_test.go
+++ b/internal/principles/principles_test.go
@@ -276,6 +276,16 @@ func TestThePrinciplesCarryTheDecisionRule(t *testing.T) {
 		// rather than be rediscovered the same way.
 		"TAKE THE SNAPSHOT IMMEDIATELY BEFORE EACH MUTATION",
 		"untested by definition",
+		// Merge-conflict discipline (#193). The last clause is the one
+		// that came from a real failure here: git split a conflict through
+		// the middle of a function, "keep both sides" truncated a test,
+		// and only the compiler noticed.
+		"resolved hunk by hunk",
+		"middle of a function",
+		// Relaying procoder's own findings, and the override that keeps
+		// brevity away from consequences.
+		"Relaying a procoder report",
+		"never for consequences",
 	} {
 		if !strings.Contains(text, phrase) {
 			t.Errorf("the principles no longer say %q — the rule is the deliverable", phrase)

--- a/skills/procoder/SKILL.md
+++ b/skills/procoder/SKILL.md
@@ -42,6 +42,13 @@ back, and a file it could not check is never reported as clean.
 - Run `procoder test` before claiming anything works. NOT run is never
   green. Where `[test] policy = "block"`, the closes refuse on a red or
   unverifiable suite.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do. `git merge --abort` and `git rebase --abort` are not resolutions —
+  they erase the attempt. Being stuck is a thing to say, not a thing to
+  undo. Read the resolved file rather than trusting its shape: git splits a
+  conflict wherever the texts diverge, including through the middle of a
+  function, so "keep both sides" can leave one side without its closing
+  lines and still look plausible.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you


### PR DESCRIPTION
Closes #193.

## Merge-conflict discipline

Resolve hunk by hunk, by what each side was trying to do rather than by which lines differ. `--abort` is not a resolution — it erases the attempt and the next person starts from nothing. Being stuck is a thing to say, not a thing to undo. Say whose intent won where it isn't obvious.

**One clause is not from the issue — it's from this repository, today.** Merging `main` into #187, git split a conflict through the *middle of a function*. Resolving it as "keep both sides" left one of them without its closing lines; it compiled as far as the next function and looked entirely plausible. Only the compiler caught it.

So the rule ends: *read the resolved file rather than trusting its shape*. That failure mode isn't in the issue because it hadn't happened yet.

## Relaying a procoder report

Three lines added to the existing `Output preferences`, not a new section: lead with what blocks and how to clear it, give a count and the command past about five findings, no preamble and no closing offer of help.

The issue's override is kept intact and matters more than the caps:

> Those caps come off for anything destructive or irreversible, and for a finding a person has already asked to see in full: brevity is for reports, never for consequences.

## Cost

The injected principles go **8,874 → 9,960 bytes**, +12% on every non-resumed session start. Stated plainly because #175 was about exactly this cost, and a rule that quietly grows the payload is the thing that issue objected to.

## Verification

Four phrases pinned by `TestThePrinciplesCarryTheDecisionRule`, four mutations applied and watched to fail. `AGENTS.md` carries the merge rule for hosts that read it instead of the injection, and the twelve generated rule files are regenerated — the gate blocks on drift.

## Note

While fixing a broken edit here I used `git checkout --`, the command that silently deleted a rule earlier today. It was safe only because the work was committed — which is exactly the condition the mutation-restore rule names. Verified afterwards that nothing was lost.
