### PR TITLE
feat: which carried-over items are carried and untouched

### DIFF
--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -52,6 +52,7 @@ import (
 	"procoder/internal/runcmd"
 	"procoder/internal/security"
 	"procoder/internal/spec"
+	"procoder/internal/stall"
 	"procoder/internal/status"
 	"procoder/internal/testrun"
 	"procoder/internal/todo"
@@ -1209,6 +1210,10 @@ func backlogCmd(args []string) int {
 		return backlog.List(root, out)
 	case "board":
 		return backlog.Board(root, out)
+	case "stalled":
+		// Which carried-over items are carried AND untouched. See
+		// internal/stall: the file changing is not the work moving.
+		return stall.Check(root, backlog.ItemFiles(root), 3, out)
 	case "close":
 		if len(args) < 3 {
 			return usageErr(os.Stderr)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -226,6 +226,26 @@ user stories**, with the story as the execution unit of spec-based work
 - `close epic <id>` / `close milestone <id>` — refuse while any child
   is open; epic close warns on spec drift (never blocks on it).
 
+**`backlog stalled`** — which carried-over items are carried _and_
+untouched.
+
+A story edited nine times across three sprints, criteria still unchecked
+and evidence still empty, looks busy in every other report. `sprint status`
+says "carried over"; nothing said "carried over and never advanced".
+
+The state is hashed over what carries status — the `Status:` line, which
+criteria are checked, whether evidence says anything — and everything else
+is deliberately excluded. A timestamp, a reworded paragraph, a reordered
+list: the file changed and the work did not, and a hash that moved on those
+would report every story as progressing. Evidence counts as
+present-or-absent rather than by content, because its text is rewritten as
+it is gathered and what matters is that it went from nothing to something.
+The template's own comment is not evidence.
+
+A detection aid, never a verdict. An item can legitimately wait; what this
+reports is that it waited while looking otherwise. A file git cannot answer
+for is reported as NOT checked, never as unstalled.
+
 #### `procoder sprint <sub>`
 
 Scope-boxed sprints over the backlog — a goal plus the stories pulled

--- a/internal/backlog/items.go
+++ b/internal/backlog/items.go
@@ -12,6 +12,7 @@ package backlog
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -292,4 +293,27 @@ func printItem(root, kind, slug, title string, fill func(now string) string, out
 	out("== write this to " + rel + ":")
 	out(fill(time.Now().UTC().Format("2006-01-02")))
 	return 0
+}
+
+// ItemFiles is every backlog item on disk, repository-relative.
+//
+// Stories, epics, milestones and sprints — the things whose progress a
+// person tracks. Used by the stall report, which asks git how each one
+// changed over time and needs paths git will recognise.
+func ItemFiles(root string) []string {
+	var out []string
+	for _, kind := range []string{KindMilestone, KindEpic, KindStory, KindSprint} {
+		dir := filepath.Join(root, filepath.FromSlash(Dir), kind)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue // a repository need not have every kind
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			out = append(out, path.Join(Dir, kind, e.Name()))
+		}
+	}
+	return out
 }

--- a/internal/stall/stall.go
+++ b/internal/stall/stall.go
@@ -1,0 +1,179 @@
+// Package stall tells work that is moving from work that is being edited.
+//
+// A story carried across three sprints, touched in nine commits, its
+// criteria still unchecked and its evidence still empty, looks busy in
+// every report procoder produces. `sprint status` says "carried over";
+// nothing says "carried over and never actually advanced".
+//
+// The difference is what changed. A timestamp, a reflowed paragraph, a
+// reordered list: the file is different and the WORK is not. So the state
+// is hashed over the fields that carry status — the Status line, which
+// criteria are checked, what evidence says — and everything else is
+// deliberately left out (#205).
+//
+// A detection aid, never an automatic anything. A story can legitimately
+// sit for weeks; what this reports is that it sat while looking otherwise,
+// and a person decides what that means.
+package stall
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Item is one file's stall verdict.
+type Item struct {
+	Path    string
+	Commits int    // how many times the file changed
+	Hash    string // the semantic state, now
+	Stalled bool   // changed repeatedly, meant the same thing throughout
+}
+
+var (
+	statusLine  = regexp.MustCompile(`(?m)^Status:\s*(.+?)\s*$`)
+	criterion   = regexp.MustCompile(`(?m)^\s*-\s*\[([ xX])\]`)
+	sectionHead = regexp.MustCompile(`(?m)^##\s+(.+?)\s*$`)
+)
+
+// Semantic reduces a backlog or todo file to what it MEANS: its status,
+// the checked-ness of each criterion in order, and whether its evidence
+// says anything.
+//
+// Everything else is dropped on purpose. Prose is reworded constantly
+// without the work moving, and a hash that changed when a sentence was
+// tightened would report every story as progressing.
+//
+// Evidence is reduced to present-or-absent rather than hashed: its text is
+// rewritten as it is gathered, and what matters for "did this move" is
+// that it went from nothing to something.
+func Semantic(text string) string {
+	var parts []string
+	if m := statusLine.FindStringSubmatch(text); m != nil {
+		parts = append(parts, "status="+strings.ToLower(strings.TrimSpace(m[1])))
+	}
+	var boxes []string
+	for _, m := range criterion.FindAllStringSubmatch(text, -1) {
+		if strings.TrimSpace(m[1]) == "" {
+			boxes = append(boxes, "0")
+		} else {
+			boxes = append(boxes, "1")
+		}
+	}
+	parts = append(parts, "criteria="+strings.Join(boxes, ""))
+	parts = append(parts, fmt.Sprintf("evidence=%v", hasEvidence(text)))
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// hasEvidence reports whether the Evidence section says anything a person
+// wrote, as opposed to being absent or still holding its template comment.
+func hasEvidence(text string) bool {
+	locs := sectionHead.FindAllStringSubmatchIndex(text, -1)
+	for i, loc := range locs {
+		if !strings.EqualFold(strings.TrimSpace(text[loc[2]:loc[3]]), "Evidence") {
+			continue
+		}
+		end := len(text)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		body := text[loc[1]:end]
+		// The template's own comment is not evidence of anything.
+		for {
+			a := strings.Index(body, "<!--")
+			if a < 0 {
+				break
+			}
+			b := strings.Index(body[a:], "-->")
+			if b < 0 {
+				body = body[:a]
+				break
+			}
+			body = body[:a] + body[a+b+3:]
+		}
+		return strings.TrimSpace(body) != ""
+	}
+	return false
+}
+
+// Check reports the files that changed repeatedly without ever meaning
+// something different.
+//
+// minCommits is the bar for "repeatedly": one edit is not a pattern, and
+// reporting every file touched twice would bury the ones that matter.
+func Check(root string, paths []string, minCommits int, out func(string)) int {
+	var stalled []Item
+	var unknown []string
+	for _, p := range paths {
+		hashes, err := semanticHistory(root, p)
+		if err != nil {
+			// git could not answer for this file. Not evidence of
+			// anything, and certainly not evidence of progress.
+			unknown = append(unknown, fmt.Sprintf("%s NOT checked (%v)", p, err))
+			continue
+		}
+		if len(hashes) < minCommits {
+			continue
+		}
+		distinct := map[string]bool{}
+		for _, h := range hashes {
+			distinct[h] = true
+		}
+		if len(distinct) == 1 {
+			stalled = append(stalled, Item{Path: p, Commits: len(hashes), Hash: hashes[0], Stalled: true})
+		}
+	}
+	sort.Slice(stalled, func(i, j int) bool { return stalled[i].Commits > stalled[j].Commits })
+	for _, u := range unknown {
+		out("  " + u)
+	}
+	if len(stalled) == 0 {
+		out(fmt.Sprintf("no stalled items — nothing changed %d+ times while meaning the same thing throughout", minCommits))
+		return 0
+	}
+	for _, s := range stalled {
+		out(fmt.Sprintf("  %s — %d commits, same status, same criteria, same evidence throughout", s.Path, s.Commits))
+	}
+	out(fmt.Sprintf("%d item(s) look active and are not — a detection aid, not a verdict: an item can legitimately wait, and this says only that it waited while looking otherwise", len(stalled)))
+	return 0
+}
+
+// semanticHistory is the file's semantic hash at each commit that touched
+// it, oldest first.
+func semanticHistory(root, path string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	log := exec.CommandContext(ctx, "git", "-C", root, "log", "--format=%H", "--", path) // nosemgrep -- a path from the repository's own listing
+	raw, err := log.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log: %v", firstLine(err))
+	}
+	var out []string
+	shas := strings.Fields(string(raw))
+	for i := len(shas) - 1; i >= 0; i-- { // oldest first
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+		show := exec.CommandContext(ctx2, "git", "-C", root, "show", shas[i]+":"+path) // nosemgrep -- a sha from git's own log
+		content, serr := show.Output()
+		cancel2()
+		if serr != nil {
+			continue // the file did not exist at that commit
+		}
+		out = append(out, Semantic(string(content)))
+	}
+	return out, nil
+}
+
+func firstLine(err error) string {
+	s := err.Error()
+	if i := strings.Index(s, "\n"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/stall/stall_test.go
+++ b/internal/stall/stall_test.go
@@ -1,0 +1,96 @@
+package stall
+
+import (
+	"strings"
+	"testing"
+)
+
+const story = `# A story
+
+Status: open
+Created: 2026-08-27
+Epic: something
+
+## Description
+
+The work to do.
+
+## Acceptance criteria
+
+- [ ] the first thing
+- [ ] the second thing
+
+## Evidence
+
+<!-- Filled at close time. -->
+`
+
+// Cosmetic edits are not progress. A file whose timestamp moved, whose
+// prose was reworded, whose list was reordered is a file that changed and
+// work that did not — and a report counting those as movement is what
+// makes a stalled story look busy.
+//
+// proved by: Semantic made to hash the whole text — every one of these
+// produces a different hash and the distinction disappears.
+func TestCosmeticEditsDoNotChangeTheMeaning(t *testing.T) {
+	base := Semantic(story)
+	for name, edited := range map[string]string{
+		"a new timestamp":  strings.Replace(story, "Created: 2026-08-27", "Created: 2026-09-01", 1),
+		"reworded prose":   strings.Replace(story, "The work to do.", "The work that needs doing, restated at length.", 1),
+		"extra whitespace": strings.Replace(story, "## Description", "## Description\n\n", 1),
+		"a reordered epic": strings.Replace(story, "Epic: something", "Epic: something-else", 1),
+	} {
+		if got := Semantic(edited); got != base {
+			t.Errorf("%s changed the semantic hash — cosmetic edits read as progress", name)
+		}
+	}
+}
+
+// And the three things that ARE progress must each move it, or the report
+// says nothing ever advances.
+//
+// proved by: each of the three parts dropped from Semantic in turn — the
+// change it represents stops registering.
+func TestRealProgressChangesTheMeaning(t *testing.T) {
+	base := Semantic(story)
+	for name, edited := range map[string]string{
+		"a criterion checked": strings.Replace(story, "- [ ] the first thing", "- [x] the first thing", 1),
+		"the status moved":    strings.Replace(story, "Status: open", "Status: done", 1),
+		"evidence written":    strings.Replace(story, "<!-- Filled at close time. -->", "Proved by TestSomething; the suite is green.", 1),
+	} {
+		if got := Semantic(edited); got == base {
+			t.Errorf("%s did not change the semantic hash — real progress reads as a stall", name)
+		}
+	}
+}
+
+// The template's own comment is not evidence. A story that has never been
+// touched would otherwise look like one carrying evidence from the moment
+// it was seeded.
+//
+// proved by: the comment-stripping loop removed from hasEvidence — the
+// untouched template reports as having evidence.
+func TestTheTemplateCommentIsNotEvidence(t *testing.T) {
+	if hasEvidence(story) {
+		t.Fatal("a story whose Evidence section holds only its template comment reports as having evidence")
+	}
+	written := strings.Replace(story, "<!-- Filled at close time. -->", "The suite is green.", 1)
+	if !hasEvidence(written) {
+		t.Fatal("real evidence was not recognised")
+	}
+}
+
+// A file git cannot answer for is not evidence of progress OR of a stall.
+// Reporting it as unstalled would be the quiet half of the same mistake.
+//
+// proved by: the error branch in Check changed to `continue` — the
+// unreadable file vanishes from the report entirely.
+func TestAFileGitCannotAnswerForIsReported(t *testing.T) {
+	var lines []string
+	// A directory with no git repository at all: every log fails.
+	Check(t.TempDir(), []string{"no/such/file.md"}, 3, func(s string) { lines = append(lines, s) })
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "NOT checked") {
+		t.Fatalf("a file git could not answer for was passed over silently:\n%s", joined)
+	}
+}


### PR DESCRIPTION
Closes #205.

A story edited nine times across three sprints, criteria still unchecked and evidence still empty, looks busy in every report procoder produces. `sprint status` says "carried over"; nothing said "carried over and never advanced".

## What counts as movement

Hashed over what carries status — the `Status:` line, which criteria are checked, whether evidence says anything. Everything else is excluded: a timestamp, a reworded paragraph, a reordered list is a file that changed and work that did not.

**Both directions are tested**, because either failure makes the report worthless:

| | |
| --- | --- |
| cosmetic edits | must **not** move the hash |
| status, criteria, evidence | each must |

## Two details that would otherwise be wrong

The template's own `<!-- Filled at close time -->` comment is not evidence — without that, every freshly seeded story looks like it already carries some.

Evidence counts as present-or-absent rather than by content, because its text is rewritten as it is gathered and what matters is that it went from nothing to something.

## On not-knowing

A file git cannot answer for is reported `NOT checked`, never as unstalled — the same shape as the five unknown-treated-as-none bugs found during this run of work, guarded against here rather than fixed afterwards.

A detection aid, not a verdict: an item can legitimately wait, and this says only that it waited while looking otherwise.

Six mutations applied and watched to fail. Run against this repository's own backlog: no stalled items.