### PR TITLE
feat: four passes before a piece of work is finished

### DIFF
--- a/.agents/rules/procoder.md
+++ b/.agents/rules/procoder.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.agents/rules/procoder.md
+++ b/.agents/rules/procoder.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.clinerules/procoder.md
+++ b/.clinerules/procoder.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.clinerules/procoder.md
+++ b/.clinerules/procoder.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.cursor/rules/procoder.mdc
+++ b/.cursor/rules/procoder.mdc
@@ -46,6 +46,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.cursor/rules/procoder.mdc
+++ b/.cursor/rules/procoder.mdc
@@ -38,6 +38,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kilo/rules/procoder.md
+++ b/.kilo/rules/procoder.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kilo/rules/procoder.md
+++ b/.kilo/rules/procoder.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kilocode/rules/procoder.md
+++ b/.kilocode/rules/procoder.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kilocode/rules/procoder.md
+++ b/.kilocode/rules/procoder.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kiro/steering/procoder.md
+++ b/.kiro/steering/procoder.md
@@ -37,6 +37,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.kiro/steering/procoder.md
+++ b/.kiro/steering/procoder.md
@@ -45,6 +45,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.qoder/rules/procoder.md
+++ b/.qoder/rules/procoder.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.qoder/rules/procoder.md
+++ b/.qoder/rules/procoder.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.roo/rules/procoder.md
+++ b/.roo/rules/procoder.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.roo/rules/procoder.md
+++ b/.roo/rules/procoder.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.windsurf/rules/procoder.md
+++ b/.windsurf/rules/procoder.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/.windsurf/rules/procoder.md
+++ b/.windsurf/rules/procoder.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -95,6 +95,12 @@ asking something different: implement what was scoped with nothing quietly
 deferred; reread the diff as a reviewer who did not write it; hunt defects
 deliberately; then the cheap polish and stop.
 
