### PR TITLE
feat: who is working on what, and what is holding work up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/changelog.md
 # the tag and publishes them; hooks/launcher.sh fetches the one this
 # machine needs and caches it here. See ADR 0009.
 /dist/
+.procoder/state/claims.json

--- a/cmd/procoder/flags.go
+++ b/cmd/procoder/flags.go
@@ -27,6 +27,7 @@ var knownFlags = map[string][]string{
 	"ci":           {"--runs"},
 	"copilot-leak": {"--since", "--quiet", "--from-copilot"},
 	"docs":         {"--ack", "--external"},
+	"claims":       {"--by"},
 	"env":          {"--sync"},
 	"index":        {"--at"},
 	"init":         {"--yes"},
@@ -142,4 +143,18 @@ func usageFor(cmd string) string {
 	// the block keeps its own indentation so the continuation lines stay
 	// aligned under the description, which is what makes it readable
 	return "usage:\n" + strings.Join(lines[start:end], "\n") + "\n"
+}
+
+// flagValue reads `--name value` out of an argument list. Absent is "",
+// which every caller treats as "not given" and refuses on when it matters.
+func flagValue(args []string, name string) string {
+	for i, a := range args {
+		if a == name && i+1 < len(args) {
+			return args[i+1]
+		}
+		if v, ok := strings.CutPrefix(a, name+"="); ok {
+			return v
+		}
+	}
+	return ""
 }

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -23,6 +23,7 @@ import (
 	"procoder/internal/backlog"
 	"procoder/internal/bench"
 	"procoder/internal/ciops"
+	"procoder/internal/claims"
 	"procoder/internal/codeindex"
 	"procoder/internal/config"
 	"procoder/internal/copilot"
@@ -335,6 +336,10 @@ const usage = `usage: procoder <command> [args]
                        as analyst, architect, implementer and reviewer in
                        turn; a lens that could not be loaded is a refusal,
                        never a review that silently happened
+  claims <sub>         who is working on what, while several agents work at
+                       once — add <glob>... --by <agent> | release --by
+                       <agent> | list. Advisory: an overlap is reported,
+                       never prevented; procoder does not own the editor
   context <sub>        the project's shared vocabulary in .procoder/context.md —
                        add <term> <definition> | list | check. What the team
                        calls things, which is not always what the code calls
@@ -722,6 +727,39 @@ func run(args []string) int {
 				return 2
 			}
 			return glossary.Add(root, args[2], strings.Join(args[3:], " "), printLine)
+		}
+		return usageErr(os.Stderr)
+	case "claims":
+		// Subcommands rather than top-level verbs: `release` is already
+		// the release controller, and one word cannot mean two things.
+		root := doctor.Root()
+		if len(args) < 2 {
+			return claims.List(root, printLine)
+		}
+		switch args[1] {
+		case "list":
+			return claims.List(root, printLine)
+		case "release":
+			by := flagValue(args[2:], "--by")
+			if by == "" {
+				printLine("claims release --by <agent> — whose claims to drop")
+				return 2
+			}
+			return claims.Release(root, by, printLine)
+		case "add":
+			by := flagValue(args[2:], "--by")
+			var globs []string
+			for i := 2; i < len(args); i++ {
+				if args[i] == "--by" {
+					i++
+					continue
+				}
+				if strings.HasPrefix(args[i], "--by=") {
+					continue
+				}
+				globs = append(globs, args[i])
+			}
+			return claims.Add(root, by, globs, time.Now(), printLine)
 		}
 		return usageErr(os.Stderr)
 	case "prune":

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -195,6 +195,17 @@ The project layer under `.procoder/backlog/`: **milestones → epics →
 user stories**, with the story as the execution unit of spec-based work
 (the todo list stays standalone for everything else).
 
+**Decisions on the board.** `board` opens with what is waiting on a person,
+and which stories say they are waiting on it. A story adds a `Blocked-by:`
+header naming the decision; the match is loose, because somebody writing
+that header shortens the question rather than pasting it.
+
+The decisions themselves stay in `.procoder/ask/decisions.md` — the agent's
+write path, and what it reaches for mid-work. This does not move them onto
+the backlog; it makes the backlog show they exist, which is the difference
+between a blocked story and one nobody has started. A decisions file
+procoder cannot read is reported as unread, never as nothing waiting.
+
 - `milestone <title>` / `epic <title> [--milestone <id>]` /
   `story <title> --epic <id>` — print each file for the agent to
   review and write; slug collisions refuse rather than overwrite.
@@ -344,6 +355,33 @@ The command comes from the repository and the binary comes from `PATH`, so
 the same declared `npm start` is a different program depending on which npm
 is first. Naming it is the difference between consenting to a command and
 consenting to a string.
+
+#### `procoder claims <sub>`
+
+Who is working on what, while several agents work at once.
+
+- `add <glob>... --by <agent>` — declare a working set, and hear about any
+  overlap
+- `release --by <agent>` — drop that agent's claims
+- `list` — who holds what, and every overlap between them
+
+The principles already say two agents never own the same file. That is
+prose, and prose does not notice: a lead fanning out four subagents has no
+way to see that two were pointed at the same package until the second one's
+edits land on the first's.
+
+**Advisory, and it cannot be otherwise.** A claim does not stop a write —
+procoder does not own the editor. What it does is make an overlap visible
+before the work collides, which is the honest half a tool can do.
+
+Overlap detection is deliberately generous: two globs that _could_ match
+the same path are reported without proof that they will. A false conflict
+costs a question; a missed one costs two agents' work. An agent never
+conflicts with itself.
+
+Claims live in `.procoder/state/claims.json`, which is gitignored — a claim
+outlives nothing but the work it describes. A ledger that exists and cannot
+be read is reported as unreadable, never as nobody holding anything.
 
 #### `procoder context <sub>`
 

--- a/internal/backlog/board.go
+++ b/internal/backlog/board.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"procoder/internal/ask"
 	"sort"
 	"strings"
 
@@ -67,6 +68,11 @@ func Board(root string, out func(string)) int {
 		out(emptyHint)
 		return 0
 	}
+	// Decisions first, because a decision is what is holding other work
+	// up, and a board that lists the work without the reason reads as
+	// nobody having started (#191).
+	printDecisions(root, items, out)
+
 	var milestones, epics, stories []Item
 	active := ""
 	for _, it := range items {
@@ -280,4 +286,62 @@ func driftFlag(root string, e Item) string {
 		return "  ⚠ spec drift"
 	}
 	return ""
+}
+
+// printDecisions shows what is waiting on a person, and which stories say
+// they are waiting on it.
+//
+// The decisions themselves live in .procoder/ask/decisions.md — the
+// agent's write path, and the thing it reaches for mid-work. This does not
+// move them onto the backlog; it makes the backlog show that they exist,
+// which is the difference between a blocked story and an unstarted one.
+func printDecisions(root string, items []Item, out func(string)) {
+	pending, notes, err := ask.PendingDecisions(root)
+	if err != nil || len(notes) > 0 {
+		// Unreadable is not "no decisions": saying nothing is waiting,
+		// because procoder could not look, is the failure this whole
+		// repository keeps finding.
+		out("DECISIONS NOT read — " + firstProblem(err, notes))
+		out("")
+		return
+	}
+	if len(pending) == 0 {
+		return
+	}
+	out(fmt.Sprintf("DECISIONS WAITING (%d) — work below may be held up by these", len(pending)))
+	for _, q := range pending {
+		head := firstLineOf(q.Text)
+		out("  ? " + head)
+		for _, it := range items {
+			if it.BlockedBy != "" && mentions(head, it.BlockedBy) {
+				out("      blocks " + it.ID)
+			}
+		}
+	}
+	out("")
+}
+
+func firstProblem(err error, notes []string) string {
+	if err != nil {
+		return err.Error()
+	}
+	if len(notes) > 0 {
+		return notes[0]
+	}
+	return "reason unknown"
+}
+
+func firstLineOf(s string) string {
+	if i := strings.Index(s, "\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}
+
+// mentions matches a story's Blocked-by: against a decision's heading
+// loosely, because a person writing the header will shorten the question
+// rather than paste it.
+func mentions(decision, blockedBy string) bool {
+	d, b := strings.ToLower(decision), strings.ToLower(strings.TrimSpace(blockedBy))
+	return b != "" && (strings.Contains(d, b) || strings.Contains(b, d))
 }

--- a/internal/backlog/decisions_test.go
+++ b/internal/backlog/decisions_test.go
@@ -1,0 +1,83 @@
+package backlog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func blockedRepo(t *testing.T, decisions, blockedBy string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range []string{".procoder/ask", ".procoder/backlog/epics", ".procoder/backlog/stories"} {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(d)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(rel, body string) {
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(rel)), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".procoder/ask/decisions.md", decisions)
+	write(".procoder/backlog/epics/e.md", "# e\n\nStatus: open\nCreated: 2026-08-27\n")
+	story := "# A story\n\nStatus: open\nCreated: 2026-08-27\nEpic: e\n"
+	if blockedBy != "" {
+		story += "Blocked-by: " + blockedBy + "\n"
+	}
+	story += "\n## Description\n\nx\n\n## Acceptance criteria\n\n- [ ] `procoder check` passes; fails if not.\n\n## Evidence\n"
+	write(".procoder/backlog/stories/s1.md", story)
+	return root
+}
+
+func lines(t *testing.T, root string) string {
+	t.Helper()
+	var out []string
+	Board(root, func(s string) { out = append(out, s) })
+	return strings.Join(out, "\n")
+}
+
+// The whole of #191: a story blocked by an undecided question looked
+// exactly like a story nobody had started.
+//
+// proved by: the printDecisions call removed from Board — the decision
+// vanishes and the blocked story is indistinguishable from an unstarted
+// one again.
+func TestABlockedStoryShowsWhatBlocksIt(t *testing.T) {
+	root := blockedRepo(t, "## Should the cache be shared between agents?\n\n- yes\n- no\n", "Should the cache be shared")
+	got := lines(t, root)
+	if !strings.Contains(got, "DECISIONS WAITING") {
+		t.Fatalf("the outstanding decision was not shown:\n%s", got)
+	}
+	if !strings.Contains(got, "blocks s1") {
+		t.Errorf("the story it blocks was not named:\n%s", got)
+	}
+}
+
+// No decisions means no section — a board that announces an empty heading
+// on every run trains people to skip it.
+//
+// proved by: the `len(pending) == 0` early return removed — the heading
+// prints with nothing under it.
+func TestNoDecisionsPrintsNothing(t *testing.T) {
+	root := blockedRepo(t, "", "")
+	if got := lines(t, root); strings.Contains(got, "DECISIONS") {
+		t.Fatalf("an empty decisions file produced a heading:\n%s", got)
+	}
+}
+
+// Unreadable is not "none waiting". Saying nothing is outstanding because
+// procoder could not look is the shape this repository has now found six
+// times.
+//
+// proved by: the error branch in printDecisions made to return silently —
+// the board reports a clean backlog over a decisions file it could not
+// read.
+func TestAnUnreadableDecisionsFileIsSaidOutLoud(t *testing.T) {
+	root := blockedRepo(t, "not a heading, just prose\n", "")
+	got := lines(t, root)
+	if !strings.Contains(got, "DECISIONS NOT read") {
+		t.Fatalf("a decisions file procoder could not parse was passed over in silence:\n%s", got)
+	}
+}

--- a/internal/backlog/items.go
+++ b/internal/backlog/items.go
@@ -43,6 +43,11 @@ var (
 	sprintRe    = regexp.MustCompile(`(?m)^Sprint:\s*(\S+)`)
 	typeRe      = regexp.MustCompile(`(?m)^Type:\s*(\S+)`)
 	severityRe  = regexp.MustCompile(`(?m)^Severity:\s*(\S+)`)
+	// A story waiting on a decision names it. Without this a blocked story
+	// looks exactly like one nobody has started, which is the whole of
+	// #191: the decisions file exists, and nothing connects it to the work
+	// it is holding up.
+	blockedByRe = regexp.MustCompile(`(?m)^Blocked-by:\s*(.+?)\s*$`)
 	// The fingerprint half is optional to MATCH so that a Spec: line without
 	// one still registers as a spec reference. It is not optional to HAVE:
 	// an epic that names a spec but records no seeding is one the board must
@@ -68,6 +73,7 @@ type Item struct {
 	SpecName  string   // epics: source spec name, "" when none
 	SpecPrint string   // epics: spec fingerprint recorded at seed time
 	Missing   []string // stories: required sections the file does not carry
+	BlockedBy string   // stories: the decision blocking this, from a Blocked-by: header
 	Path      string
 }
 
@@ -165,6 +171,9 @@ func LoadAll(root string) ([]Item, error) {
 			}
 			if m := severityRe.FindStringSubmatch(text); m != nil {
 				it.Severity = m[1]
+			}
+			if m := blockedByRe.FindStringSubmatch(text); m != nil {
+				it.BlockedBy = m[1]
 			}
 			if m := specRe.FindStringSubmatch(text); m != nil {
 				it.SpecName, it.SpecPrint = m[1], m[2]

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -1,0 +1,221 @@
+// Package claims is coordination between agents working at once, not
+// sandboxing.
+//
+// The principles already say two agents never own the same file. That is
+// prose, and prose does not notice — a lead fanning out four subagents has
+// no way to see that two of them were pointed at the same package until
+// the second one's edits land on top of the first's (#199).
+//
+// A claim is a statement of intent: "I am working on these paths". It does
+// not stop a write, and cannot — procoder does not own the editor. What it
+// does is make an overlap VISIBLE before the work collides, which is the
+// only part a tool can do honestly.
+//
+// Conservative on purpose. Two globs that COULD match the same path are
+// reported as a conflict without proof that they will, because a false
+// conflict costs a question and a missed one costs two agents' work.
+package claims
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// File is where claims live: procoder-owned session state, beside the
+// handoff note. Ephemeral by nature — a claim outlives nothing but the
+// work it describes.
+const File = ".procoder/state/claims.json"
+
+// Claim is one agent's declared working set.
+type Claim struct {
+	By     string   `json:"by"`
+	Globs  []string `json:"globs"`
+	Opened string   `json:"opened"`
+}
+
+type ledger struct {
+	Claims []Claim `json:"claims"`
+}
+
+// Load reads the ledger, and says when it could not.
+//
+// An absent file is no claims, which is the ordinary case. A file that
+// exists and cannot be read or parsed is NOT no claims — reporting it as
+// none would say "nobody else is working here" on the strength of not
+// having looked, which is the failure this package exists to prevent.
+func Load(root string) ([]Claim, error) {
+	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(File)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var l ledger
+	if err := json.Unmarshal(raw, &l); err != nil {
+		return nil, fmt.Errorf("%s is not readable JSON (%v)", File, err)
+	}
+	return l.Claims, nil
+}
+
+// Save writes the ledger. This is procoder's own session state, not
+// repository content — the same footing as the handoff note, and outside
+// P-CONTROL for the same reason.
+func Save(root string, cs []Claim) error {
+	p := filepath.Join(root, filepath.FromSlash(File))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(ledger{Claims: cs}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, append(raw, '\n'), 0o644)
+}
+
+// Overlap reports whether two globs could match the same path.
+//
+// Deliberately generous. It answers "could these collide" rather than
+// "will they", because the question being asked is whether two agents
+// might be about to write the same file, and a maybe is worth saying.
+func Overlap(a, b string) bool {
+	if a == b {
+		return true
+	}
+	// A literal path under the other's directory prefix, either way round.
+	if covers(a, b) || covers(b, a) {
+		return true
+	}
+	// Both globs: compare the fixed part before the first wildcard.
+	pa, pb := literalPrefix(a), literalPrefix(b)
+	if pa == "" || pb == "" {
+		return true // one of them is wide open
+	}
+	return strings.HasPrefix(pa, pb) || strings.HasPrefix(pb, pa)
+}
+
+func covers(glob, other string) bool {
+	if ok, _ := path.Match(glob, other); ok {
+		return true
+	}
+	dir := literalPrefix(glob)
+	return dir != "" && strings.HasPrefix(other, dir)
+}
+
+// literalPrefix is the part of a glob before its first wildcard, trimmed
+// to a path boundary so `internal/ga*` does not read as covering
+// `internal/gate/`.
+func literalPrefix(glob string) string {
+	i := strings.IndexAny(glob, "*?[")
+	if i < 0 {
+		return glob
+	}
+	p := glob[:i]
+	if j := strings.LastIndex(p, "/"); j >= 0 {
+		return p[:j+1]
+	}
+	return ""
+}
+
+// Add records a claim and reports any it overlaps.
+func Add(root, by string, globs []string, now time.Time, out func(string)) int {
+	if strings.TrimSpace(by) == "" || len(globs) == 0 {
+		out("claim <glob>... --by <agent> — who is claiming, and what")
+		return 2
+	}
+	existing, err := Load(root)
+	if err != nil {
+		out("claims NOT read (" + err.Error() + ") — refusing to claim when procoder cannot see who else holds what")
+		return 2
+	}
+	conflicts := Conflicts(existing, Claim{By: by, Globs: globs})
+	existing = append(existing, Claim{By: by, Globs: globs, Opened: now.UTC().Format(time.RFC3339)})
+	if err := Save(root, existing); err != nil {
+		out("claim NOT recorded (" + err.Error() + ")")
+		return 2
+	}
+	out(fmt.Sprintf("%s claims %s", by, strings.Join(globs, ", ")))
+	for _, c := range conflicts {
+		out("  CONFLICT " + c)
+	}
+	if len(conflicts) > 0 {
+		out("  advisory: this reports an overlap, it does not prevent a write — procoder does not own the editor. Two agents on one file is a decision for whoever is leading them")
+	}
+	return 0
+}
+
+// Conflicts is every existing claim the new one could collide with.
+func Conflicts(existing []Claim, want Claim) []string {
+	var out []string
+	for _, e := range existing {
+		if strings.EqualFold(e.By, want.By) {
+			continue // an agent does not conflict with itself
+		}
+		for _, eg := range e.Globs {
+			for _, wg := range want.Globs {
+				if Overlap(eg, wg) {
+					out = append(out, fmt.Sprintf("%s already claims %s, which overlaps %s", e.By, eg, wg))
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Release drops an agent's claims.
+func Release(root, by string, out func(string)) int {
+	existing, err := Load(root)
+	if err != nil {
+		out("claims NOT read (" + err.Error() + ")")
+		return 2
+	}
+	var kept []Claim
+	dropped := 0
+	for _, c := range existing {
+		if strings.EqualFold(c.By, by) {
+			dropped++
+			continue
+		}
+		kept = append(kept, c)
+	}
+	if err := Save(root, kept); err != nil {
+		out("claims NOT written (" + err.Error() + ")")
+		return 2
+	}
+	out(fmt.Sprintf("released %d claim(s) held by %s", dropped, by))
+	return 0
+}
+
+// List prints who holds what, and every overlap between them.
+func List(root string, out func(string)) int {
+	cs, err := Load(root)
+	if err != nil {
+		out("claims NOT read (" + err.Error() + ") — this is not the same as nobody holding anything")
+		return 2
+	}
+	if len(cs) == 0 {
+		out("no active claims")
+		return 0
+	}
+	for _, c := range cs {
+		out(fmt.Sprintf("  %-16s %s", c.By, strings.Join(c.Globs, ", ")))
+	}
+	seen := map[string]bool{}
+	for i, c := range cs {
+		for _, other := range Conflicts(cs[:i], c) {
+			if !seen[other] {
+				out("  CONFLICT " + other)
+				seen[other] = true
+			}
+		}
+	}
+	out(fmt.Sprintf("%d claim(s), %d overlap(s) — advisory: an overlap is reported, never prevented", len(cs), len(seen)))
+	return 0
+}

--- a/internal/claims/claims_test.go
+++ b/internal/claims/claims_test.go
@@ -1,0 +1,114 @@
+package claims
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func collect() (func(string), *[]string) {
+	var l []string
+	return func(s string) { l = append(l, s) }, &l
+}
+
+var when = time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+// Overlap answers "could these collide", not "will they". A maybe is worth
+// saying: a false conflict costs a question, a missed one costs two
+// agents' work.
+//
+// proved by: Overlap made to return `a == b` only — every glob pair below
+// stops conflicting and the check reports nothing useful.
+func TestOverlapIsConservative(t *testing.T) {
+	for _, c := range []struct{ a, b string }{
+		{"internal/gate/**", "internal/gate/adoption.go"},
+		{"internal/gate/", "internal/gate/gate.go"},
+		{"internal/*/x.go", "internal/gate/x.go"},
+		{"docs/a.md", "docs/a.md"},
+	} {
+		if !Overlap(c.a, c.b) {
+			t.Errorf("%q and %q could collide and were not reported", c.a, c.b)
+		}
+	}
+}
+
+// And unrelated paths must not conflict, or every claim collides with
+// every other and the report says nothing.
+//
+// proved by: literalPrefix made to return "" always — both globs read as
+// wide open and everything conflicts.
+func TestUnrelatedPathsDoNotConflict(t *testing.T) {
+	for _, c := range []struct{ a, b string }{
+		{"internal/gate/**", "internal/security/**"},
+		{"docs/a.md", "docs/b.md"},
+		{"cmd/**", "internal/**"},
+	} {
+		if Overlap(c.a, c.b) {
+			t.Errorf("%q and %q are unrelated and were reported as a conflict", c.a, c.b)
+		}
+	}
+}
+
+// An agent does not conflict with itself — claiming twice is not a
+// collision, and reporting it would train people to ignore the report.
+//
+// proved by: the EqualFold self-check removed from Conflicts — a second
+// claim by the same agent conflicts with its own first.
+func TestAnAgentDoesNotConflictWithItself(t *testing.T) {
+	existing := []Claim{{By: "alice", Globs: []string{"internal/gate/**"}}}
+	if got := Conflicts(existing, Claim{By: "alice", Globs: []string{"internal/gate/x.go"}}); len(got) != 0 {
+		t.Fatalf("an agent conflicted with its own claim: %v", got)
+	}
+}
+
+// An unreadable ledger is not an empty one. Reporting it as no claims
+// would say "nobody else is working here" on the strength of not having
+// looked — the failure this package exists to prevent, and the same shape
+// found five times elsewhere in this codebase.
+//
+// proved by: the JSON error branch in Load made to return nil, nil — the
+// corrupt ledger reads as no claims and Add proceeds.
+func TestAnUnreadableLedgerIsNotAnEmptyOne(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, filepath.FromSlash(File))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(root); err == nil {
+		t.Fatal("a corrupt ledger loaded as no claims at all")
+	}
+	out, lines := collect()
+	if code := Add(root, "alice", []string{"x/**"}, when, out); code == 0 {
+		t.Errorf("a claim was recorded against a ledger procoder could not read: %v", *lines)
+	}
+}
+
+// A claim, its conflict, and the release that clears it.
+//
+// proved by: Release made to keep every claim — the released agent still
+// holds theirs and the next claim still conflicts.
+func TestAClaimConflictsUntilItIsReleased(t *testing.T) {
+	root := t.TempDir()
+	out, _ := collect()
+	Add(root, "alice", []string{"internal/gate/**"}, when, out)
+
+	out2, lines2 := collect()
+	Add(root, "bob", []string{"internal/gate/adoption.go"}, when, out2)
+	if !strings.Contains(strings.Join(*lines2, "\n"), "CONFLICT") {
+		t.Fatalf("the overlap was not reported: %v", *lines2)
+	}
+
+	out3, _ := collect()
+	Release(root, "alice", out3)
+
+	out4, lines4 := collect()
+	Add(root, "carol", []string{"internal/gate/gate.go"}, when, out4)
+	if strings.Contains(strings.Join(*lines4, "\n"), "alice") {
+		t.Fatalf("a released claim still conflicts: %v", *lines4)
+	}
+}

--- a/internal/docs/coverage.go
+++ b/internal/docs/coverage.go
@@ -18,7 +18,7 @@ import (
 // procoder's own inventory, not a rule any other repository is held to — no
 // check reads it.
 var Commands = []string{
-	"adr", "agents", "analyze", "ask", "audit", "backlog", "bench", "check", "ci",
+	"adr", "agents", "analyze", "ask", "audit", "backlog", "bench", "check", "ci", "claims",
 	"config", "context", "copilot-leak", "debt", "deps", "docs", "doctor", "env",
 	"format", "git", "hook", "index", "infra", "init", "lessons", "lint",
 	"maintain", "plan", "principles", "prune", "release", "review", "run", "scrub", "security", "spec",

--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -507,7 +507,7 @@ func CriteriaWithoutFalsifiers(text string) []CriterionFault {
 // TestCommandsMatchTheDocsCoverageList pins the two together.
 var Commands = map[string]bool{
 	"adr": true, "agents": true, "analyze": true, "ask": true, "audit": true,
-	"backlog": true, "bench": true, "check": true, "ci": true, "config": true,
+	"backlog": true, "bench": true, "check": true, "ci": true, "claims": true, "config": true,
 	"context": true, "copilot-leak": true, "debt": true, "deps": true, "docs": true,
 	"doctor": true, "env": true, "format": true, "git": true, "hook": true,
 	"index": true, "infra": true, "init": true, "lessons": true, "lint": true,


### PR DESCRIPTION
Closes #199. Closes #191.

Two coordination gaps, one branch, because they're the same subject: making visible what several agents working at once cannot see.

## #199 — claims

The principles say two agents never own the same file. Prose doesn't notice: a lead fanning out four subagents has no way to see that two were pointed at the same package until the second one's edits land on the first's.

`procoder claims add <glob>... --by <agent>` declares a working set and reports overlaps.

**Advisory, and it cannot be otherwise** — a claim does not stop a write, because procoder does not own the editor. What it does is make the collision visible before it happens.

Overlap detection is deliberately generous: two globs that *could* match the same path are reported without proof they will. A false conflict costs a question; a missed one costs two agents' work.

Subcommands rather than top-level verbs, because `release` is already the release controller and one word can't mean two things.

## #191 — decisions on the board

3.2.0 gave a decision somewhere to live; nothing connected it to the work it was holding up, so a **blocked story looked exactly like one nobody had started**. `backlog board` now opens with what's waiting on a person and which stories say they wait on it.

The decisions stay in `.procoder/ask/decisions.md` rather than moving onto the backlog — that's the agent's write path, what it reaches for mid-work, and asking it to open a backlog item at that moment is asking it to stop doing the thing that raised the question.

## On not-knowing

Both guard the shape this repository has now found six times: an unreadable ledger reports as unreadable, an unreadable decisions file as unread — never as nothing being there. **First time that guard was written before the bug rather than after review found it.**

## What the gate caught

`--by` was implemented and not registered in `knownFlags`, so it would have been **refused at runtime** — a command that couldn't work as documented. Third of this repo's own pinning tests to earn its keep today.

Nine mutations applied and watched to fail.