### PR TITLE
feat: the skill contract has a version, and three more weak oracles refuse

### DIFF
--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -35,6 +35,7 @@ import (
 	"procoder/internal/gate"
 	"procoder/internal/gitcmd"
 	"procoder/internal/gitx"
+	"procoder/internal/glossary"
 	"procoder/internal/hook"
 	"procoder/internal/infra"
 	"procoder/internal/initcmd"
@@ -334,6 +335,10 @@ const usage = `usage: procoder <command> [args]
                        as analyst, architect, implementer and reviewer in
                        turn; a lens that could not be loaded is a refusal,
                        never a review that silently happened
+  context <sub>        the project's shared vocabulary in .procoder/context.md —
+                       add <term> <definition> | list | check. What the team
+                       calls things, which is not always what the code calls
+                       them; reported, never blocking
   release [<version>] [--credits]
                        the pre-tag controller: version-sync across [release]
                        files, the changelog entry, a clean tree, the gate, and
@@ -701,6 +706,24 @@ func run(args []string) int {
 			force = true
 		}
 		return releases.Upgrade(version, force, upgradeConsent, printLine)
+	case "context":
+		root := doctor.Root()
+		if len(args) < 2 {
+			return usageErr(os.Stderr)
+		}
+		switch args[1] {
+		case "list":
+			return glossary.List(root, printLine)
+		case "check":
+			return glossary.Check(root, printLine)
+		case "add":
+			if len(args) < 4 {
+				printLine("context add <term> <definition>")
+				return 2
+			}
+			return glossary.Add(root, args[2], strings.Join(args[3:], " "), printLine)
+		}
+		return usageErr(os.Stderr)
 	case "prune":
 		apply := false
 		for _, a := range args[1:] {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -313,6 +313,27 @@ nothing. Without `[release] files` the version-sync leg says
 it verified nothing. Bare `procoder release` reads the newest changelog
 version and checks that.
 
+#### `procoder context <sub>`
+
+The project's shared vocabulary in `.procoder/context.md` — what the team
+calls things, which is not always what the code calls them.
+
+- `add <term> <definition>` — prints the entry to append. The binary does
+  not write the file.
+- `list` — the vocabulary, alphabetically.
+- `check` — every term has a definition, and no term is defined twice under
+  two spellings.
+
+`procoder spec check` reads it and notes when a spec appears to be
+describing something already named, which costs a reader the work of
+noticing they are the same thing.
+
+**Everything here reports and nothing refuses.** A glossary that stopped
+work over a wording disagreement would be worse than not having one. It is
+also not an ADR — an ADR is a decision with reasoning; this is vocabulary —
+and not generated from code, because the value is what a team agreed to
+call something, which is not always its identifier.
+
 #### `procoder adr <sub>`
 
 Architecture decision records under `.procoder/adr/`, numbered and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -293,6 +293,18 @@ request that is the contributor, who would then be excluded from the credit
 they are owed. With nothing configured it asks `gh` locally, so a
 repository that has set nothing still gets the rule by hand.
 
+**The skill contract.** `skills/procoder/SKILL.md` is what agents are told
+to do; its body is generated from `AGENTS.md` and its frontmatter carries a
+`contract` version. When the body changes since the last tag and that
+version does not, `procoder release` says so — an adopter upgrading would
+otherwise be governed by different rules with nothing to tell them.
+
+Reported, not refused. A wording fix changes the body too, and blocking
+every typo behind a version bump would make the bump meaningless within a
+month. The version is bumped in `internal/portability/portability.go`,
+which makes it a deliberate act rather than a field somebody edits in
+passing, and `procoder agents` regenerates the file.
+
 `procoder release --credits` runs those two checks and nothing else, and CI
 runs it on every commit with a token. That is the difference between a rule
 and a habit: until it ran in CI it ran only when whoever cut the release
@@ -563,7 +575,18 @@ that is the answer. Two of sprint 021's deviations were criteria that could
 not fail at all: one describing a narrowing that cannot happen, one on a
 fixture where the two outcomes were indistinguishable.
 
-All four refuse only while the spec is a `draft` — deliberately the moment
+Three more ways a criterion can look measured and not be, each refused:
+
+- **a command whose output cannot differ** — `echo`, a `--version`, a
+  `--help`. It prints the same thing on a working system and a broken one,
+  so the criterion has no failing branch at all.
+- **hedged vocabulary** — "mostly", "generally", "as appropriate". There is
+  no observation that contradicts them, so the criterion passes whatever
+  the code does.
+- **a bar with no number** — "fast enough", "not too many". Two people
+  reading the same result would disagree about whether it passed.
+
+All seven refuse only while the spec is a `draft` — deliberately the moment
 before the sprint opens, when a deviation is cheap. A spec already marked
 `complete` gets notes instead, because retrofitting a rule onto an archive
 nobody will rewrite is how a check gets switched off. `backlog close story`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,16 @@ That distinction is not cosmetic. An instruction nobody can follow is how
 and #185 — and it happened here, with a key added in one commit reported
 unknown by the plugin binary from the release before it.
 
+## `.procoder/context.md`
+
+The project's shared vocabulary: a `## <term>` heading per entry with a
+one-paragraph definition beneath. Written by hand or by an agent, never
+generated — the value is what the team agreed to call something.
+
+`procoder context` reads and checks it; `procoder spec check` notes when a
+spec seems to be describing a term already defined. Both report; neither
+refuses.
+
 ## Adopted and universal repositories
 
 Procoder runs two gates, and which one you get is decided from the

--- a/docs/influences.md
+++ b/docs/influences.md
@@ -69,6 +69,31 @@ draws: Procoder computes the change and hands it over; the agent
 reviews it and writes it. A rename you never saw is a change nobody
 reviewed.
 
+## From BMad Method
+
+**A different relationship from the three above.** Those were replaced.
+[BMad Method](https://github.com/bmad-code-org/BMAD-METHOD) was not, and
+the choice was deliberate: procoder learned the half it had never built,
+and separately learned to get out of the way for repositories that would
+rather run the real thing. Both halves shipped in 2.0.0.
+
+So this section is credit without a migration note. If you run BMad Method,
+keep running it — `[planning] method = "bmad"` exists so that the two do
+not compete for the same artifacts.
+
+| Concept                                                                                                   | Where it lives in Procoder                                                                                                                                                                                                                                                               |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A phase before the spec that asks whether the _idea_ is good, not only whether the _document_ is complete | `procoder analyze` — `brief`, `where`, `list`, `check`, held to the same non-hollow standard `spec check` holds a spec to                                                                                                                                                                |
+| A repository's planning artifacts can live outside `.procoder/` entirely, governed by their own tool      | `[planning] method = "bmad"` — the seam in `internal/planning/bmad.go`, which reads BMad's own `sprint-status.yaml` and its `output_folder` setting rather than copying them, and reports an unrecognised status by name instead of quietly mapping it to something procoder understands |
+| Governance reaches the same verdict about the same code whichever methodology planned it                  | `TestGovernanceIsUntouchedByThePlanningMethod` in `internal/gitcmd/seam_test.go` — asserted by a test rather than promised in prose                                                                                                                                                      |
+
+**What procoder did not take.** BMad's agent personas — the analyst, the
+architect, the scrum master — are the part it models most distinctively,
+and procoder has no equivalent. Its unit is a domain with a controller that
+refuses, not a role with a voice. Naming that plainly is the point of this
+page: the personas are not missing by oversight, and a reader comparing the
+two should know where the resemblance stops.
+
 ## Deliberately not adopted
 
 Superpowers' subagent-orchestration machinery and branch-finishing flow

--- a/internal/docs/coverage.go
+++ b/internal/docs/coverage.go
@@ -19,7 +19,7 @@ import (
 // check reads it.
 var Commands = []string{
 	"adr", "agents", "analyze", "ask", "audit", "backlog", "bench", "check", "ci",
-	"config", "copilot-leak", "debt", "deps", "docs", "doctor", "env",
+	"config", "context", "copilot-leak", "debt", "deps", "docs", "doctor", "env",
 	"format", "git", "hook", "index", "infra", "init", "lessons", "lint",
 	"maintain", "plan", "principles", "prune", "release", "review", "run", "scrub", "security", "spec",
 	"self-upgrade", "sprint", "status", "templates", "test", "todo", "version",

--- a/internal/glossary/glossary.go
+++ b/internal/glossary/glossary.go
@@ -1,0 +1,197 @@
+// Package glossary is the project's shared vocabulary: what this team
+// calls things, which is not always what the code calls them.
+//
+// It exists because the same idea gets described three different ways
+// across three specs, each one re-explaining it, and the naming drifts
+// apart as it goes. A term everybody already agreed on is shorter to write
+// and unambiguous to read (#195).
+//
+// Deliberately not an ADR and deliberately not blocking. An ADR is a
+// decision with reasoning; this is vocabulary. And a glossary that stops
+// work over a wording disagreement is worse than no glossary — so every
+// finding here reports and none of them refuse.
+package glossary
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Path is where the glossary lives, beside the other things a repository
+// tells procoder about itself.
+const Path = ".procoder/context.md"
+
+// Term is one entry: the word the team uses, and what it means here.
+type Term struct {
+	Name       string
+	Definition string
+	Line       int
+}
+
+// Load reads the glossary. A repository without one has no vocabulary
+// recorded yet, which is the ordinary case and not a problem.
+func Load(root string) []Term {
+	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(Path)))
+	if err != nil {
+		return nil
+	}
+	var out []Term
+	var current *Term
+	for i, line := range strings.Split(normaliseEOL(string(raw)), "\n") {
+		if heading := strings.TrimPrefix(line, "## "); heading != line {
+			if current != nil {
+				current.Definition = strings.TrimSpace(current.Definition)
+				out = append(out, *current)
+			}
+			current = &Term{Name: strings.TrimSpace(heading), Line: i + 1}
+			continue
+		}
+		if current != nil {
+			current.Definition += line + "\n"
+		}
+	}
+	if current != nil {
+		current.Definition = strings.TrimSpace(current.Definition)
+		out = append(out, *current)
+	}
+	return out
+}
+
+func normaliseEOL(s string) string {
+	if !strings.ContainsRune(s, '\r') {
+		return s
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
+
+// Check reports what is wrong with the glossary itself: an entry with no
+// definition, and two entries that are the same term written differently.
+//
+// Both report. Neither refuses — see the package comment.
+func Check(root string, out func(string)) int {
+	terms := Load(root)
+	if len(terms) == 0 {
+		out("no glossary — " + Path + " does not exist or records nothing")
+		return 0
+	}
+	var problems []string
+	seen := map[string]Term{}
+	for _, t := range terms {
+		if t.Name == "" {
+			problems = append(problems, fmt.Sprintf("line %d: a heading with no term", t.Line))
+			continue
+		}
+		if strings.TrimSpace(t.Definition) == "" {
+			problems = append(problems, fmt.Sprintf("line %d: %q has no definition — a term nobody defined is one everybody will define differently", t.Line, t.Name))
+		}
+		key := normalise(t.Name)
+		if first, ok := seen[key]; ok {
+			problems = append(problems, fmt.Sprintf("line %d: %q is line %d's %q written differently — one term, one entry", t.Line, t.Name, first.Line, first.Name))
+			continue
+		}
+		seen[key] = t
+	}
+	for _, t := range terms {
+		out(fmt.Sprintf("  %s", t.Name))
+	}
+	if len(problems) == 0 {
+		out(fmt.Sprintf("%d term(s), all defined", len(terms)))
+		return 0
+	}
+	for _, p := range problems {
+		out("  " + p)
+	}
+	out(fmt.Sprintf("%d term(s), %d problem(s) — reported, never blocking", len(terms), len(problems)))
+	return 0
+}
+
+// List prints the vocabulary.
+func List(root string, out func(string)) int {
+	terms := Load(root)
+	if len(terms) == 0 {
+		out("no glossary — write " + Path + " with a `## <term>` section per entry")
+		return 0
+	}
+	sort.Slice(terms, func(i, j int) bool { return terms[i].Name < terms[j].Name })
+	for _, t := range terms {
+		out(t.Name + " — " + firstLine(t.Definition))
+	}
+	return 0
+}
+
+// Add PRINTS the entry to write. The binary does not touch the file:
+// P-CONTROL, the same as `adr new` and every other authoring command here.
+func Add(root, term, definition string, out func(string)) int {
+	if strings.TrimSpace(term) == "" {
+		out("a glossary entry needs a term")
+		return 2
+	}
+	if strings.TrimSpace(definition) == "" {
+		out("a glossary entry needs a definition — a term nobody defined is one everybody will define differently")
+		return 2
+	}
+	for _, existing := range Load(root) {
+		if normalise(existing.Name) == normalise(term) {
+			out(fmt.Sprintf("%q is already defined at %s:%d — edit that entry rather than adding a second", existing.Name, Path, existing.Line))
+			return 2
+		}
+	}
+	out("== append this to " + Path + ":")
+	out("")
+	out("## " + strings.TrimSpace(term))
+	out("")
+	out(strings.TrimSpace(definition))
+	return 0
+}
+
+// Near reports glossary terms a piece of prose seems to be reinventing:
+// close to an existing term without using it.
+//
+// Conservative on purpose, and reporting rather than blocking. The cost of
+// a miss is one duplicated word; the cost of firing on every document is a
+// check people stop reading.
+func Near(terms []Term, prose string) []Term {
+	lower := strings.ToLower(prose)
+	var out []Term
+	for _, t := range terms {
+		name := normalise(t.Name)
+		if name == "" || len(name) < 4 {
+			// A short term matches too much to be evidence of anything.
+			continue
+		}
+		if strings.Contains(lower, strings.ToLower(t.Name)) {
+			continue // the prose uses the term, which is the point
+		}
+		if singular := strings.TrimSuffix(name, "s"); singular != name && strings.Contains(normalise(prose), singular) {
+			out = append(out, t)
+			continue
+		}
+		if strings.Contains(normalise(prose), name) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// normalise makes two spellings of one term comparable: case, spacing and
+// the punctuation people vary without meaning anything by it.
+func normalise(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func firstLine(s string) string {
+	if i := strings.Index(s, "\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}

--- a/internal/glossary/glossary_test.go
+++ b/internal/glossary/glossary_test.go
@@ -1,0 +1,135 @@
+package glossary
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withGlossary(t *testing.T, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	p := filepath.Join(root, filepath.FromSlash(Path))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func collect() (func(string), *[]string) {
+	var lines []string
+	return func(s string) { lines = append(lines, s) }, &lines
+}
+
+// The glossary is a flat list of terms with definitions.
+//
+// proved by: the `## ` heading test in Load inverted — nothing parses and
+// the glossary reads as empty.
+func TestLoadReadsTermsAndDefinitions(t *testing.T) {
+	root := withGlossary(t, "# Vocabulary\n\n## quality chain\n\nThe refusing controllers.\n\n## the gate\n\nWhat runs before a commit.\n")
+	terms := Load(root)
+	if len(terms) != 2 {
+		t.Fatalf("want 2 terms, got %d: %+v", len(terms), terms)
+	}
+	if terms[0].Name != "quality chain" || !strings.Contains(terms[0].Definition, "refusing controllers") {
+		t.Errorf("first term parsed wrong: %+v", terms[0])
+	}
+}
+
+// P-CONTROL: add PRINTS the entry. The binary never writes the file — the
+// same rule as `adr new` and every other authoring command here.
+//
+// proved by: an os.WriteFile added to Add — the file appears and the test
+// names it.
+func TestAddWritesNothing(t *testing.T) {
+	root := withGlossary(t, "## existing\n\nA thing.\n")
+	before, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(Path)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, lines := collect()
+	if code := Add(root, "new term", "Its definition.", out); code != 0 {
+		t.Fatalf("exit %d: %v", code, *lines)
+	}
+	after, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(Path)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("Add wrote to the glossary — the binary prints, the agent writes")
+	}
+	if !strings.Contains(strings.Join(*lines, "\n"), "## new term") {
+		t.Errorf("the entry to write was not printed: %v", *lines)
+	}
+}
+
+// A term already defined is edited, not added twice. Two entries for one
+// word is the drift a glossary exists to stop.
+//
+// proved by: the duplicate check removed from Add — a second entry is
+// printed for a term that already exists.
+func TestAddRefusesATermAlreadyDefined(t *testing.T) {
+	root := withGlossary(t, "## The Gate\n\nWhat runs before a commit.\n")
+	out, lines := collect()
+	// Different spelling, same term — case and spacing must not hide it.
+	if code := Add(root, "the gate", "Something else.", out); code == 0 {
+		t.Fatalf("a term already defined was added again: %v", *lines)
+	}
+	if !strings.Contains(strings.Join(*lines, "\n"), "already defined") {
+		t.Errorf("the refusal does not say why: %v", *lines)
+	}
+}
+
+// A term with no definition is one everybody will define differently.
+// Reported, never blocking — a glossary that refuses over wording is worse
+// than no glossary.
+//
+// proved by: the empty-definition test removed from Check — the finding
+// disappears.
+func TestCheckReportsATermWithNoDefinition(t *testing.T) {
+	root := withGlossary(t, "## orphan\n\n## defined\n\nA thing.\n")
+	out, lines := collect()
+	code := Check(root, out)
+	joined := strings.Join(*lines, "\n")
+	if code != 0 {
+		t.Errorf("check must report, never block: exit %d", code)
+	}
+	if !strings.Contains(joined, "orphan") || !strings.Contains(joined, "no definition") {
+		t.Errorf("the undefined term was not reported: %s", joined)
+	}
+}
+
+// Near is the whole point of cross-referencing: prose reinventing a word
+// the project already has. It must NOT fire when the prose uses the term,
+// or every document that mentions the vocabulary gets flagged.
+//
+// proved by: the `strings.Contains(lower, ...)` skip removed — a spec that
+// correctly uses the term is reported as reinventing it.
+func TestNearIgnoresProseThatUsesTheTerm(t *testing.T) {
+	terms := []Term{{Name: "quality chain", Definition: "x"}}
+	if got := Near(terms, "This spec extends the quality chain with another controller."); len(got) != 0 {
+		t.Fatalf("prose using the term was flagged: %+v", got)
+	}
+}
+
+// And a short term matches too much to be evidence of anything.
+//
+// Recorded honestly: the `len(name) < 4` guard is NOT what makes this
+// pass. "investigate" contains "gate", so the literal "prose uses the
+// term" skip catches it first, and removing the length guard fails
+// nothing. Verified, not assumed. The guard stays as defence for a short
+// term whose only match appears after normalisation, and this test pins
+// the behaviour rather than the mechanism.
+//
+// proved by: the literal `strings.Contains(lower, ...)` skip removed —
+// then this fixture is reported and the test names it.
+func TestNearIgnoresVeryShortTerms(t *testing.T) {
+	terms := []Term{{Name: "gate", Definition: "x"}}
+	if got := Near(terms, "We should investigate delegating this."); len(got) != 0 {
+		t.Fatalf("a short term matched unrelated prose: %+v", got)
+	}
+}

--- a/internal/portability/portability.go
+++ b/internal/portability/portability.go
@@ -73,9 +73,24 @@ license: Apache-2.0
 metadata:
   category: development
   author: pascal-watteel
+  contract: "` + ContractVersion + `"
 ---
 
 `
+
+// ContractVersion is the version of the BEHAVIOUR this skill asks for, not
+// of procoder. It is bumped when the contract changes — what the gate
+// requires before work is finished, the order the chain enforces, what an
+// agent must do rather than how it is worded (#196).
+//
+// Separate from the release version on purpose. procoder ships often and
+// the contract changes rarely, so tying them together would make every
+// patch look like a behavioural change to anybody depending on this file.
+//
+// `procoder release` reports when the skill body changed since the last
+// tag and this did not, so a contract change cannot ship silently. Bumping
+// it is a deliberate act: see docs/commands.md.
+const ContractVersion = "1"
 
 // versionedManifests are the plugin-tier manifests whose version field
 // must match .claude-plugin/plugin.json — a release where every manifest
@@ -186,6 +201,16 @@ func Agents(root string, out func(string)) int {
 		case normalize(stripFrontmatter(string(raw))) != want:
 			bad++
 			out("== " + c.Host + ": DRIFTED — rewrite " + c.Path + " with:")
+			out(c.Frontmatter + body)
+		case !strings.HasPrefix(string(raw), c.Frontmatter):
+			// The envelope, not just the body. It was compared on body
+			// alone, so a host's frontmatter could sit stale forever —
+			// which made the skill's contract marker (#196) unenforceable:
+			// a version that cannot be checked is a version nobody can
+			// trust. Reported the same way, because the fix is the same
+			// file.
+			bad++
+			out("== " + c.Host + ": FRONTMATTER DRIFTED — rewrite " + c.Path + " with:")
 			out(c.Frontmatter + body)
 		default:
 			out("   " + c.Host + ": ok (" + c.Path + ")")

--- a/internal/portability/portability_test.go
+++ b/internal/portability/portability_test.go
@@ -312,3 +312,40 @@ func TestPluginTwinIsIdentical(t *testing.T) {
 		t.Error(".kilo/plugin/procoder.js is not the .opencode/plugins/procoder.mjs source — copy it across")
 	}
 }
+
+// The envelope is compared, not only the body.
+//
+// It was body-only, which meant a host's frontmatter could sit stale
+// forever — and that made the skill's contract version (#196)
+// unenforceable: a version nothing compares is a string, not a version.
+// Found while adding that marker, when `agents` reported the file as "ok"
+// with the marker absent from it.
+//
+// proved by: the frontmatter case removed from Agents — a file with the
+// right body and the wrong envelope reports ok.
+func TestFrontmatterDriftIsReported(t *testing.T) {
+	root := t.TempDir()
+	master := filepath.Join(root, Master)
+	if err := os.WriteFile(master, []byte("# Rules\n\nBody.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Every copy written with the correct body but no frontmatter at all.
+	for _, c := range Copies {
+		p := filepath.Join(root, c.Path)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("# Rules\n\nBody.\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var lines []string
+	code := Agents(root, func(s string) { lines = append(lines, s) })
+	joined := strings.Join(lines, "\n")
+	if code == 0 {
+		t.Fatalf("a stale envelope reported clean:\n%s", joined)
+	}
+	if !strings.Contains(joined, "FRONTMATTER DRIFTED") {
+		t.Errorf("the finding does not name what drifted:\n%s", joined)
+	}
+}

--- a/internal/release/contract.go
+++ b/internal/release/contract.go
@@ -1,0 +1,99 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// SkillPath is the governance contract agents read. Its body is generated
+// from AGENTS.md; its frontmatter carries the contract version.
+const SkillPath = "skills/procoder/SKILL.md"
+
+// ContractDrift reports a skill contract that changed without saying so.
+//
+// The body of that file is what an agent is told to do. When it changes
+// and the version in its frontmatter does not, an adopter who upgrades is
+// governed by different rules with nothing to tell them — and nothing in
+// the repository would have noticed, because the version is only a string
+// until something compares it (#196).
+//
+// Reported, not refused. A wording fix changes the body too, and blocking
+// every typo behind a version bump would make the bump meaningless within
+// a month — which is how a version stops tracking anything. What this
+// buys is that the change is stated at release time, where somebody is
+// already deciding what shipped.
+func ContractDrift(root, previousTag string) []string {
+	if previousTag == "" {
+		return nil // nothing to compare against: the first release
+	}
+	was, err := fileAtTag(root, previousTag, SkillPath)
+	if err != nil {
+		// The file did not exist at that tag, or git could not answer.
+		// Neither is evidence the contract changed.
+		return nil
+	}
+	now, err := fileAtTag(root, "HEAD", SkillPath)
+	if err != nil {
+		return nil
+	}
+	if bodyOf(was) == bodyOf(now) {
+		return nil
+	}
+	oldV, newV := contractVersionOf(was), contractVersionOf(now)
+	if oldV != newV {
+		return nil // it changed and said so
+	}
+	return []string{fmt.Sprintf(
+		"%s changed since %s and its contract version is still %q — an adopter upgrading would be governed by different rules with nothing to tell them. Bump `ContractVersion` in internal/portability/portability.go and regenerate, or say in the changelog why the change does not alter the contract",
+		SkillPath, previousTag, newV)}
+}
+
+// bodyOf drops the frontmatter, so a version bump alone is not read as a
+// contract change — the version IS the announcement, not the thing
+// announced.
+func bodyOf(file string) string {
+	if !strings.HasPrefix(file, "---\n") {
+		return file
+	}
+	if i := strings.Index(file[4:], "\n---\n"); i >= 0 {
+		return file[4+i+5:]
+	}
+	return file
+}
+
+func contractVersionOf(file string) string {
+	for _, line := range strings.Split(file, "\n") {
+		t := strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(t, "contract:"); ok {
+			return strings.Trim(strings.TrimSpace(rest), `"`)
+		}
+		if strings.HasPrefix(t, "# ") {
+			break // past the frontmatter
+		}
+	}
+	return ""
+}
+
+func fileAtTag(root, ref, path string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", root, "show", ref+":"+path)
+	raw, err := cmd.Output()
+	return string(raw), err
+}
+
+// previousTag is the newest v-tag reachable from HEAD, or "" when there is
+// none — the first release, where there is nothing to compare against.
+func previousTag(root string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", root, "describe", "--tags", "--abbrev=0", "--match", "v*")
+	raw, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}

--- a/internal/release/contract_test.go
+++ b/internal/release/contract_test.go
@@ -1,0 +1,61 @@
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+// bodyOf must drop the frontmatter, or a version bump alone reads as a
+// contract change — the version IS the announcement, not the thing being
+// announced, and a check that fired on its own fix would be useless.
+//
+// proved by: bodyOf made to return its argument unchanged — the two
+// fixtures below stop comparing equal.
+func TestBodyIgnoresTheFrontmatter(t *testing.T) {
+	a := "---\nname: x\nmetadata:\n  contract: \"1\"\n---\n\n# Rules\n\nSame body.\n"
+	b := "---\nname: x\nmetadata:\n  contract: \"2\"\n---\n\n# Rules\n\nSame body.\n"
+	if bodyOf(a) != bodyOf(b) {
+		t.Fatalf("a version bump alone read as a body change:\n%q\n%q", bodyOf(a), bodyOf(b))
+	}
+	if !strings.Contains(bodyOf(a), "Same body") {
+		t.Errorf("the body was lost: %q", bodyOf(a))
+	}
+}
+
+// And the version has to be readable, or nothing can compare it.
+//
+// proved by: the `contract:` prefix test changed to an exact match on the
+// unindented key — the indented frontmatter value is never found.
+func TestContractVersionIsRead(t *testing.T) {
+	got := contractVersionOf("---\nname: x\nmetadata:\n  contract: \"7\"\n---\n\n# Rules\n")
+	if got != "7" {
+		t.Fatalf("contract version = %q, want 7", got)
+	}
+	if v := contractVersionOf("---\nname: x\n---\n\n# Rules\n"); v != "" {
+		t.Errorf("a file with no contract version reported %q", v)
+	}
+}
+
+// The scan stops at the body. A document whose PROSE mentions a contract
+// must not be read as declaring one.
+//
+// proved by: the `strings.HasPrefix(t, "# ")` break removed — the body's
+// text is scanned and a sentence becomes a version.
+func TestTheVersionScanStopsAtTheBody(t *testing.T) {
+	if v := contractVersionOf("---\nname: x\n---\n\n# Rules\n\ncontract: this is prose, not frontmatter\n"); v != "" {
+		t.Fatalf("prose in the body was read as a contract version: %q", v)
+	}
+}
+
+// No previous tag is the first release: nothing to compare against, and
+// nothing to report.
+//
+// The `previousTag == ""` guard is an early return, not the protection:
+// with no tag, `git show :path` fails and the function returns nil anyway.
+// Verified — removing it fails nothing. This pins the behaviour so a
+// future version that treats an empty ref as HEAD fails here.
+func TestNoPreviousTagReportsNothing(t *testing.T) {
+	if got := ContractDrift(t.TempDir(), ""); len(got) != 0 {
+		t.Fatalf("the first release reported contract drift: %v", got)
+	}
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -122,6 +122,8 @@ func Run(root, version string, gateClean func() bool, suite func() (bool, string
 	for _, p := range MissingCredits(root, entry) {
 		failures = append(failures, p)
 	}
+	// The skill contract, reported rather than refused — see ContractDrift.
+	contractNotes := ContractDrift(root, previousTag(root))
 
 	if len(failures) > 0 {
 		out(fmt.Sprintf("release %s is NOT ready:", version))
@@ -129,6 +131,9 @@ func Run(root, version string, gateClean func() bool, suite func() (bool, string
 			out("  " + f)
 		}
 		return 1
+	}
+	for _, n := range contractNotes {
+		out("  note: " + n)
 	}
 	out(fmt.Sprintf("release %s is ready — tag it:", version))
 	out(fmt.Sprintf("  git tag -a v%s -m %q", version, version))

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"procoder/internal/analysis"
 	"procoder/internal/answers"
+	"procoder/internal/glossary"
 	"regexp"
 	"sort"
 	"strings"
@@ -333,6 +334,17 @@ func checkOne(root, path string, out func(string)) int {
 			}
 		} else {
 			gaps = append(gaps, truth...)
+		}
+	}
+
+	// The shared vocabulary, reported and never blocking (#195). A spec
+	// describing something the project already has a word for costs a
+	// reader the work of noticing they are the same thing — and a glossary
+	// that refused over wording would be worse than not having one.
+	if near := glossary.Near(glossary.Load(root), text); len(near) > 0 {
+		for _, t := range near {
+			notes = append(notes, fmt.Sprintf("  note: this spec may be describing %q, which %s already defines — using the term is shorter to write and unambiguous to read",
+				t.Name, glossary.Path))
 		}
 	}
 

--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -505,7 +505,7 @@ func CriteriaWithoutFalsifiers(text string) []CriterionFault {
 var Commands = map[string]bool{
 	"adr": true, "agents": true, "analyze": true, "ask": true, "audit": true,
 	"backlog": true, "bench": true, "check": true, "ci": true, "config": true,
-	"copilot-leak": true, "debt": true, "deps": true, "docs": true,
+	"context": true, "copilot-leak": true, "debt": true, "deps": true, "docs": true,
 	"doctor": true, "env": true, "format": true, "git": true, "hook": true,
 	"index": true, "infra": true, "init": true, "lessons": true, "lint": true,
 	"maintain": true, "plan": true, "principles": true, "prune": true,

--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -542,7 +542,12 @@ var hedged = regexp.MustCompile(`(?i)\b(mostly|generally|as appropriate|reasonab
 // fixedOutput is a command whose result cannot differ. `echo`, a `--help`,
 // a `--version`: they print the same thing on a working system and a
 // broken one, so a criterion checking them has no failing branch at all.
-var fixedOutput = regexp.MustCompile("`[^`]*\\b(echo|true|cat\\s+[^`]*README|--help|--version|-h\\b)[^`]*`")
+// The word alternatives carry their own \b; the flag forms cannot, because
+// there is no word boundary before a hyphen. Writing one \b in front of
+// the whole group made `--help`, `--version` and `-h` match nothing at all
+// while the tests passed on `echo` alone — raised in review on #218, and
+// verified by probing each shape before the fix.
+var fixedOutput = regexp.MustCompile("`[^`]*(\\becho\\b|\\btrue\\b|\\bcat\\s+[^`]*README|--help\\b|--version\\b|(?:^|\\s)-h\\b)[^`]*`")
 
 // unmeasured is a bar nobody can hold a result against. "Fast enough" and
 // "not too many" name a threshold without giving one, so two people

--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -352,6 +352,9 @@ func TruthGaps(root, text string) []string {
 	for _, f := range CriteriaWithoutFalsifiers(text) {
 		gaps = append(gaps, fmt.Sprintf("line %d: the criterion %s", f.Line, f.Why))
 	}
+	for _, f := range WeakOracles(text) {
+		gaps = append(gaps, fmt.Sprintf("line %d: the criterion %s", f.Line, f.Why))
+	}
 	return gaps
 }
 
@@ -523,4 +526,61 @@ func normaliseEOL(s string) string {
 		return s
 	}
 	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
+
+// The remaining half of #198, after 3.2.0 took the unfalsifiable case.
+//
+// Three ways a criterion can look measured and not be. Each fires only on
+// an unambiguous shape, for the reason every rule in this file errs the
+// same way: a criterion refused wrongly gets deleted rather than fixed.
+
+// hedged is vocabulary that removes the possibility of being wrong.
+// "Mostly works" has no observation that contradicts it, so a criterion
+// written this way passes whatever the code does.
+var hedged = regexp.MustCompile(`(?i)\b(mostly|generally|as appropriate|reasonably|roughly|more or less|where sensible|if needed|should be fine|works well)\b`)
+
+// fixedOutput is a command whose result cannot differ. `echo`, a `--help`,
+// a `--version`: they print the same thing on a working system and a
+// broken one, so a criterion checking them has no failing branch at all.
+var fixedOutput = regexp.MustCompile("`[^`]*\\b(echo|true|cat\\s+[^`]*README|--help|--version|-h\\b)[^`]*`")
+
+// unmeasured is a bar nobody can hold a result against. "Fast enough" and
+// "not too many" name a threshold without giving one, so two people
+// reading the same result disagree about whether it passed.
+var unmeasured = regexp.MustCompile(`(?i)\b(fast enough|quick enough|not too (many|slow|long|big)|small enough|large enough|acceptable performance|reasonable time)\b`)
+
+// WeakOracles returns the criteria that look like measurements and are
+// not.
+//
+// Separate from UncheckableCriteria because the failure differs: that one
+// is a criterion with no observation at all, this one is a criterion whose
+// observation cannot fail. Both end the same way — a promise ticked
+// without ever being tested — and reporting them separately tells the
+// author which mistake they made.
+func WeakOracles(text string) []CriterionFault {
+	body := sectionOf(text, "Acceptance criteria")
+	if body == "" {
+		return nil
+	}
+	var out []CriterionFault
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), "- [") {
+			continue
+		}
+		criterion := joinWrapped(lines, i)
+		at := lineOf(text, "Acceptance criteria", i)
+		switch {
+		case fixedOutput.MatchString(criterion):
+			out = append(out, CriterionFault{Text: criterion, Line: at,
+				Why: "checks a command whose output cannot differ — it prints the same thing on a working system and a broken one, so this criterion has no failing branch; check something the change actually affects"})
+		case hedged.MatchString(criterion):
+			out = append(out, CriterionFault{Text: criterion, Line: at,
+				Why: "is hedged — there is no observation that contradicts \"mostly\" or \"generally\", so it passes whatever the code does; say what must be true, exactly"})
+		case unmeasured.MatchString(criterion):
+			out = append(out, CriterionFault{Text: criterion, Line: at,
+				Why: "names a bar without giving one — two people reading the same result would disagree about whether it passed; put the number in"})
+		}
+	}
+	return out
 }

--- a/internal/spec/truth_test.go
+++ b/internal/spec/truth_test.go
@@ -504,8 +504,25 @@ func TestACriterionNamingNeitherIsStillCaught(t *testing.T) {
 // the case it covers is named here as unreported.
 func TestWeakOraclesAreReported(t *testing.T) {
 	for name, tc := range map[string]struct{ criterion, want string }{
-		"fixed output": {
+		"fixed output: echo": {
 			"- [ ] [S-1] `echo ok` prints ok after the change; fails if it does not.",
+			"no failing branch",
+		},
+		// The flag forms, which the first version of this rule matched
+		// nothing at all: a single \b in front of the alternation cannot
+		// match a token starting with a hyphen, and the test covered only
+		// `echo`, so three of the four shapes were silently dead. Raised
+		// in review on #218.
+		"fixed output: --help": {
+			"- [ ] [S-1] `procoder --help` prints usage; fails if it does not.",
+			"no failing branch",
+		},
+		"fixed output: --version": {
+			"- [ ] [S-1] `procoder --version` prints the version; fails if it does not.",
+			"no failing branch",
+		},
+		"fixed output: -h": {
+			"- [ ] [S-1] `mytool -h` prints usage; fails if it does not.",
 			"no failing branch",
 		},
 		"hedged": {

--- a/internal/spec/truth_test.go
+++ b/internal/spec/truth_test.go
@@ -496,3 +496,53 @@ func TestACriterionNamingNeitherIsStillCaught(t *testing.T) {
 		t.Fatalf("a criterion naming neither a test nor a falsifier was not caught: %+v", got)
 	}
 }
+
+// #198's remaining half, after 3.2.0 took the unfalsifiable case. Three
+// ways a criterion looks measured and is not.
+//
+// proved by: each of the three regexps in turn made to match nothing —
+// the case it covers is named here as unreported.
+func TestWeakOraclesAreReported(t *testing.T) {
+	for name, tc := range map[string]struct{ criterion, want string }{
+		"fixed output": {
+			"- [ ] [S-1] `echo ok` prints ok after the change; fails if it does not.",
+			"no failing branch",
+		},
+		"hedged": {
+			"- [ ] [S-1] `procoder check` mostly reports the right findings; fails if it regresses.",
+			"hedged",
+		},
+		"unmeasured": {
+			"- [ ] [S-1] `procoder check` runs fast enough on a large repo; fails if it slows down.",
+			"without giving one",
+		},
+	} {
+		doc := truthSpec(map[string]string{"Acceptance criteria": tc.criterion})
+		got := WeakOracles(doc)
+		if len(got) != 1 {
+			t.Errorf("%s: want 1 finding, got %d: %+v", name, len(got), got)
+			continue
+		}
+		if !strings.Contains(got[0].Why, tc.want) {
+			t.Errorf("%s: the finding does not explain the fault: %q", name, got[0].Why)
+		}
+	}
+}
+
+// And a criterion that measures something real is silent — the rule is
+// worthless if it fires on the criteria it is meant to encourage.
+//
+// proved by: `hedged` widened to match any word — every good criterion is
+// refused and the checker becomes noise.
+func TestAMeasuredCriterionIsSilent(t *testing.T) {
+	for _, c := range []string{
+		"- [ ] [S-1] `procoder check` exits 1 over the fixture; fails if the branch is made unconditional.",
+		"- [ ] [S-2] The report names all three findings, asserted by `TestAllThree`.",
+		"- [ ] [S-3] `procoder prune --apply` reclaims 1.03 GB on the fixture; fails if the sweep is skipped.",
+	} {
+		doc := truthSpec(map[string]string{"Acceptance criteria": c})
+		if got := WeakOracles(doc); len(got) != 0 {
+			t.Errorf("a measured criterion was refused: %q -> %+v", c, got)
+		}
+	}
+}

--- a/skills/procoder/SKILL.md
+++ b/skills/procoder/SKILL.md
@@ -12,6 +12,7 @@ license: Apache-2.0
 metadata:
   category: development
   author: pascal-watteel
+  contract: "1"
 ---
 
 # Procoder


### PR DESCRIPTION
Closes #196. Closes #198.

## #196 — the skill contract has a version

`skills/procoder/SKILL.md` is what agents are told to do. Its body is generated from `AGENTS.md` so it changes often, and nothing said whether a given change altered the **contract** or only the wording. An adopter upgrading could be governed by different rules with nothing to tell them.

- `metadata.contract` in the frontmatter, bumped in `internal/portability/portability.go` — a deliberate act, not a field edited in passing
- `procoder release` reports when the body changed since the last tag and the version did not

**Reported, never refused.** A wording fix changes the body too, and blocking every typo behind a version bump makes the bump meaningless inside a month.

### It found a real hole

`procoder agents` compared only the **body**. So it reported `SKILL.md` as "ok" while the new marker was absent from the file entirely — a version nothing compares is a string, not a version, and the whole feature would have been decorative.

The envelope is compared now. I checked first that every other host's on-disk frontmatter already matches its constant, so the only file this flags is the one that genuinely drifted.

## #198 — three more weak oracles

The half 3.2.0 left behind. A criterion can look measured and not be:

| Shape | Why it can't fail |
| --- | --- |
| `echo ok`, `--version`, `--help` | prints the same thing on a working system and a broken one |
| "mostly", "generally", "as appropriate" | no observation contradicts them |
| "fast enough", "not too many" | two readers disagree about whether it passed |

Each is paired with a test that a *measured* criterion stays silent — a rule that fires on the criteria it exists to encourage is one people delete.

## Verification

Nine mutations applied and watched to fail, including `hedged` widened to match any word (which must break the silent-on-good-criteria test).

One survived and the claim was corrected rather than a mutation invented: the empty-previous-tag guard in `ContractDrift` is an early return, since `git show :path` fails anyway.

Checked and worth stating: existing specs reporting NOT ready is **pre-existing** — old specs lacking `[S-n]` ids, identical output before and after this change.
