### PR TITLE
docs: the limits, the layer, the sources, and the evidence

### DIFF
--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -46,3 +46,103 @@ roadmap. They are one cluster and none is small.
 - label both roadmap: the cluster reads as direction rather than queued
   work, which is what the label was created for.
 - leave them unlabelled: they stay in the ordinary queue.
+
+## Remove the cached 3.1.0 plugin too, or keep it as the rollback?
+
+**Decided: keep 3.1.0.** The rollback is worth 45 MB; prune's
+active-plus-one-previous policy stands as written.
+
+`procoder prune --apply` removed 3.0.0 and reclaimed 45 MB. It kept 3.1.0
+deliberately: the policy is the active version plus one previous, so a
+release that misbehaves has somewhere to fall back to. Removing 3.1.0 is
+outside what prune will do — it would be a manual `rm -rf` of
+`~/.claude/plugins/cache/procoder/procoder/3.1.0`.
+
+The trade is a fixed ~45 MB against the one-step rollback. Note that 3.1.0
+is now three releases behind and predates `release.maintainers`, so as a
+rollback target it would reintroduce the false positive that blocked the
+3.3.0 release commit.
+
+- keep 3.1.0: prune's own policy, and a rollback that costs 45 MB.
+- remove 3.1.0: reclaims the space; rollback then means reinstalling from
+  the marketplace rather than a local directory.
+
+## `procoder wizard` (#192): what shape may it take?
+
+CORRECTED after reading the code. An earlier pass here claimed #192
+contradicts AGENTS.md and that #200 shipped a fingerprinted approval to
+gate it on. Both were wrong, and both came from grepping a summary line
+instead of reading what shipped.
+
+The rule reads "never executed AUTOMATICALLY", and it names `procoder run`
+as the shape to copy: prints the candidates, executes only under `--exec`,
+refuses when more than one candidate exists. `procoder run --exec` already
+executes a command the repository declared. So a human typing
+`procoder wizard run <name>` is the sanctioned shape, not a violation.
+
+What #200 actually shipped is ten lines in internal/runcmd/runcmd.go that
+print which binary `--exec` resolved to on PATH. There is no fingerprint
+store and no approval record. Anything needing one builds it first.
+
+**Decided: the `procoder run` shape.** Print by default, execute under an
+explicit flag, refuse rather than guess. No new boundary, no new mechanism.
+
+- build it in the `procoder run` shape: print by default, execute under an
+  explicit flag, refuse rather than guess. No new boundary needed.
+- build the fingerprinted approval first, then the wizard on top of it.
+- close #192: the manual procedures it targets (#66-#73) are one-offs.
+
+## What is next after v3.3.0?
+
+**Decided: all of them.** Working the six roadmap issues in dependency
+order: #194, then #211, then #209 (the docs cluster, which cross-reference
+each other), then #192, then #189, then #190 last as the largest.
+
+The ordinary queue is empty; all six open issues are roadmap-labelled.
+
+- #189 SKILL.md hardening: smallest, and its own research note calls it the
+  single highest-leverage change. Three of its four criteria still apply.
+- #194 + #211 docs cluster: pitfalls tables, honest-limits, positioning,
+  comparable projects. Medium, low risk, aimed at a skeptical adopter.
+- #209 research bibliography: needs real external citations, verified. The
+  one item where the failure mode is fabricating a source in a document
+  whose entire purpose is evidentiary honesty.
+- #190 `procoder learn`: largest by far, and the issue itself says it needs
+  a spec before any implementation.
+
+## #211 asks for a claim the issue record contradicts
+
+**Decided: write it accurately.** Sources are named as sources; the
+convergence argument is made only where it holds.
+
+#211's acceptance criteria require a "framing paragraph [that] makes the
+'independent convergence as evidence' argument explicit" about unlazy,
+addyosmani/agent-skills and mattpocock/skills.
+
+Checked against this repo's own issue record, that framing is false for
+those three. #199 (leases), #200 (approval binding), #201 (never-execute),
+#202 (dispatch waves) and #207 (depth scaling) each open with
+"## Source — Leonxlnx/unlazy's ..." and were all filed on 2026-08-26 in one
+research sweep. #189's anti-rationalization table cites addyosmani's repo
+the same way. Procoder did not converge on these independently; it read
+them and took them, deliberately and recently.
+
+Verified against each project's own repo today: unlazy does ship the Depth
+Tree, lease coordination, a Stop hook, and pre-execution PATH disclosure;
+addyosmani/agent-skills does ship per-skill rationalization tables, a
+docs/comparison.md and a docs/skill-anatomy.md.
+
+A convergence claim is still available, but only for what procoder had
+BEFORE the sweep — the gate, the quality controllers, evidence-gated
+closes — which unlazy arrived at separately. That is a narrower and
+checkable claim.
+
+- write it accurately: name unlazy and agent-skills as SOURCES in
+  influences.md (a fifth relationship: borrowed from, recently), and make
+  the convergence argument only for the pre-sweep features where it holds.
+- follow the criteria as written: make the broad convergence argument.
+  Publishing a claim this repo's own issues contradict, in a document whose
+  purpose is credibility.
+- split: comparable-projects.md lists the projects factually with no
+  convergence framing; the argument moves to #209's research page or is
+  dropped.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ completeness check — a feature family it stops mentioning blocks the
 gate. No benchmark numbers appear here because none have been run; any
 future number will carry its method alongside it.
 
