### PR TITLE
feat: whether a fan-out was actually parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/changelog.md
 # the tag and publishes them; hooks/launcher.sh fetches the one this
 # machine needs and caches it here. See ADR 0009.
 /dist/
+.procoder/state/dispatch.json

--- a/cmd/procoder/flags.go
+++ b/cmd/procoder/flags.go
@@ -27,6 +27,7 @@ var knownFlags = map[string][]string{
 	"ci":           {"--runs"},
 	"copilot-leak": {"--since", "--quiet", "--from-copilot"},
 	"docs":         {"--ack", "--external"},
+	"dispatch":     {"--task"},
 	"env":          {"--sync"},
 	"index":        {"--at"},
 	"init":         {"--yes"},
@@ -142,4 +143,18 @@ func usageFor(cmd string) string {
 	// the block keeps its own indentation so the continuation lines stay
 	// aligned under the description, which is what makes it readable
 	return "usage:\n" + strings.Join(lines[start:end], "\n") + "\n"
+}
+
+// flagValue reads `--name value` out of an argument list. Absent is "",
+// which every caller treats as "not given" and refuses on when it matters.
+func flagValue(args []string, name string) string {
+	for i, a := range args {
+		if a == name && i+1 < len(args) {
+			return args[i+1]
+		}
+		if v, ok := strings.CutPrefix(a, name+"="); ok {
+			return v
+		}
+	}
+	return ""
 }

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -28,6 +28,7 @@ import (
 	"procoder/internal/copilot"
 	"procoder/internal/debt"
 	"procoder/internal/deps"
+	"procoder/internal/dispatch"
 	"procoder/internal/docs"
 	"procoder/internal/doctor"
 	"procoder/internal/envsync"
@@ -335,6 +336,11 @@ const usage = `usage: procoder <command> [args]
                        as analyst, architect, implementer and reviewer in
                        turn; a lens that could not be loaded is a refusal,
                        never a review that silently happened
+  dispatch <sub>       whether a fan-out was actually parallel —
+                       open <wave> | start <wave> --task <id> | seal <wave> |
+                       return <wave> --task <id> | status [wave]. A return
+                       before the seal is the signature of serial work.
+                       Advisory: it makes the claim checkable, not true
   context <sub>        the project's shared vocabulary in .procoder/context.md —
                        add <term> <definition> | list | check. What the team
                        calls things, which is not always what the code calls
@@ -724,6 +730,16 @@ func run(args []string) int {
 			return glossary.Add(root, args[2], strings.Join(args[3:], " "), printLine)
 		}
 		return usageErr(os.Stderr)
+	case "dispatch":
+		if len(args) < 2 {
+			printLine("dispatch open|start|seal|return|status <wave-id> [--task <id>]")
+			return 2
+		}
+		id := ""
+		if len(args) > 2 && !strings.HasPrefix(args[2], "--") {
+			id = args[2]
+		}
+		return dispatch.Run(doctor.Root(), args[1], id, flagValue(args[2:], "--task"), time.Now(), printLine)
 	case "prune":
 		apply := false
 		for _, a := range args[1:] {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -345,6 +345,39 @@ the same declared `npm start` is a different program depending on which npm
 is first. Naming it is the difference between consenting to a command and
 consenting to a string.
 
+#### `procoder dispatch <sub>`
+
+Whether a fan-out was actually parallel.
+
+The principles tell an agent to launch independent work together rather
+than grinding through it serially. Nothing checked, and the difference is
+invisible afterwards: an agent that ran three subagents one at a time and
+narrated it as parallel produces the same transcript as one that did it
+properly.
+
+- `open <wave>` — start recording a fan-out
+- `start <wave> --task <id>` — once per task, **before anything is awaited**
+- `seal <wave>` — no more tasks may join
+- `return <wave> --task <id>` — a task came back
+- `status [wave]` — the verdict
+
+**A return recorded before the seal is the signature of serial work**: that
+task finished before the last one was launched, which is precisely what
+parallel means it should not have done. The early return is remembered when
+it happens, because by the time anybody asks, the seal has usually been
+called and the evidence would be gone.
+
+Three verdicts, and the middle one matters: `parallel`, `NOT parallel`, and
+`NOT verified` for a wave nobody sealed. Not verified is **not** the same
+as verified serial — it says nobody recorded the barrier, which is a
+different claim from saying the work was serial.
+
+**Advisory.** procoder cannot stop an agent calling this dishonestly, or at
+all. What it does is make the claim checkable, which turns "I ran them in
+parallel" from narration into something with a record behind it — and it
+catches the honest mistake, genuinely serial work honestly recorded, which
+is the common one.
+
 #### `procoder context <sub>`
 
 The project's shared vocabulary in `.procoder/context.md` — what the team

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1,0 +1,211 @@
+// Package dispatch records whether a fan-out was actually parallel.
+//
+// The principles tell an agent to launch independent work together rather
+// than grinding through it serially. Nothing checked, and the difference
+// is invisible afterwards: an agent that ran three subagents one at a
+// time and narrated it as parallel produces the same transcript as one
+// that did it properly (#202).
+//
+// The states are a barrier. Every task in a wave is STARTED, then the wave
+// is SEALED, and only then may anything RETURN. A return recorded before
+// the seal is the signature of serial work — the first task finished
+// before the last was launched, which is precisely what parallel means it
+// should not have done.
+//
+// Advisory, and the issue says so itself: procoder cannot stop an agent
+// calling this dishonestly, or at all. What it can do is make the claim
+// checkable, which turns "I ran them in parallel" from a narration into
+// something with a record behind it. It catches the honest mistake
+// — genuinely serial work, honestly recorded — and that is the common one.
+package dispatch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// File is where waves live: procoder's own session state, beside the
+// handoff note and the claims ledger.
+const File = ".procoder/state/dispatch.json"
+
+// Wave is one fan-out.
+type Wave struct {
+	ID string `json:"id"`
+	// Started, in the order the tasks were launched.
+	Started []string `json:"started"`
+	// Sealed is when no more tasks may join. Empty means still open.
+	Sealed string `json:"sealed,omitempty"`
+	// Returned, in the order they came back.
+	Returned []string `json:"returned"`
+	// EarlyReturn is a task that came back before the wave was sealed.
+	// Recorded when it happens, because by the time status is asked the
+	// seal has usually been called and the evidence would be gone.
+	EarlyReturn []string `json:"early_return,omitempty"`
+}
+
+type ledger struct {
+	Waves []Wave `json:"waves"`
+}
+
+// Load reads the ledger, and says when it could not. An absent file is no
+// waves; a file that exists and will not parse is not the same thing, and
+// reporting it as none would be claiming every wave was clean on the
+// strength of not having looked.
+func Load(root string) ([]Wave, error) {
+	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(File)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var l ledger
+	if err := json.Unmarshal(raw, &l); err != nil {
+		return nil, fmt.Errorf("%s is not readable JSON (%v)", File, err)
+	}
+	return l.Waves, nil
+}
+
+// Save writes the ledger — session state, not repository content.
+func Save(root string, ws []Wave) error {
+	p := filepath.Join(root, filepath.FromSlash(File))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(ledger{Waves: ws}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, append(raw, '\n'), 0o644)
+}
+
+func find(ws []Wave, id string) int {
+	for i, w := range ws {
+		if w.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// Apply performs one transition and returns the ledger to save.
+//
+// Split out from the command so the barrier itself is testable without a
+// filesystem: the rule is the interesting part, not the plumbing.
+func Apply(ws []Wave, verb, id, task string, now time.Time) ([]Wave, string, int) {
+	i := find(ws, id)
+	switch verb {
+	case "open":
+		if i >= 0 {
+			return ws, fmt.Sprintf("wave %q already exists — pick another id rather than reopening one whose record you would be overwriting", id), 2
+		}
+		return append(ws, Wave{ID: id}), fmt.Sprintf("wave %s open", id), 0
+	case "start":
+		if i < 0 {
+			return ws, fmt.Sprintf("no wave %q — open it first", id), 2
+		}
+		if ws[i].Sealed != "" {
+			return ws, fmt.Sprintf("wave %s is sealed — a task starting after the seal was not part of the wave, and recording it as one would make the barrier meaningless", id), 2
+		}
+		ws[i].Started = append(ws[i].Started, task)
+		return ws, fmt.Sprintf("wave %s started %s (%d launched)", id, task, len(ws[i].Started)), 0
+	case "seal":
+		if i < 0 {
+			return ws, fmt.Sprintf("no wave %q — open it first", id), 2
+		}
+		if ws[i].Sealed != "" {
+			return ws, fmt.Sprintf("wave %s is already sealed", id), 0
+		}
+		ws[i].Sealed = now.UTC().Format(time.RFC3339)
+		return ws, fmt.Sprintf("wave %s sealed — %d task(s) launched before anything was awaited", id, len(ws[i].Started)), 0
+	case "return":
+		if i < 0 {
+			return ws, fmt.Sprintf("no wave %q — open it first", id), 2
+		}
+		ws[i].Returned = append(ws[i].Returned, task)
+		if ws[i].Sealed == "" {
+			// The signature of serial work: this one finished before the
+			// last was launched. Recorded now, because by the time anybody
+			// asks, the seal will have been called and the evidence gone.
+			ws[i].EarlyReturn = append(ws[i].EarlyReturn, task)
+			return ws, fmt.Sprintf("wave %s returned %s BEFORE the seal — this task finished before the wave stopped accepting launches, which is what serial work looks like", id, task), 0
+		}
+		return ws, fmt.Sprintf("wave %s returned %s (%d of %d)", id, task, len(ws[i].Returned), len(ws[i].Started)), 0
+	}
+	return ws, "unknown dispatch verb " + verb, 2
+}
+
+// Status reports the verdict for one wave, or all of them.
+func Status(root, id string, out func(string)) int {
+	ws, err := Load(root)
+	if err != nil {
+		out("dispatch NOT read (" + err.Error() + ") — which is not the same as no waves having run")
+		return 2
+	}
+	if len(ws) == 0 {
+		out("no waves recorded")
+		return 0
+	}
+	sort.Slice(ws, func(i, j int) bool { return ws[i].ID < ws[j].ID })
+	for _, w := range ws {
+		if id != "" && w.ID != id {
+			continue
+		}
+		out(Verdict(w))
+	}
+	return 0
+}
+
+// Verdict is the one-line answer for a wave.
+//
+// Three outcomes, and the middle one is the point: not verified is not the
+// same as verified serial. A wave still open, or one nobody sealed, has
+// not been shown to be parallel — and saying so is different from saying
+// it was not.
+func Verdict(w Wave) string {
+	switch {
+	case len(w.EarlyReturn) > 0:
+		return fmt.Sprintf("  %s: NOT parallel — %s returned before the wave was sealed, so the first finished before the last was launched",
+			w.ID, strings.Join(w.EarlyReturn, ", "))
+	case w.Sealed == "":
+		return fmt.Sprintf("  %s: NOT verified — %d started, never sealed. Nothing here says the wave was serial; it says nobody recorded the barrier",
+			w.ID, len(w.Started))
+	default:
+		return fmt.Sprintf("  %s: parallel — %d task(s) launched before the first was awaited, %d returned",
+			w.ID, len(w.Started), len(w.Returned))
+	}
+}
+
+// Run is the command surface.
+func Run(root, verb, id, task string, now time.Time, out func(string)) int {
+	if verb == "status" {
+		return Status(root, id, out)
+	}
+	if strings.TrimSpace(id) == "" {
+		out("dispatch " + verb + " <wave-id> — which wave")
+		return 2
+	}
+	if (verb == "start" || verb == "return") && strings.TrimSpace(task) == "" {
+		out("dispatch " + verb + " <wave-id> --task <id> — which task")
+		return 2
+	}
+	ws, err := Load(root)
+	if err != nil {
+		out("dispatch NOT read (" + err.Error() + ") — refusing to record against a ledger procoder cannot see")
+		return 2
+	}
+	ws, msg, code := Apply(ws, verb, id, task, now)
+	if code == 0 {
+		if serr := Save(root, ws); serr != nil {
+			out("dispatch NOT recorded (" + serr.Error() + ")")
+			return 2
+		}
+	}
+	out(msg)
+	return code
+}

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1,0 +1,127 @@
+package dispatch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var when = time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+// A wave launched properly: every task started, then sealed, then returns.
+//
+// proved by: the `w.Sealed == ""` test in Apply's return branch inverted —
+// a correct wave records an early return and reads as serial.
+func TestAWaveLaunchedTogetherReadsAsParallel(t *testing.T) {
+	var ws []Wave
+	ws, _, _ = Apply(ws, "open", "w", "", when)
+	ws, _, _ = Apply(ws, "start", "w", "a", when)
+	ws, _, _ = Apply(ws, "start", "w", "b", when)
+	ws, _, _ = Apply(ws, "seal", "w", "", when)
+	ws, _, _ = Apply(ws, "return", "w", "a", when)
+	if v := Verdict(ws[0]); !strings.Contains(v, "parallel") || strings.Contains(v, "NOT") {
+		t.Fatalf("a correctly launched wave did not read as parallel: %s", v)
+	}
+}
+
+// The check that matters: a return before the seal means the first task
+// finished before the last was launched, which is what serial work is.
+//
+// proved by: the EarlyReturn append removed — serial work reads as
+// parallel and the whole barrier does nothing.
+func TestAReturnBeforeTheSealIsNotParallel(t *testing.T) {
+	var ws []Wave
+	ws, _, _ = Apply(ws, "open", "w", "", when)
+	ws, _, _ = Apply(ws, "start", "w", "a", when)
+	ws, _, _ = Apply(ws, "return", "w", "a", when) // before the seal
+	ws, _, _ = Apply(ws, "start", "w", "b", when)
+	ws, _, _ = Apply(ws, "seal", "w", "", when)
+	v := Verdict(ws[0])
+	if !strings.Contains(v, "NOT parallel") {
+		t.Fatalf("serial work read as parallel: %s", v)
+	}
+	// The evidence has to survive the later seal, or asking afterwards
+	// finds a wave that looks clean.
+	if len(ws[0].EarlyReturn) != 1 {
+		t.Errorf("the early return was not remembered: %+v", ws[0])
+	}
+}
+
+// Not verified is not the same as verified serial. A wave nobody sealed
+// has not been shown to be parallel — and saying that is different from
+// saying it was not.
+//
+// proved by: the `w.Sealed == ""` case removed from Verdict — an unsealed
+// wave reports as parallel on no evidence.
+func TestAnUnsealedWaveIsNotVerifiedRatherThanSerial(t *testing.T) {
+	var ws []Wave
+	ws, _, _ = Apply(ws, "open", "w", "", when)
+	ws, _, _ = Apply(ws, "start", "w", "a", when)
+	v := Verdict(ws[0])
+	if !strings.Contains(v, "NOT verified") {
+		t.Fatalf("an unsealed wave did not report as unverified: %s", v)
+	}
+	if strings.Contains(v, "NOT parallel") {
+		t.Errorf("an unsealed wave was reported as serial, which is a claim nothing supports: %s", v)
+	}
+}
+
+// A task starting after the seal was not part of the wave. Accepting it
+// would let an agent seal early, keep launching, and collect a clean
+// verdict.
+//
+// proved by: the sealed check removed from the start branch — a late task
+// joins and the barrier means nothing.
+func TestATaskCannotJoinAfterTheSeal(t *testing.T) {
+	var ws []Wave
+	ws, _, _ = Apply(ws, "open", "w", "", when)
+	ws, _, _ = Apply(ws, "seal", "w", "", when)
+	ws, msg, code := Apply(ws, "start", "w", "late", when)
+	if code == 0 {
+		t.Fatalf("a task joined a sealed wave: %s", msg)
+	}
+	if len(ws[0].Started) != 0 {
+		t.Errorf("the late task was recorded anyway: %+v", ws[0])
+	}
+}
+
+// Reopening a wave would overwrite the record of what happened.
+//
+// proved by: the existing-wave check removed from open — the second open
+// silently replaces the first wave's history.
+func TestAWaveCannotBeReopened(t *testing.T) {
+	var ws []Wave
+	ws, _, _ = Apply(ws, "open", "w", "", when)
+	ws, _, code := Apply(ws, "open", "w", "", when)
+	if code == 0 {
+		t.Fatal("a wave was reopened, overwriting its record")
+	}
+	if len(ws) != 1 {
+		t.Errorf("a duplicate wave was appended: %d", len(ws))
+	}
+}
+
+// An unreadable ledger is not "no waves ran" — the shape this repository
+// has found six times, guarded here rather than fixed later.
+//
+// proved by: the JSON error branch in Load made to return nil, nil — a
+// corrupt ledger reports no waves and Status reports success.
+func TestAnUnreadableLedgerIsNotNoWaves(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, filepath.FromSlash(File))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(root); err == nil {
+		t.Fatal("a corrupt ledger loaded as no waves")
+	}
+	var lines []string
+	if code := Status(root, "", func(s string) { lines = append(lines, s) }); code == 0 {
+		t.Errorf("status reported success over a ledger it could not read: %v", lines)
+	}
+}

--- a/internal/docs/coverage.go
+++ b/internal/docs/coverage.go
@@ -19,7 +19,7 @@ import (
 // check reads it.
 var Commands = []string{
 	"adr", "agents", "analyze", "ask", "audit", "backlog", "bench", "check", "ci",
-	"config", "context", "copilot-leak", "debt", "deps", "docs", "doctor", "env",
+	"config", "context", "copilot-leak", "debt", "deps", "dispatch", "docs", "doctor", "env",
 	"format", "git", "hook", "index", "infra", "init", "lessons", "lint",
 	"maintain", "plan", "principles", "prune", "release", "review", "run", "scrub", "security", "spec",
 	"self-upgrade", "sprint", "status", "templates", "test", "todo", "version",

--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -508,7 +508,7 @@ func CriteriaWithoutFalsifiers(text string) []CriterionFault {
 var Commands = map[string]bool{
 	"adr": true, "agents": true, "analyze": true, "ask": true, "audit": true,
 	"backlog": true, "bench": true, "check": true, "ci": true, "config": true,
-	"context": true, "copilot-leak": true, "debt": true, "deps": true, "docs": true,
+	"context": true, "copilot-leak": true, "debt": true, "deps": true, "dispatch": true, "docs": true,
 	"doctor": true, "env": true, "format": true, "git": true, "hook": true,
 	"index": true, "infra": true, "init": true, "lessons": true, "lint": true,
 	"maintain": true, "plan": true, "principles": true, "prune": true,


### PR DESCRIPTION
Closes #202.

The principles tell an agent to launch independent work together rather than grinding through it serially. Nothing checked — and the difference is invisible afterwards: an agent that ran three subagents one at a time and narrated it as parallel produces the same transcript as one that did it properly.

## The barrier

Every task `start`ed, then the wave `seal`ed, and only then may anything `return`.

**A return recorded before the seal is the signature of serial work**: that task finished before the last was launched, which is precisely what parallel means it should not have done. The early return is remembered *when it happens*, because by the time anybody asks, the seal has been called and the evidence would be gone.

## Three verdicts, and the middle one is the point

| Verdict | Means |
| --- | --- |
| `parallel` | all launched before the first was awaited |
| `NOT parallel` | something returned before the seal |
| `NOT verified` | nobody sealed it |

**Not verified is not verified serial.** It says nobody recorded the barrier — a different claim from saying the work was serial, and collapsing them would be the silent green in reverse.

## Advisory, as the issue states

procoder cannot stop an agent calling this dishonestly, or at all. What it does is make the claim checkable, and it catches the honest mistake — genuinely serial work, honestly recorded — which is the common one.

## A triage correction

I flagged this as possibly not buildable. Reading its acceptance criteria rather than its summary, it was buildable all along, with the same honest limit as the claims ledger.

Judging an issue by its summary is the failure #186 exists for — made during the triage that shipped #186's fix.

Five mutations applied and watched to fail, including the early-return record and the corrupt-ledger guard.