### PR TITLE
feat: did the change stay where the plan said it would

### DIFF
--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -53,6 +53,7 @@ import (
 	"procoder/internal/security"
 	"procoder/internal/spec"
 	"procoder/internal/status"
+	"procoder/internal/surgical"
 	"procoder/internal/testrun"
 	"procoder/internal/todo"
 	"procoder/internal/tools"
@@ -1209,6 +1210,14 @@ func backlogCmd(args []string) int {
 		return backlog.List(root, out)
 	case "board":
 		return backlog.Board(root, out)
+	case "scope":
+		// Did the change stay where the plans said it would? Report only.
+		changed, cerr := gitx.ChangedFiles(root)
+		if cerr != nil {
+			out("scope NOT checked — the changed files could not be listed (" + cerr.Error() + ")")
+			return 0
+		}
+		return surgical.Check(root, changed, plan.Files(root), out)
 	case "close":
 		if len(args) < 3 {
 			return usageErr(os.Stderr)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -226,6 +226,28 @@ user stories**, with the story as the execution unit of spec-based work
 - `close epic <id>` / `close milestone <id>` — refuse while any child
   is open; epic close warns on spec drift (never blocks on it).
 
+**`backlog scope`** — did the change stay where the plans said it would?
+
+The failure is the drive-by edit: a change that does what was asked and
+also touches four files nowhere near it, each a small unrelated
+improvement nobody reviewed as such. The build principles already say a
+small diff in the wrong place is a second bug — but prose does not notice.
+
+A plan declares which files each task touches, and `plan check` already
+blocks a task that names none, so the declared set exists. This compares it
+against what actually changed and reports what no plan mentions. Both
+declaration spellings are read — `` **Files:** `a`, `b` `` and
+`Files: a, b` — and a plan naming a directory covers what is under it,
+because demanding every file by name makes the declaration a chore nobody
+keeps current.
+
+**Report only, and quiet when it cannot tell.** No plan, or plans that
+declare no files, reports `scope NOT checked` — there is genuinely nothing
+to compare against, and that is not the same as saying the change was
+surgical. When it does report, neither answer is automatically wrong:
+either the plan is behind the work or the work wandered, and both are worth
+a look.
+
 #### `procoder sprint <sub>`
 
 Scope-boxed sprints over the backlog — a goal plus the stories pulled

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -204,3 +204,8 @@ func planFiles(root string) []string {
 	sort.Strings(out)
 	return out
 }
+
+// Files is every plan on disk, as absolute paths. Exported for the
+// surgical-scope check, which reads the `**Files:**` lines a plan already
+// has to carry.
+func Files(root string) []string { return planFiles(root) }

--- a/internal/surgical/surgical.go
+++ b/internal/surgical/surgical.go
@@ -1,0 +1,158 @@
+// Package surgical asks whether a change stayed where it said it would.
+//
+// The failure is drive-by edits: a change that does what was asked and
+// also touches four files nowhere near it, each one a small unrelated
+// improvement nobody reviewed as such. The principles already say a bug
+// fix goes to the root cause and a small diff in the wrong place is a
+// second bug — but that is prose, and prose does not notice (#197).
+//
+// A plan declares which files each task touches; `plan check` already
+// blocks a task that names none. So the declared set exists, and the
+// changed set is a git question. This compares them.
+//
+// Report-only, and quiet when it cannot tell. A plan is not required, most
+// changes have none, and refusing on that basis would make every small
+// commit argue with a checker. What it says is narrower and true: these
+// files changed and nothing in the plan mentions them.
+package surgical
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// filesLine finds a plan task's file declaration. Both spellings, because
+// both exist: the marketplace plan writes “**Files:** `a`, `b` “ and the
+// backlog plan writes `Files: a, b` — plain, comma-separated, no ticks.
+//
+// The first version of this required backticks, and found nothing in three
+// of the four plans in this repository while the line itself matched. It
+// was caught by running the check against the real plans rather than
+// against the template, which asks for one form and does not get it.
+var (
+	filesLine = regexp.MustCompile(`(?m)^\s*\**Files:\**\s*(.+)$`)
+	ticked    = regexp.MustCompile("`([^`]+)`")
+)
+
+// paths splits a declaration into file names, accepting either spelling.
+// Backticked entries win when present, because prose around them is
+// common; otherwise the line is comma-separated paths.
+func paths(decl string) []string {
+	if m := ticked.FindAllStringSubmatch(decl, -1); len(m) > 0 {
+		var out []string
+		for _, t := range m {
+			out = append(out, strings.TrimSpace(t[1]))
+		}
+		return out
+	}
+	var out []string
+	for _, part := range strings.Split(decl, ",") {
+		part = strings.TrimSpace(part)
+		// Drop a trailing parenthetical or comment the author added.
+		if i := strings.Index(part, " ("); i > 0 {
+			part = part[:i]
+		}
+		part = strings.Trim(part, "`*")
+		if part == "" || strings.HasPrefix(part, "<!--") {
+			continue
+		}
+		out = append(out, part)
+	}
+	return out
+}
+
+// Declared is every file the plans say a task will touch.
+//
+// The union across tasks, not per task: a commit legitimately spans
+// several tasks, and attributing a file to the wrong one would produce a
+// finding about bookkeeping rather than about the change.
+func Declared(root string, planFiles []string) (map[string]bool, int) {
+	out := map[string]bool{}
+	declaring := 0
+	for _, p := range planFiles {
+		// plan.Files hands back absolute paths; a caller with
+		// repository-relative ones is equally valid. Joining root onto an
+		// already-absolute path produced a path that does not exist, and
+		// every plan was skipped in silence — which is why this reported
+		// "no plan declares files" against four plans that do.
+		full := p
+		if !filepath.IsAbs(full) {
+			full = filepath.Join(root, filepath.FromSlash(p))
+		}
+		raw, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		found := false
+		for _, m := range filesLine.FindAllStringSubmatch(string(raw), -1) {
+			for _, name := range paths(m[1]) {
+				out[path.Clean(filepath.ToSlash(name))] = true
+				found = true
+			}
+		}
+		if found {
+			declaring++
+		}
+	}
+	return out, declaring
+}
+
+// Check reports changed files no plan mentions.
+//
+// Silence when there is nothing to compare against: no plan, or plans that
+// declare no files. That is not a pass being handed out — there is
+// genuinely no declared scope, and saying so is what the caller prints.
+func Check(root string, changed []string, planFiles []string, out func(string)) int {
+	declared, declaring := Declared(root, planFiles)
+	if declaring == 0 {
+		out("scope NOT checked — no plan declares files, so there is nothing to compare a change against " +
+			"(a plan's `**Files:**` lines are the declaration; `procoder plan check` already blocks a task without one)")
+		return 0
+	}
+	var stray []string
+	for _, c := range changed {
+		rel := c
+		if r, ok := gitx.RepoRel(root, c); ok {
+			rel = r
+		}
+		rel = path.Clean(filepath.ToSlash(rel))
+		if declared[rel] || underDeclaredDir(declared, rel) {
+			continue
+		}
+		stray = append(stray, rel)
+	}
+	sort.Strings(stray)
+	if len(stray) == 0 {
+		out(fmt.Sprintf("every changed file is in the declared scope (%d file(s) declared across the plans)", len(declared)))
+		return 0
+	}
+	for _, s := range stray {
+		out("  " + s + " — changed, and no plan names it")
+	}
+	out(fmt.Sprintf("%d file(s) outside the declared scope — report only. Either the plan is behind the work, or the work wandered; both are worth a look, neither is automatically wrong",
+		len(stray)))
+	return 0
+}
+
+// underDeclaredDir lets a plan name a directory and cover what is in it.
+// A task that says `internal/gate/` has declared the files beneath it, and
+// demanding each one by name would make the declaration a maintenance
+// chore nobody keeps current.
+func underDeclaredDir(declared map[string]bool, rel string) bool {
+	for d := range declared {
+		if strings.HasSuffix(d, "/") && strings.HasPrefix(rel, d) {
+			return true
+		}
+		if !strings.Contains(path.Base(d), ".") && strings.HasPrefix(rel, d+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/surgical/surgical_test.go
+++ b/internal/surgical/surgical_test.go
@@ -1,0 +1,113 @@
+package surgical
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func planAt(t *testing.T, body string) (root, rel string) {
+	t.Helper()
+	root = t.TempDir()
+	rel = ".procoder/plans/p.md"
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, rel
+}
+
+func collect() (func(string), *[]string) {
+	var l []string
+	return func(s string) { l = append(l, s) }, &l
+}
+
+// Both spellings, because both exist in this repository: one plan writes
+// backticked names, three write plain comma-separated ones. The first
+// version accepted only backticks and found nothing in three of four while
+// the line itself matched.
+//
+// proved by: the plain-path branch removed from paths() — the unticked
+// declaration yields nothing.
+func TestBothDeclarationSpellingsAreRead(t *testing.T) {
+	for name, body := range map[string]string{
+		"plain":      "Files: internal/a/x.go, internal/a/x_test.go\n",
+		"backticked": "**Files:** `internal/a/x.go`, `internal/a/x_test.go`\n",
+	} {
+		root, rel := planAt(t, body)
+		got, declaring := Declared(root, []string{rel})
+		if declaring != 1 {
+			t.Errorf("%s: no plan counted as declaring", name)
+		}
+		if !got["internal/a/x.go"] || !got["internal/a/x_test.go"] {
+			t.Errorf("%s: parsed %v", name, got)
+		}
+	}
+}
+
+// An absolute path is as valid as a relative one — plan.Files hands back
+// absolute paths, and joining root onto those produced a path that does
+// not exist, so every plan was skipped in silence.
+//
+// proved by: the IsAbs branch removed from Declared — the absolute path is
+// joined onto root and nothing is read.
+func TestAnAbsolutePlanPathIsRead(t *testing.T) {
+	root, rel := planAt(t, "Files: internal/a/x.go\n")
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if _, declaring := Declared(root, []string{abs}); declaring != 1 {
+		t.Fatal("an absolute plan path was skipped — every plan would be, in silence")
+	}
+}
+
+// A file no plan names is the finding. That is the drive-by edit: the
+// change does what was asked and also touches something nobody reviewed as
+// part of it.
+//
+// proved by: the `declared[rel]` test inverted — the declared files are
+// reported and the stray one is not.
+func TestAFileNoPlanNamesIsReported(t *testing.T) {
+	root, rel := planAt(t, "Files: internal/a/x.go\n")
+	out, lines := collect()
+	Check(root, []string{"internal/a/x.go", "internal/b/drive_by.go"}, []string{rel}, out)
+	joined := strings.Join(*lines, "\n")
+	if !strings.Contains(joined, "drive_by.go") {
+		t.Errorf("the undeclared file was not reported:\n%s", joined)
+	}
+	if strings.Contains(joined, "internal/a/x.go —") {
+		t.Errorf("a declared file was reported as stray:\n%s", joined)
+	}
+}
+
+// A plan naming a directory covers what is under it. Demanding every file
+// by name would make the declaration a chore nobody keeps current, and a
+// stale declaration reports noise.
+//
+// proved by: underDeclaredDir made to return false — the file beneath a
+// declared directory is reported as stray.
+func TestADeclaredDirectoryCoversWhatIsUnderIt(t *testing.T) {
+	root, rel := planAt(t, "Files: internal/gate/\n")
+	out, lines := collect()
+	Check(root, []string{"internal/gate/adoption.go"}, []string{rel}, out)
+	if strings.Contains(strings.Join(*lines, "\n"), "adoption.go —") {
+		t.Fatalf("a file under a declared directory was reported as stray:\n%s", strings.Join(*lines, "\n"))
+	}
+}
+
+// No declared scope is not a pass. There is genuinely nothing to compare
+// against, and saying so is different from saying the change was surgical.
+//
+// proved by: the `declaring == 0` branch changed to report success — a
+// repository with no plans reports every change as in scope.
+func TestNoDeclaredScopeSaysSo(t *testing.T) {
+	root, rel := planAt(t, "## A plan\n\nNo file declarations at all.\n")
+	out, lines := collect()
+	Check(root, []string{"anything.go"}, []string{rel}, out)
+	joined := strings.Join(*lines, "\n")
+	if !strings.Contains(joined, "NOT checked") {
+		t.Fatalf("a plan declaring nothing reported a verdict:\n%s", joined)
+	}
+}


### PR DESCRIPTION
Closes #197.

The drive-by edit: a change that does what was asked and *also* touches four files nowhere near it, each a small unrelated improvement nobody reviewed as one. The build principles already say a small diff in the wrong place is a second bug — but prose doesn't notice.

A plan declares which files each task touches, and `plan check` already blocks a task naming none, so the declared set exists. `backlog scope` compares it against what changed.

## Two bugs found by running it against the real repository

Either would have shipped as a check that silently reported nothing:

1. **The extractor required backticked paths**, because that's what the plan *template* asks for. Three of this repo's four plans write `Files: a, b` — plain, comma-separated. The line matched; nothing was extracted.
2. **`plan.Files` returns absolute paths**, which I joined onto root again. Every plan was skipped in silence.

Together: `no plan declares files` reported against four plans that do. Both fixed, both mutation-verified.

## Honest limits, as the issue asked

No plan — or plans declaring no files — reports `scope NOT checked`. That is **not** the same as saying the change was surgical, which is exactly the distinction the issue's "known hard part" section asks for.

A plan naming a directory covers what is under it: demanding every file by name makes the declaration a chore nobody keeps current, and a stale declaration reports noise.

Five mutations applied and watched to fail.