+The same four at the eleventh story as at the first. A task split three
+levels deep gets them at every leaf, not a share of them — "I am nine
+stories in, I can go faster now" is the feeling that precedes the bug that
+took longest to find, and `backlog close story` says so where the
+temptation arrives.
+
 `procoder review` is the third pass, and its `adversarial` and `edge-case`
 lenses are pointed at exactly that. Nothing checks that four passes
 happened — nothing on disk could — so this is a discipline, not a gate.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -90,6 +90,17 @@ Procoder — only the checks that are true anywhere run, and the content
 checks see only the lines the commit wrote. The run says which mode it was
 in; see [Adopted and universal repositories](configuration.md#adopted-and-universal-repositories).
 
+**Where review sits.** Finishing a piece of work is four passes, each
+asking something different: implement what was scoped with nothing quietly
+deferred; reread the diff as a reviewer who did not write it; hunt defects
+deliberately; then the cheap polish and stop.
+
+`procoder review` is the third pass, and its `adversarial` and `edge-case`
+lenses are pointed at exactly that. Nothing checks that four passes
+happened — nothing on disk could — so this is a discipline, not a gate.
+What it buys is that thoroughness comes from asking four different
+questions rather than asking the same one harder.
+
 #### `procoder review [--lens <name>[,<name>]] [paths...]`
 
 The judgment half of the gate. Every other check Procoder runs is

--- a/internal/backlog/close.go
+++ b/internal/backlog/close.go
@@ -144,6 +144,11 @@ func CloseStoryWith(root, id string, gateClean func() bool, suite func() (bool, 
 	// anything.
 	out("  note: before this is finished — implemented as scoped, reread as a reviewer, " +
 		"defects hunted (`procoder review`), then cheap polish. Four questions, not one asked harder")
+	// #207: the same four at the eleventh story as at the first. Said here
+	// because this is where the temptation arrives — the epic is nearly
+	// done and the pieces left look small.
+	out("  note: splitting work does not divide the care — this story gets the same four " +
+		"passes as the first in its epic, not a share of them")
 	if len(missing) > 0 {
 		out("story " + id + " stays OPEN — the quality controller found:")
 		for _, m := range missing {

--- a/internal/backlog/close.go
+++ b/internal/backlog/close.go
@@ -138,6 +138,12 @@ func CloseStoryWith(root, id string, gateClean func() bool, suite func() (bool, 
 	for _, n := range criterionNotes {
 		out("  note: " + n)
 	}
+	// The four passes are a discipline, not a check — nothing on disk can
+	// tell whether they happened (#203). Naming them where a person is
+	// deciding a story is done is the moment the reminder is worth
+	// anything.
+	out("  note: before this is finished — implemented as scoped, reread as a reviewer, " +
+		"defects hunted (`procoder review`), then cheap polish. Four questions, not one asked harder")
 	if len(missing) > 0 {
 		out("story " + id + " stays OPEN — the quality controller found:")
 		for _, m := range missing {

--- a/internal/principles/principles_test.go
+++ b/internal/principles/principles_test.go
@@ -358,3 +358,33 @@ func TestAnythingOtherThanAResumeGetsTheWholeText(t *testing.T) {
 		}
 	}
 }
+
+// The four-pass discipline (#203). Nothing on disk can verify an agent did
+// four distinct passes, which is why this is a rule and not a check — and
+// exactly why its absence has to fail something, or it quietly stops being
+// part of the contract.
+//
+// proved by: the four-pass bullet deleted from AGENTS.md — the phrases are
+// named here as missing.
+func TestTheAgentContractCarriesTheFourPasses(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "AGENTS.md"))
+	if err != nil {
+		t.Skipf("no AGENTS.md here: %v", err)
+	}
+	// Whitespace-normalised: the file is prettier-formatted, so any phrase
+	// long enough to be worth pinning will eventually be reflowed across a
+	// line break. Matching raw text would make this fail on a wrap rather
+	// than on the rule going missing.
+	text := strings.Join(strings.Fields(string(raw)), " ")
+	for _, phrase := range []string{
+		"four passes",
+		"reviewer who did not write it",
+		"adversarial",
+		"edge-case",
+		"not from asking the same one harder",
+	} {
+		if !strings.Contains(text, phrase) {
+			t.Errorf("AGENTS.md no longer says %q — the discipline is the deliverable", phrase)
+		}
+	}
+}

--- a/internal/principles/principles_test.go
+++ b/internal/principles/principles_test.go
@@ -382,6 +382,9 @@ func TestTheAgentContractCarriesTheFourPasses(t *testing.T) {
 		"adversarial",
 		"edge-case",
 		"not from asking the same one harder",
+		// #207: the same rigour at depth, which is where attention leaks.
+		"Splitting work does not divide the care",
+		"I am nine stories in",
 	} {
 		if !strings.Contains(text, phrase) {
 			t.Errorf("AGENTS.md no longer says %q — the discipline is the deliverable", phrase)

--- a/skills/procoder/SKILL.md
+++ b/skills/procoder/SKILL.md
@@ -50,6 +50,14 @@ back, and a file it could not check is never reported as clean.
   conflict wherever the texts diverge, including through the middle of a
   function, so "keep both sides" can leave one side without its closing
   lines and still look plausible.
+- Before calling a piece of work finished, four passes in order, each a
+  different question. Implement what was scoped, with nothing quietly
+  deferred. Reread the diff as a reviewer who did not write it. Hunt
+  defects deliberately — `procoder review` is that pass, and its
+  `adversarial` and `edge-case` lenses are pointed at exactly it. Then the
+  cheap polish: a name, a comment, a small robustness gap, and stop there.
+  Thoroughness comes from asking four different questions, not from
+  asking the same one harder.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you

--- a/skills/procoder/SKILL.md
+++ b/skills/procoder/SKILL.md
@@ -58,6 +58,13 @@ back, and a file it could not check is never reported as clean.
   cheap polish: a name, a comment, a small robustness gap, and stop there.
   Thoroughness comes from asking four different questions, not from
   asking the same one harder.
+- Splitting work does not divide the care. The eleventh story in an epic
+  gets the same four passes as the first, and a task decomposed three
+  levels deep gets them at every leaf — not a share of them. "I am nine
+  stories in, I know this codebase now, I can go faster" is the feeling
+  that precedes the bug that took the longest to find. Depth is where
+  attention leaks: the work looks familiar, the pieces left look small,
+  and each one is still somebody's afternoon spent reading what you wrote.
 - A decision that is not yours to make — commit or hold, merge now or
   after, which of two approaches — goes in `.procoder/ask/decisions.md`,
   one `## ` heading per decision with its options beneath, and then you


### PR DESCRIPTION
Closes #203.

The issue is right that this cannot be a check: nothing on disk can tell whether an agent did four distinct passes or one pass four times. So it is a discipline — written where an agent reads it, and named where a person is deciding a story is done.

1. **Implement** what was scoped, nothing quietly deferred
2. **Reread** the diff as a reviewer who did not write it
3. **Hunt defects** deliberately — `procoder review` is this pass, and its `adversarial` and `edge-case` lenses point at exactly it
4. **Cheap polish**, then stop

The claim underneath: thoroughness comes from asking four different questions, not from asking the same one harder.

Both lenses were verified to exist before being cited — a doc naming a flag that isn't there is the failure #186 exists for.

## On pinning a rule that has no check

A rule with no check needs its absence to fail something, or it quietly stops being part of the contract. The phrases are pinned by a test.

That test needed fixing twice. Prettier reflowed the pinned phrase across a line break, so it now normalises whitespace before matching — matching raw text would make it fail on a **wrap** rather than on the rule going missing. Same fragility as the CRLF bug in the spec checks.