+Where the rigor costs more than it returns, and where a check is narrower
+than its name, is written down rather than left to be discovered:
+[Honest limits](docs/honest-limits.md). What layer procoder occupies, and
+what it does not try to be: [Where procoder sits](docs/positioning.md).
+
+The external evidence behind each premise, and the premises that have none,
+are separated and labelled in [Research](docs/research.md).
+
 ## Implementation
 
 One Go binary, no runtime dependencies, cross-compiled per platform into

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -107,6 +107,23 @@ happened — nothing on disk could — so this is a discipline, not a gate.
 What it buys is that thoroughness comes from asking four different
 questions rather than asking the same one harder.
 
+**Known pitfalls.**
+
+- **The gate answers about the change; CI answers about the tree.** A clean
+  `procoder check` means the files in this commit are clean. It makes no
+  claim about the rest of the repository, and the two are answered by
+  different jobs on purpose.
+- **The attribution check reads unpushed commits, not just this one.** One
+  old trailer sitting in an unpushed commit blocks every later commit,
+  while the message reads as though it were about the change in hand.
+- **An out-of-date binary reports valid configuration as unrecognised.** A
+  config key added in a later release is unknown to an older build, and the
+  finding is a real block on a file that is not wrong. Check the version
+  before editing the config.
+- **In universal scope, content checks narrow to the diff; existence checks
+  do not.** A file the commit never touched can still produce a finding
+  when what is missing is the file itself.
+
 #### `procoder review [--lens <name>[,<name>]] [paths...]`
 
 The judgment half of the gate. Every other check Procoder runs is
@@ -296,6 +313,15 @@ A detection aid, never a verdict. An item can legitimately wait; what this
 reports is that it waited while looking otherwise. A file git cannot answer
 for is reported as NOT checked, never as unstalled.
 
+**Known pitfalls.**
+
+- **An epic that was never seeded is not the same as one that drifted**,
+  and the report says which. Reading "not seeded" as drift sends you
+  looking for a divergence that does not exist.
+- **`backlog scope` compares against what the plans declare.** No plan, or
+  plans declaring no files, reports `scope NOT checked` — genuinely nothing
+  to compare against, which is not the same as a change being surgical.
+
 #### `procoder sprint <sub>`
 
 Scope-boxed sprints over the backlog — a goal plus the stories pulled
@@ -414,6 +440,20 @@ The command comes from the repository and the binary comes from `PATH`, so
 the same declared `npm start` is a different program depending on which npm
 is first. Naming it is the difference between consenting to a command and
 consenting to a string.
+
+**Known pitfalls.**
+
+- **A manifest missing from `[release] files` is never checked.** The list
+  is the whole of what version-sync knows about; a tenth file added to the
+  repo and not to the list drifts silently, release after release. An empty
+  list says `version-sync verified nothing` rather than passing quietly.
+- **Version matching is substring, by design.** A version appears inside
+  longer lines — badges, install commands — and that counts as synced. The
+  cost is that any file already containing the string for an unrelated
+  reason satisfies the check without carrying a real version marker.
+- **`--credits` needs `[release] maintainers` set.** Whose notes these are
+  is configuration, not discovery: `gh api user` returns 403 under CI's app
+  installation token, so the question has no answer where it matters most.
 
 #### `procoder dispatch <sub>`
 
@@ -624,6 +664,17 @@ never echoed, rotation ordered. `--deep` adds semgrep SAST (ERROR blocks)
 and osv-scanner dependency vulnerabilities (CVSS ≥ 7.0 blocks) over the
 repository.
 
+**Known pitfalls.**
+
+- **A missing tool blocks; it does not skip.** No gitleaks means
+  `NOT checked — gitleaks is not installed`, and that finding is blocking.
+  A scan that could not run must never read as one that found nothing, so
+  the honest answer costs you a red gate until `procoder init` fixes it.
+- **The three passes have three different bars.** Secrets block always,
+  SAST blocks at ERROR severity, dependency vulnerabilities block at
+  high/critical. A quiet `security` run is not "no findings" — it is "no
+  findings above those lines".
+
 #### `procoder maintain`
 
 `maintain` is report-only about its findings: complexity and dead code are
@@ -801,6 +852,17 @@ Coverage is **declared, never inferred**. Matching a bullet to a
 criterion by keyword would fail open, and a bullet wrongly judged
 covered is the exact silence this prevents. A spec whose bullets carry
 no ids is reported NOT CHECKED rather than covered.
+
+**Known pitfalls.**
+
+- **A spec marked `complete` stops being checked.** The truth checks —
+  unresolved citations, uncheckable criteria, weak oracles — refuse only
+  while the status is `draft`. On a `complete` spec the same gaps are
+  printed as notes and the verdict stands. That is deliberate: refusing
+  would retrofit a rule onto an archive nobody will rewrite. It also means
+  advancing the status early is how a spec quietly stops being enforced.
+- **The template ships `Status: draft` and nothing advances it**, so a
+  finished spec reads as a draft forever unless you edit the line yourself.
 
 #### `procoder plan <sub>`
 

--- a/docs/comparable-projects.md
+++ b/docs/comparable-projects.md
@@ -1,0 +1,96 @@
+# Comparable projects
+
+**An explanation.** Other people are solving adjacent problems. This page
+names them, states what each targets, and says plainly how procoder's
+approach differs. It is descriptive, not competitive.
+
+It is deliberately separate from [Influences](influences.md), which records
+what procoder _took_ from other tools. Some projects appear on both pages,
+and where they do, this page is not the place the debt is acknowledged —
+that page is.
+
+## What this page can and cannot argue
+
+There is a tempting argument that several unrelated teams building the same
+defences is itself evidence the problem is real. It is a good argument, and
+it does not apply to most of what is listed here.
+
+Procoder read [unlazy](https://github.com/Leonxlnx/unlazy),
+[addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) and
+[mattpocock/skills](https://github.com/mattpocock/skills) in a research
+sweep on 2026-08-26, and shipped mechanisms from all three within days.
+Those are borrowings. Calling them convergence would be a claim this
+repository's own issue bodies contradict, on a page whose whole purpose is
+to be checkable.
+
+The narrower claim does hold, and it is worth stating. Procoder's commit
+gate landed on 2026-08-18 and its evidence-gated closes on 2026-08-19 —
+both before that sweep, in a project whose first commit was 2026-08-16.
+unlazy independently ships acceptance ledgers with runnable gates and
+required evidence. Two projects reaching "a claim of completion is not
+evidence of completion, so make the evidence runnable" without contact is a
+real signal about the failure mode, and it is the one convergence claim on
+this page that survives its own check.
+
+## The projects
+
+### unlazy
+
+**Targets:** model laziness, underthinking, and premature completion
+claims, at the level of a single task's acceptance ledger.
+
+**Overlaps:** runnable verification gates with recorded evidence; a Stop
+hook that blocks a turn ending on incomplete work; parallel-dispatch
+honesty; ownership leases for concurrent agents.
+
+**Diverges:** unlazy is task-scoped and ledger-centric — the unit is one
+piece of work and its gates. Procoder is repository-scoped: the same
+honesty applied to a commit, a sprint, a release, and ten domain checks
+that run whether or not any task is open. unlazy also executes approved
+checks on re-verification; procoder's binary executes nothing it was not
+explicitly asked to, and modifies no file outside its own cache.
+
+**Also:** its `research/validation-protocol.md` retracts an earlier
+internal benchmark rather than quietly dropping it, which is the discipline
+[Research](research.md) is held to.
+
+### addyosmani/agent-skills
+
+**Targets:** the full engineering lifecycle as 24 skills, plus specialist
+personas and reference checklists, installable across 70+ agents.
+
+**Overlaps:** per-skill rationalization tables against agents talking
+themselves out of steps; progressive disclosure to keep entry-point files
+small; multi-angle review as separate personas.
+
+**Diverges:** it advises and procoder computes. A skill telling an agent to
+run the tests and a binary refusing to close the task when they did not run
+are different kinds of object. It also ships an honest `docs/comparison.md`
+naming its own alternatives, which is the model this page follows.
+
+### mattpocock/skills
+
+**Targets:** disciplined workflows — TDD, code review, debugging, domain
+modelling — as model- and user-invoked skills.
+
+**Overlaps:** its `wizard` skill scripts a walkthrough for steps only a
+human can perform; its `handoff` compacts work for the next agent, which
+procoder keeps as `.procoder/state/handoff.md`.
+
+**Diverges:** same advice-versus-computation line as above.
+
+### anthropics/skills and the Agent Skills spec
+
+**Targets:** the shared format itself, rather than a competing opinion.
+
+**Relationship:** procoder conforms to it. `skills/procoder/SKILL.md` is a
+spec-compliant skill and `plugin.json` a spec-compliant plugin. This is the
+foundation both this page and [Influences](influences.md) are written on
+top of, and naming it is more useful than leaving it implicit.
+
+## Related reading
+
+- [Influences](influences.md) — what procoder took, and from whom
+- [Where procoder sits](positioning.md) — the layer, and what it is not
+- [Research](research.md) — external evidence for the premises
+- [Honest limits](honest-limits.md) — where the rigor stops paying

--- a/docs/honest-limits.md
+++ b/docs/honest-limits.md
@@ -1,0 +1,88 @@
+# Honest limits
+
+Procoder's reports are worth what their claims are worth, so this page
+states where the rigor stops paying and where a check is quieter than it
+sounds. Everything here is a property of the current build, checked against
+the code rather than remembered.
+
+The rule the rest of this page follows: **a check that could not run is
+never reported as one that passed.** That honesty has a price, and the
+price is what this page is about.
+
+## When the gate costs more than it returns
+
+**A first `procoder audit` on a large unformatted repository.** `audit` runs
+every domain over the whole tree rather than a commit's diff. On a codebase
+that has never been formatted, the result is a finding count in the
+thousands, and none of it is about the change you came to make. Onboard in
+scope order — format one directory, commit, move on — rather than reading a
+report you cannot act on in one sitting.
+
+**A repository where the toolchain is not installed.** Domain checks resolve
+a real binary: gitleaks for secrets, semgrep for SAST, osv-scanner for
+dependency vulnerabilities. A missing tool produces `NOT checked`, and for
+secrets that finding is **blocking**. A scan that did not run must not read
+as a scan that found nothing — but the honest answer is a red gate on a
+machine that is not set up, not a green one. `procoder doctor` names the
+gaps and `procoder init` closes them.
+
+**A language procoder has no formatter for.** The summary says
+`N file(s) not formatting-checked` rather than counting them clean. That
+number is not a defect count and not a pass; it is the size of what nobody
+looked at.
+
+**Very large commits.** The gate reads the diff, and the checks that narrow
+to changed lines do that work per line. A thousand-file commit is slow
+because it is a thousand files, not because the gate is inefficient — and
+splitting it is better for the reviewer anyway.
+
+## Where a check is narrower than its name
+
+**`procoder check` answers about the change, not the tree.** Two tiers, on
+purpose: the gate answers "is this commit clean", CI answers "is the
+repository clean". A green gate is not a claim about code you did not
+touch.
+
+**Adoption scope changes what content checks see.** In universal scope — a
+repository that has not adopted procoder — content checks narrow to the
+lines the commit actually wrote, so procoder does not lecture a third party
+about code it did not come to change. Checks about a file's _existence_ do
+not narrow, because absence has no line number.
+
+**`backlog scope` is silent when there is nothing to compare.** No plan, or
+plans that declare no files, reports `scope NOT checked`. That is not a
+finding of surgical work; it is the absence of a declaration to check
+against.
+
+**`bench` is Go-only in this version.** Other ecosystems get no benchmark
+comparison at all, and the absence is not reported per-language.
+
+**Coverage is reported, never enforced.** `procoder test --coverage` prints
+a number. No policy consumes it.
+
+## Where honesty is the friction
+
+**Secrets block on a missing scanner.** Covered above, and it is the single
+most common surprise: people expect a skip and get a block.
+
+**The attribution check reads unpushed commits.** One old trailer in an
+unpushed commit blocks every later commit, and the message reads as though
+it concerned the change in hand. Correct, and confusing the first time.
+
+**An out-of-date binary reports valid configuration as unrecognised.** A
+key added in a later release is unknown to an older build. The finding is a
+real block on a file that is not wrong, which is why it names the running
+build and both routes — a typo is yours to fix, an old build is not.
+
+## What has never been measured
+
+No benchmark numbers appear in procoder's documentation because none have
+been run. Whether the gate's overhead is repaid in defects caught is an
+open empirical question, not a settled one, and
+[#190](https://github.com/azrtydxb/procoder/issues/190) exists to make it
+measurable rather than assumed. Any future number will carry its method
+alongside it.
+
+Claims about _behaviour_ — what each check does and does not look at — are
+checkable today by reading the code, and this page is held to that standard.
+Claims about _value_ are not yet, and this page does not make them.

--- a/docs/influences.md
+++ b/docs/influences.md
@@ -98,6 +98,34 @@ refuses, not a role with a voice. Naming that plainly is the point of this
 page: the personas are not missing by oversight, and a reader comparing the
 two should know where the resemblance stops.
 
+## Borrowed from, recently
+
+A fifth relationship, distinct from the four above: projects procoder read
+in a deliberate research sweep on 2026-08-26 and took specific mechanisms
+from within days. These are sources, not parallel discoveries, and the
+issue bodies say so — each opens with `## Source` naming the project.
+
+| Taken from [unlazy](https://github.com/Leonxlnx/unlazy)                      | Where it lives in Procoder                                                                                 |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| The Depth Tree: every leaf of a decomposed task gets the full rigor budget   | The depth-scaling rule in this file ([#207](https://github.com/azrtydxb/procoder/issues/207))              |
+| Ownership leases: an `OWNS:` glob per task, conflicts reported not prevented | `procoder claims` ([#199](https://github.com/azrtydxb/procoder/issues/199))                                |
+| The launch-wave protocol: every agent started before the first is awaited    | `procoder dispatch` ([#202](https://github.com/azrtydxb/procoder/issues/202))                              |
+| Approval bound to the resolved PATH, not just the command text               | `procoder run --exec` naming the resolved binary ([#200](https://github.com/azrtydxb/procoder/issues/200)) |
+| A hook that displays evidence and never executes what it reads               | The never-execute-automatically rule ([#201](https://github.com/azrtydxb/procoder/issues/201))             |
+
+From [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills):
+the per-skill rationalization table, and the progressive-disclosure
+guidance in its `docs/skill-anatomy.md`
+([#189](https://github.com/azrtydxb/procoder/issues/189)).
+
+From [mattpocock/skills](https://github.com/mattpocock/skills): the wizard
+shape — scripting a walkthrough for steps only a human can perform
+([#192](https://github.com/azrtydxb/procoder/issues/192)).
+
+Where procoder arrived at something before that sweep and another project
+holds it too, that is a different claim and it is made separately in
+[Comparable projects](comparable-projects.md).
+
 ## Deliberately not adopted
 
 Superpowers' subagent-orchestration machinery and branch-finishing flow

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,74 @@
+# Where procoder sits
+
+Procoder is often compared against things it is not, so this page states
+the layer it occupies and what it is not trying to be. It is descriptive,
+not competitive: the tools named here are good at what they do.
+
+## Four layers, not one
+
+A useful split, and one the ecosystem broadly agrees on:
+
+| Layer          | What it is                               | Example                  |
+| -------------- | ---------------------------------------- | ------------------------ |
+| **Connection** | How an agent reaches a system at all     | MCP servers              |
+| **Actions**    | Individual capabilities an agent invokes | Tools, function calls    |
+| **Behaviour**  | What an agent is told to do, in prose    | Agent Skills, rule files |
+| **Governance** | What is computed and refused regardless  | Procoder's binary        |
+
+Procoder spans the bottom two rows, and the distinction between them is the
+whole point.
+
+## Advice versus computation
+
+A skill pack, a rules file, and an `AGENTS.md` are all **advice**. They
+change what an agent is likely to do. They cannot change what happens when
+the agent does something else, because nothing reads them at the moment of
+the commit.
+
+Procoder ships both halves deliberately:
+
+- **The advisory half** — `AGENTS.md`, `skills/procoder/SKILL.md`, and
+  eleven generated host rule files. This is ordinary prose guidance, and it
+  works exactly as well as prose guidance ever works.
+- **The computed half** — a binary that reads the actual diff, resolves
+  real tools, and exits non-zero. `procoder check` does not ask the agent
+  whether the files are formatted; it formats them in memory and compares.
+
+The second half is why procoder is a binary rather than a prompt. An agent
+under pressure talks itself past a paragraph. It does not talk itself past
+a non-zero exit code, because that conversation is not available.
+
+## What procoder does not do
+
+- **It does not write your code**, and outside its own plugin cache it does
+  not modify files at all. The binary prints; the agent writes. That is a
+  hard rule with one recorded exception (`procoder prune --apply`, which
+  touches only procoder's own cache).
+- **It does not replace a methodology.** Procoder governs whether work is
+  finished and honest. It has no opinion about how you decompose a problem,
+  and it defers to BMad's artifacts when `[planning] method = "bmad"` is
+  set. See [Influences](influences.md).
+- **It does not replace your linters.** Each domain shells out to the
+  field's canonical tool — gitleaks, semgrep, osv-scanner, ruff, prettier —
+  rather than reimplementing them. Procoder decides what blocks; the tools
+  decide what is true.
+- **It does not measure its own value.** See
+  [Honest limits](honest-limits.md).
+
+## Compared to a skills pack
+
+The closest comparison is a well-built Agent Skills collection. The
+difference is not quality; it is enforceability. A skills pack **suggests a
+workflow**; procoder **computes a verdict**. A pack can tell an agent to
+run the tests. Procoder can refuse to close the task when they did not run,
+because `NOT run` is a state it can observe and `I ran them` is a claim it
+cannot.
+
+Procoder conforms to the Agent Skills spec and ships as a plugin, so the
+two are not alternatives — the skill is procoder's advisory half, and it is
+generated from the same source as every other host's rule file so they
+cannot drift.
+
+For the specific projects solving adjacent problems, see
+[Comparable projects](comparable-projects.md). For the research behind the
+premises, see [Research](research.md).

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,0 +1,141 @@
+# Research
+
+**An explanation.** Each procoder domain exists because of a belief about
+how software work goes wrong. This page states those beliefs and, where
+external evidence exists, cites it. Where it does not, this page says so
+rather than implying a backing that is not there.
+
+That rule matters more than the citations. A page of references is easy to
+write and worth nothing if any of them is misapplied, so every entry below
+is one of two kinds: **cited**, meaning a real source was read and says
+what is claimed, or **uncited**, meaning the premise is procoder's own
+design judgment and is labelled as such.
+
+## Correction policy
+
+If a citation here turns out to be misapplied, misquoted, or to not say
+what was claimed, it gets corrected **in place, with the correction
+visible** — struck through or marked, never silently deleted. A page that
+quietly drops its mistakes teaches its reader nothing about how carefully
+the rest was checked.
+
+No corrections have been issued yet. This section is here so the first one
+has an established place to go, not because the page is assumed correct.
+
+---
+
+## Cited
+
+### Agents claim completion they have not reached
+
+**Premise behind:** the quality controllers, evidence-gated closes,
+`procoder test`'s "NOT run is never green".
+
+**Evidence:** _SlopCodeBench: Benchmarking How Coding Agents Degrade Over
+Long-Horizon Iterative Tasks_ — Orlanski, Roy, Yun, Shin, Gu, Ge, Adila,
+Roberts, Sala, Albarghouthi
+([arXiv:2603.24755](https://arxiv.org/abs/2603.24755), submitted March
+2026, revised May 2026). Across 36 problems, 196 checkpoints and 15 coding
+agents, the best checkpoint pass rate was **14.8%**, and **no agent solved
+any problem end to end**. Structural erosion increased in 77% of
+trajectories and verbosity in 75.5%; agent code measured 2.3× more verbose
+and 2.0× more eroded than 473 open-source Python repositories.
+
+**How it is used here:** as evidence that iterative agent work degrades
+measurably, which is the premise behind refusing to accept a claim of
+completion in place of evidence of it. Note the version caveat: earlier and
+later revisions of this paper report different problem, checkpoint and
+percentage figures. The numbers above are from the revised abstract.
+
+### Prose guidance shifts the starting point, not the drift
+
+**Premise behind:** procoder shipping a _binary_ rather than only an
+`AGENTS.md`. See [Where procoder sits](positioning.md).
+
+**Evidence:** the same paper. Explicit quality guidance reduced initial
+verbosity and erosion **by up to one third — without affecting the rate of
+degradation**.
+
+**How it is used here:** it supports the split procoder is built on, and it
+cuts both ways honestly. Guidance demonstrably helps; it demonstrably does
+not stop the drift. That is an argument for keeping both halves, not for
+dismissing the advisory one.
+
+### Developers do admit debt in comments, and much of it stays
+
+**Premise behind:** `procoder debt` harvesting `debt:` markers, and
+flagging a marker with no revisit condition as rot.
+
+**Evidence:** _An Exploratory Study on Self-Admitted Technical Debt_ —
+Potdar and Shihab
+([Semantic Scholar](https://www.semanticscholar.org/paper/An-Exploratory-Study-on-Self-Admitted-Technical-Potdar-Shihab/ddf82ba67e252428fde55fcf9b73e848924a3372)),
+studying Eclipse, Chromium OS, Apache HTTP Server and ArgoUML. Self-admitted
+technical debt appeared in up to **31% of files**, and between **26.3% and
+63.5%** of it was removed after introduction.
+
+**How it is used here:** the practice procoder relies on — engineers
+writing down the corner they cut — is empirically real and widespread. The
+removal range is the more useful half: on the low end, roughly three
+quarters of admitted debt was still there. A comment alone does not get
+debt paid, which is why procoder harvests markers into a ledger and treats
+one without a revisit condition as rot rather than as a record.
+
+---
+
+## Uncited — procoder's own judgment
+
+These premises have no external citation here. Some may have supporting
+literature nobody has looked for yet; one has literature that does _not_
+settle the question. Either way, no claim of research backing is made.
+
+### Multi-lens review catches more than a single pass
+
+**Premise behind:** `procoder review`'s five lenses.
+
+**Status: contested, deliberately not claimed as support.** The nearest
+literature compares checklist-based against ad hoc code reading, and it
+does not agree with itself. A controlled study in a distributed groupware
+environment found **no significant difference** in defect detection
+effectiveness, effort, or false positives between the two
+([arXiv:0909.4260](https://arxiv.org/abs/0909.4260)). Other experiments
+report checklist-based reading as substantially superior. Reviews of this
+literature describe the results as inconsistent and conflicting.
+
+Citing only the favourable half would be exactly the failure this page
+exists to avoid. The five lenses are a design judgment, and the honest
+statement is that the external evidence is mixed.
+
+### Formatting, hygiene and secret drift is costly enough to gate on
+
+**Premise behind:** the commit gate itself.
+
+**Status: uncited.** No study has been read that measures the cost of this
+specific drift in agent-written code. The gate is justified here by
+mechanism rather than measurement: an unformatted file, a committed secret
+and a junk artifact are each objectively identifiable, and identifying them
+at the commit is cheaper than at review.
+
+### Specification before implementation reduces rework
+
+**Premise behind:** the spec → plan → backlog → sprint chain.
+
+**Status: uncited.** There is a substantial requirements-engineering
+literature on defect cost escalating with the phase in which a defect is
+found, and it has not been read and verified for this page. Until it has,
+the chain stands on procoder's own reasoning.
+
+---
+
+## What procoder has not measured about itself
+
+Nothing on this page is evidence that _procoder_ works. No benchmark of the
+gate's overhead against defects caught has been run — see
+[Honest limits](honest-limits.md), and
+[#190](https://github.com/azrtydxb/procoder/issues/190), which exists to
+make that measurable rather than assumed.
+
+## Related reading
+
+- [Comparable projects](comparable-projects.md) — others solving adjacent problems
+- [Influences](influences.md) — what procoder took, and from whom
+- [Honest limits](honest-limits.md) — where the rigor stops paying

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,3 +62,7 @@ nav:
       - The quality chain: quality-chain.md
       - Architecture: architecture.md
       - Influences: influences.md
+      - Where procoder sits: positioning.md
+      - Honest limits: honest-limits.md
+      - Comparable projects: comparable-projects.md
+      - Research: research.md


### PR DESCRIPTION
Closes #194, #211, #209. One change because the three cross-reference each
other by design and landing them apart would ship broken links.

#194: five commands gain a Known pitfalls block, each verified against the
code rather than recalled. A spec marked complete downgrades its truth
checks to notes. A manifest missing from [release] files is never checked,
and version matching is substring. Missing gitleaks blocks rather than
skips. docs/honest-limits.md states where the rigor stops paying;
docs/positioning.md states the layer and what procoder is not.

#211 did not survive its own accuracy bar as written. It asked for an
'independent convergence' framing about unlazy, agent-skills and
mattpocock. This repo's issues contradict it: #199, #200, #201, #202 and
#207 each open with '## Source - Leonxlnx/unlazy' and were filed the same
day, and #189 cites addyosmani the same way. Those are borrowings, so
influences.md gains a fifth relationship that says so, naming what was
taken and where it now lives.

One convergence claim survives and is made: the gate landed 2026-08-18 and
evidence-gated closes 2026-08-19, before that sweep, in a project whose
first commit was 2026-08-16. unlazy reached runnable acceptance evidence
separately.

#209 separates cited premises from uncited ones. SlopCodeBench
(arXiv:2603.24755) is read and quoted precisely, including the finding that
explicit guidance cut initial erosion by up to a third without changing the
rate of degradation - which argues for procoder's two halves and cuts both
ways. Potdar and Shihab ground the debt ledger. The review lenses get no
citation on purpose: the checklist-versus-ad-hoc literature conflicts with
itself, and quoting only the favourable half is the failure the page exists
to prevent. Two more premises are labelled uncited outright.

Every external claim was fetched and read today, not recalled.