### PR TITLE
feat: walk a human through what procoder cannot do for them

### DIFF
--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -61,6 +61,7 @@ import (
 	"procoder/internal/testrun"
 	"procoder/internal/todo"
 	"procoder/internal/tools"
+	"procoder/internal/wizard"
 )
 
 func init() {
@@ -399,6 +400,11 @@ const usage = `usage: procoder <command> [args]
                        add <title> | list | show <id> | close <id> — close
                        REFUSES until every acceptance criterion is checked,
                        evidence is recorded, and the gate is clean
+  wizard <sub>         walk a human through a procedure procoder cannot do
+                       for them — list | new <name> | show <name> |
+                       run <name>. It executes nothing: the steps are
+                       accounts, dashboards and tokens, not commands. A
+                       captured value is shape-checked and never echoed
   version [--check]    print the version; --check asks GitHub what the
                        newest release is and offers to install it when this
                        build is behind. Silenced by [version] check = "off"
@@ -747,6 +753,34 @@ func run(args []string) int {
 				return 2
 			}
 			return glossary.Add(root, args[2], strings.Join(args[3:], " "), printLine)
+		}
+		return usageErr(os.Stderr)
+	case "wizard":
+		root := doctor.Root()
+		if len(args) < 2 {
+			return wizard.List(root, printLine)
+		}
+		switch args[1] {
+		case "list":
+			return wizard.List(root, printLine)
+		case "new":
+			if len(args) < 3 {
+				printLine("wizard new <name> — prints a wizard to write")
+				return 2
+			}
+			return wizard.Scaffold(args[2], printLine)
+		case "show":
+			if len(args) < 3 {
+				printLine("wizard show <name> — prints every step, runs nothing")
+				return 2
+			}
+			return wizard.Show(root, args[2], printLine)
+		case "run":
+			if len(args) < 3 {
+				printLine("wizard run <name> — walks the steps one at a time")
+				return 2
+			}
+			return wizard.Run(root, args[2], os.Stdin, printLine)
 		}
 		return usageErr(os.Stderr)
 	case "dispatch":

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1104,6 +1104,40 @@ Nothing calls this from a hook, and a test asserts that by reading the hook
 sources — a delete of this size is a deliberate action a person takes, not
 something that happens to them while they are typing.
 
+#### `procoder wizard <sub>`
+
+Walk a human through a procedure procoder cannot do for them: create an
+account, generate a token, click submit in somebody else's dashboard. Those
+steps are not shell commands, so this command **executes nothing at all** —
+`show` prints the steps and `run` advances through them one at a time, so
+none is skipped by reading past it.
+
+A wizard is `.procoder/wizards/<name>.md`: a `## ` heading per step, the
+body underneath, and an optional `Capture: NAME matching <pattern>` line
+for a step that needs a value back. `wizard new <name>` **prints** a wizard
+to write rather than writing one — the binary prints and the agent writes,
+like `adr new` and `context add`.
+
+`list` names what the repository carries. An unreadable wizard directory
+says so and exits 1 rather than reporting no wizards: nothing found and
+nothing readable are different answers.
+
+**A captured value is checked and never echoed.** Wizards exist partly to
+walk somebody through generating credentials, and a token printed back is a
+token in the scrollback — so the value appears in no message, not even the
+one rejecting it. What the walk reports at the end is which names were
+checked, never what they held. A pattern that does not compile reports
+`NOT checked` rather than panicking or silently accepting.
+
+**Known pitfalls.**
+
+- **`run` proves a human confirmed each step, not that each step worked.**
+  It cannot see the dashboard you clicked in. It removes the "I thought I
+  did that one" failure, and no other.
+- **Captured values go nowhere.** They are validated while you have them in
+  front of you and then discarded; procoder does not store them, print
+  them, or put them in your CI. Paste them yourself.
+
 #### `procoder version [--check]` and `procoder self-upgrade [--force]`
 
 Bare `version` prints one line and asks nobody anything.

--- a/internal/docs/coverage.go
+++ b/internal/docs/coverage.go
@@ -22,7 +22,7 @@ var Commands = []string{
 	"config", "context", "copilot-leak", "debt", "deps", "dispatch", "docs", "doctor", "env", "evidence",
 	"format", "git", "hook", "index", "infra", "init", "lessons", "lint",
 	"maintain", "plan", "principles", "prune", "release", "review", "run", "scrub", "security", "spec",
-	"self-upgrade", "sprint", "status", "templates", "test", "todo", "version",
+	"self-upgrade", "sprint", "status", "templates", "test", "todo", "version", "wizard",
 }
 
 // surfaceCoverageCap is how many undocumented symbols are worth listing; past

--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -515,7 +515,7 @@ var Commands = map[string]bool{
 	"release": true, "review": true, "run": true, "scrub": true,
 	"security": true, "self-upgrade": true, "spec": true, "sprint": true,
 	"status": true, "templates": true, "test": true, "todo": true,
-	"version": true,
+	"version": true, "wizard": true,
 }
 
 // normaliseEOL makes CRLF and CR read as LF, so a document parses the same

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -84,12 +84,26 @@ func read(root, name string) (string, string) {
 
 // List names the wizards this repository carries.
 func List(root string, out func(string)) int {
-	entries, err := os.ReadDir(filepath.Join(root, Dir))
+	dir := filepath.Join(root, Dir)
+	// Absent and unreadable are different answers, and os.ReadDir alone
+	// cannot tell them apart everywhere: on Windows, reading a path that
+	// is a FILE reports "cannot find the path", which satisfies
+	// os.IsNotExist — so the honest failure would read as "no wizards".
+	// Stat first, and let the kind of the thing decide.
+	info, statErr := os.Stat(dir)
+	switch {
+	case statErr != nil && os.IsNotExist(statErr):
+		out("no wizards — `procoder wizard new <name>` prints one to write")
+		return 0
+	case statErr != nil:
+		out(Dir + " cannot be read (" + statErr.Error() + ") — the wizards are NOT listed")
+		return 1
+	case !info.IsDir():
+		out(Dir + " is not a directory — the wizards are NOT listed")
+		return 1
+	}
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			out("no wizards — `procoder wizard new <name>` prints one to write")
-			return 0
-		}
 		out(Dir + " cannot be read (" + err.Error() + ") — the wizards are NOT listed")
 		return 1
 	}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -1,0 +1,274 @@
+// Package wizard walks a human through a procedure procoder cannot perform
+// for them: create an account, generate a token, click submit in somebody
+// else's dashboard. Those steps are not shell commands and never were, so
+// this package executes nothing at all — it displays steps and, under
+// `run`, advances through them one at a time so none is skipped.
+//
+// A wizard is `.procoder/wizards/<name>.md`, written by the agent. procoder
+// reads it; `wizard new` PRINTS a scaffold rather than writing one, the
+// same P-CONTROL every other authoring command follows.
+//
+// A captured value is validated and never echoed. Wizards exist to walk
+// somebody through generating credentials, and a token printed back to the
+// terminal is a token in the scrollback.
+package wizard
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Dir is where wizards live, relative to the repository root.
+const Dir = ".procoder/wizards"
+
+// Step is one thing a human does, in order.
+type Step struct {
+	Title string
+	Body  []string
+	// Capture is the name of a value this step asks back, empty when the
+	// step only needs a confirmation.
+	Capture string
+	// Shape is the pattern Capture must match. Empty means any non-empty
+	// value is accepted — a shape nobody wrote is not a shape that failed.
+	Shape string
+}
+
+// captureRe reads `Capture: NAME matching <pattern>` or `Capture: NAME`.
+var captureRe = regexp.MustCompile(`^Capture:\s*(\w+)(?:\s+matching\s+(.+))?$`)
+
+// Parse reads a wizard file into ordered steps. A `## ` heading starts a
+// step; everything under it is that step's body.
+func Parse(text string) []Step {
+	var steps []Step
+	for _, line := range strings.Split(normaliseEOL(text), "\n") {
+		if strings.HasPrefix(line, "## ") {
+			steps = append(steps, Step{Title: strings.TrimSpace(line[3:])})
+			continue
+		}
+		if len(steps) == 0 {
+			continue // preamble before the first step is the title block
+		}
+		cur := &steps[len(steps)-1]
+		if m := captureRe.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			cur.Capture, cur.Shape = m[1], strings.TrimSpace(m[2])
+			continue
+		}
+		cur.Body = append(cur.Body, line)
+	}
+	return steps
+}
+
+func normaliseEOL(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
+
+// read returns a wizard's text, or a message naming why it could not.
+func read(root, name string) (string, string) {
+	p := filepath.Join(root, Dir, name+".md")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "no wizard named " + name + " — expected " + filepath.ToSlash(filepath.Join(Dir, name+".md"))
+		}
+		// Unknown is never none: an unreadable wizard is a named failure.
+		return "", filepath.ToSlash(filepath.Join(Dir, name+".md")) + " cannot be read (" + err.Error() + ")"
+	}
+	return string(raw), ""
+}
+
+// List names the wizards this repository carries.
+func List(root string, out func(string)) int {
+	entries, err := os.ReadDir(filepath.Join(root, Dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			out("no wizards — `procoder wizard new <name>` prints one to write")
+			return 0
+		}
+		out(Dir + " cannot be read (" + err.Error() + ") — the wizards are NOT listed")
+		return 1
+	}
+	var names []string
+	for _, e := range entries {
+		if n := strings.TrimSuffix(e.Name(), ".md"); !e.IsDir() && n != e.Name() {
+			names = append(names, n)
+		}
+	}
+	if len(names) == 0 {
+		out("no wizards — `procoder wizard new <name>` prints one to write")
+		return 0
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		text, _ := read(root, n)
+		out("  " + n + " — " + strconv.Itoa(len(Parse(text))) + " step(s)")
+	}
+	return 0
+}
+
+// Show prints every step without prompting. This is the default shape:
+// display it, and let a human decide to walk it.
+func Show(root, name string, out func(string)) int {
+	text, bad := read(root, name)
+	if bad != "" {
+		out(bad)
+		return 1
+	}
+	steps := Parse(text)
+	if len(steps) == 0 {
+		out(name + " has no `## ` step headings — nothing to walk")
+		return 1
+	}
+	out(name + " — " + strconv.Itoa(len(steps)) + " step(s), nothing runs:")
+	for i, s := range steps {
+		out("")
+		out("  " + strconv.Itoa(i+1) + ". " + s.Title)
+		for _, b := range s.Body {
+			if strings.TrimSpace(b) != "" {
+				out("     " + strings.TrimSpace(b))
+			}
+		}
+		if s.Capture != "" {
+			out("     asks for: " + s.Capture + shapeSuffix(s.Shape))
+		}
+	}
+	return 0
+}
+
+func shapeSuffix(shape string) string {
+	if shape == "" {
+		return ""
+	}
+	return " (matching " + shape + ")"
+}
+
+// Run walks the steps one at a time, advancing only on a confirmation, so
+// a step cannot be skipped by reading past it. It executes nothing.
+//
+// A captured value is checked against its shape and never echoed: what the
+// human is told is that it was accepted, which is all they need to know.
+func Run(root, name string, in io.Reader, out func(string)) int {
+	text, bad := read(root, name)
+	if bad != "" {
+		out(bad)
+		return 1
+	}
+	steps := Parse(text)
+	if len(steps) == 0 {
+		out(name + " has no `## ` step headings — nothing to walk")
+		return 1
+	}
+	r := bufio.NewScanner(in)
+	captured := make([]string, 0, len(steps))
+	out(name + " — " + strconv.Itoa(len(steps)) + " step(s). procoder runs none of them; you do.")
+	for i, s := range steps {
+		out("")
+		out("step " + strconv.Itoa(i+1) + "/" + strconv.Itoa(len(steps)) + ": " + s.Title)
+		for _, b := range s.Body {
+			if strings.TrimSpace(b) != "" {
+				out("  " + strings.TrimSpace(b))
+			}
+		}
+		if s.Capture == "" {
+			out("  press enter when this is done (or type 'stop')")
+			if !r.Scan() {
+				out("stopped at step " + strconv.Itoa(i+1) + " — input ended before the wizard did")
+				return 1
+			}
+			if strings.EqualFold(strings.TrimSpace(r.Text()), "stop") {
+				out("stopped at step " + strconv.Itoa(i+1) + " of " + strconv.Itoa(len(steps)))
+				return 1
+			}
+			continue
+		}
+		ok, code := capture(r, s, out)
+		if !ok {
+			return code
+		}
+		captured = append(captured, s.Capture)
+	}
+	out("")
+	out("every step confirmed (" + strconv.Itoa(len(steps)) + "/" + strconv.Itoa(len(steps)) + ")")
+	if len(captured) > 0 {
+		// Named, never valued. The point of capturing was to check the
+		// shape while the human still had the value in front of them.
+		out("values checked and NOT stored or printed: " + strings.Join(captured, ", "))
+	}
+	return 0
+}
+
+// capture prompts for one value and validates its shape. It returns false
+// with the exit code when the wizard should stop.
+func capture(r *bufio.Scanner, s Step, out func(string)) (bool, int) {
+	var re *regexp.Regexp
+	if s.Shape != "" {
+		// Compile is deliberate over MustCompile: the pattern comes from a
+		// file somebody wrote, and a bad pattern is a finding, not a panic.
+		c, err := regexp.Compile(s.Shape)
+		if err != nil {
+			out("  the shape for " + s.Capture + " is not a valid pattern (" + err.Error() + ") — NOT checked")
+			return false, 1
+		}
+		re = c
+	}
+	for {
+		out("  enter " + s.Capture + shapeSuffix(s.Shape) + " (or 'stop'); it is not echoed or stored")
+		if !r.Scan() {
+			out("stopped — input ended before " + s.Capture + " was given")
+			return false, 1
+		}
+		v := strings.TrimSpace(r.Text())
+		if strings.EqualFold(v, "stop") {
+			out("stopped before " + s.Capture)
+			return false, 1
+		}
+		if v == "" {
+			out("  " + s.Capture + " cannot be empty")
+			continue
+		}
+		if re != nil && !re.MatchString(v) {
+			// The value is never quoted back, not even when it is wrong.
+			out("  that does not match " + s.Shape + " — check it and enter it again")
+			continue
+		}
+		out("  " + s.Capture + " accepted")
+		return true, 0
+	}
+}
+
+// Scaffold PRINTS a wizard to write. It does not create the file: the
+// binary prints and the agent writes (P-CONTROL).
+func Scaffold(name string, out func(string)) int {
+	if strings.TrimSpace(name) == "" {
+		out("wizard new <name> — the name becomes " + Dir + "/<name>.md")
+		return 2
+	}
+	out("write this to " + filepath.ToSlash(filepath.Join(Dir, name+".md")) + ":")
+	out("")
+	out("# " + name)
+	out("")
+	out("One sentence: what a person has when this is finished.")
+	out("")
+	out("## Create the account")
+	out("")
+	out("Go to https://example.com/signup and register. Procoder cannot do")
+	out("this for you: it needs an email nobody else can read.")
+	out("")
+	out("## Generate a token")
+	out("")
+	out("Settings -> Developer -> New token. Give it the smallest scope that")
+	out("works.")
+	out("")
+	out("Capture: TOKEN matching ^[A-Za-z0-9_-]{20,}$")
+	out("")
+	out("## Paste it where it belongs")
+	out("")
+	out("Put the token in your password manager, then into the CI secret.")
+	out("Procoder never sees it.")
+	return 0
+}

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -68,9 +68,14 @@ func TestAMissingWizardIsNamed(t *testing.T) {
 	}
 }
 
-// proved by: have List swallow the ReadDir error and print the empty-state
-// line — an unreadable directory then reads as "no wizards", and this
-// fails on both the exit code and the word NOT.
+// Windows found this one. os.ReadDir on a path that is a FILE reports
+// "cannot find the path specified" there, which satisfies os.IsNotExist —
+// so the first version of List answered "no wizards" for a path it could
+// not read. Absent and unreadable are different answers on every platform.
+//
+// proved by: replace the Stat switch in List with a bare os.ReadDir whose
+// error path returns the empty-state line — this fails on Windows, and the
+// !info.IsDir() arm is what makes it fail on Unix too.
 func TestAnUnreadableWizardDirIsNotReportedAsEmpty(t *testing.T) {
 	root := t.TempDir()
 	// A file where the directory belongs: ReadDir fails on every platform,
@@ -85,8 +90,12 @@ func TestAnUnreadableWizardDirIsNotReportedAsEmpty(t *testing.T) {
 	if code := List(root, out); code != 1 {
 		t.Errorf("code = %d, want 1", code)
 	}
-	if !strings.Contains(strings.Join(*got, "\n"), "NOT listed") {
+	joined := strings.Join(*got, "\n")
+	if !strings.Contains(joined, "NOT listed") {
 		t.Errorf("an unreadable dir read as empty: %v", *got)
+	}
+	if strings.Contains(joined, "no wizards") {
+		t.Errorf("an unreadable dir claimed there are none: %v", *got)
 	}
 }
 

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -1,0 +1,208 @@
+package wizard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func write(t *testing.T, root, name, body string) {
+	t.Helper()
+	dir := filepath.Join(root, Dir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func collect() (func(string), *[]string) {
+	var got []string
+	return func(s string) { got = append(got, s) }, &got
+}
+
+// proved by: drop the `Capture:` branch in Parse — the line falls through
+// into Body and Capture stays empty, so this fails.
+func TestParseReadsStepsAndTheirCaptures(t *testing.T) {
+	steps := Parse("# title\n\npreamble\n\n## One\n\ndo a thing\n\n## Two\n\nCapture: TOKEN matching ^gh_\\w+$\n")
+	if len(steps) != 2 {
+		t.Fatalf("want 2 steps, got %d", len(steps))
+	}
+	if steps[0].Title != "One" || steps[1].Title != "Two" {
+		t.Fatalf("titles: %q %q", steps[0].Title, steps[1].Title)
+	}
+	if steps[1].Capture != "TOKEN" {
+		t.Errorf("capture = %q, want TOKEN", steps[1].Capture)
+	}
+	if steps[1].Shape != `^gh_\w+$` {
+		t.Errorf("shape = %q", steps[1].Shape)
+	}
+	for _, b := range steps[1].Body {
+		if strings.Contains(b, "Capture:") {
+			t.Error("the Capture line leaked into the body")
+		}
+	}
+}
+
+// proved by: change normaliseEOL to return s unchanged — the CRLF heading
+// keeps its \r, the title mismatches, and this fails.
+func TestParseHandlesCRLF(t *testing.T) {
+	steps := Parse("## One\r\n\r\nbody\r\n")
+	if len(steps) != 1 || steps[0].Title != "One" {
+		t.Fatalf("CRLF not normalised: %#v", steps)
+	}
+}
+
+// proved by: make read() return "" with no message when the file is
+// missing — Show then reports "no step headings" instead of naming the
+// absent file, and this fails.
+func TestAMissingWizardIsNamed(t *testing.T) {
+	out, got := collect()
+	if code := Show(t.TempDir(), "nope", out); code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if !strings.Contains(strings.Join(*got, "\n"), "no wizard named nope") {
+		t.Errorf("did not name the missing wizard: %v", *got)
+	}
+}
+
+// proved by: have List swallow the ReadDir error and print the empty-state
+// line — an unreadable directory then reads as "no wizards", and this
+// fails on both the exit code and the word NOT.
+func TestAnUnreadableWizardDirIsNotReportedAsEmpty(t *testing.T) {
+	root := t.TempDir()
+	// A file where the directory belongs: ReadDir fails on every platform,
+	// where chmod 000 does not deny reads on Windows.
+	if err := os.MkdirAll(filepath.Join(root, ".procoder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, Dir), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, got := collect()
+	if code := List(root, out); code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if !strings.Contains(strings.Join(*got, "\n"), "NOT listed") {
+		t.Errorf("an unreadable dir read as empty: %v", *got)
+	}
+}
+
+// proved by: delete the `if v == ""` guard in capture — the empty line is
+// accepted as TOKEN, Run reaches its success line, and this fails.
+func TestRunRefusesAnEmptyCapture(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "w", "## Give it\n\nCapture: TOKEN\n")
+	out, got := collect()
+	// empty, then stop
+	code := Run(root, "w", strings.NewReader("\nstop\n"), out)
+	if code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if !strings.Contains(strings.Join(*got, "\n"), "cannot be empty") {
+		t.Errorf("empty value was not refused: %v", *got)
+	}
+}
+
+// proved by: drop the `!re.MatchString(v)` branch — the wrong token is
+// accepted and Run exits 0, so this fails.
+func TestRunEnforcesTheShape(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "w", "## Give it\n\nCapture: TOKEN matching ^gh_[a-z]+$\n")
+	out, got := collect()
+	code := Run(root, "w", strings.NewReader("wrong\ngh_ok\n"), out)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0: %v", code, *got)
+	}
+	joined := strings.Join(*got, "\n")
+	if !strings.Contains(joined, "does not match") {
+		t.Errorf("the bad value was accepted: %v", *got)
+	}
+	if !strings.Contains(joined, "TOKEN accepted") {
+		t.Errorf("the good value was not accepted: %v", *got)
+	}
+}
+
+// The rule the package exists under: a captured value never reaches the
+// terminal, right or wrong.
+//
+// proved by: add the value to either message in capture (e.g. `+ " ("+v+")"`)
+// — it appears in the output and this fails.
+func TestACapturedValueIsNeverEchoed(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "w", "## Give it\n\nCapture: TOKEN matching ^gh_[a-z]+$\n")
+	out, got := collect()
+	Run(root, "w", strings.NewReader("sup3rsecret\ngh_ok\n"), out)
+	joined := strings.Join(*got, "\n")
+	for _, secret := range []string{"sup3rsecret", "gh_ok"} {
+		if strings.Contains(joined, secret) {
+			t.Errorf("the value %q was echoed: %v", secret, *got)
+		}
+	}
+}
+
+// proved by: swap regexp.Compile for regexp.MustCompile in capture — the
+// bad pattern panics instead of reporting, and this fails.
+func TestABadShapeIsAFindingNotAPanic(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "w", "## Give it\n\nCapture: TOKEN matching ^gh_[a-z\n")
+	out, got := collect()
+	if code := Run(root, "w", strings.NewReader("anything\n"), out); code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if !strings.Contains(strings.Join(*got, "\n"), "NOT checked") {
+		t.Errorf("a bad shape did not say NOT checked: %v", *got)
+	}
+}
+
+// proved by: have Run continue past a "stop" instead of returning — it
+// reaches step 2 and the success line, and this fails.
+func TestStopEndsTheWalkWhereItStood(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "w", "## One\n\na\n\n## Two\n\nb\n")
+	out, got := collect()
+	if code := Run(root, "w", strings.NewReader("stop\n"), out); code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	joined := strings.Join(*got, "\n")
+	if !strings.Contains(joined, "stopped at step 1 of 2") {
+		t.Errorf("stop was not honoured: %v", *got)
+	}
+	if strings.Contains(joined, "every step confirmed") {
+		t.Error("a stopped walk reported success")
+	}
+}
+
+// P-CONTROL: the binary prints, the agent writes.
+//
+// proved by: make Scaffold write the file it prints — the directory exists
+// afterwards and this fails.
+func TestScaffoldPrintsAndWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd) //nolint:errcheck
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	out, got := collect()
+	if code := Scaffold("setup", out); code != 0 {
+		t.Fatalf("code = %d", code)
+	}
+	if _, err := os.Stat(filepath.Join(root, Dir)); !os.IsNotExist(err) {
+		t.Error("Scaffold created something; it must only print")
+	}
+	if !strings.Contains(strings.Join(*got, "\n"), "## Generate a token") {
+		t.Errorf("scaffold did not include a step: %v", *got)
+	}
+}
+
+// proved by: drop the empty-name guard in Scaffold — it prints a wizard
+// named "" and returns 0, so this fails.
+func TestScaffoldRefusesAnEmptyName(t *testing.T) {
+	out, _ := collect()
+	if code := Scaffold("  ", out); code != 2 {
+		t.Errorf("code = %d, want 2", code)
+	}
+}


### PR DESCRIPTION
Closes #192.

The issue asked for a generated bash script that `wizard run` executes.
Reading the steps it targets settles the design differently: #66-#73 are
'create an account', 'generate a token', 'submit form Y' — not shell
commands. Nothing needed executing, so nothing executes. A wizard is
declarative markdown, and `run` walks it a step at a time so none is
skipped by reading past it.

That also keeps the shape AGENTS.md names: display it, require a separate
step a human invokes. `show` is the default and prompts for nothing;
`run` is the human's own invocation; `new` PRINTS a wizard to write
rather than writing one, like `adr new` and `context add`.

A captured value is shape-checked and never echoed — not in the accepting
message, not in the rejecting one, not in the summary, which names TOKEN
and never what it held. Wizards exist partly to walk somebody through
generating credentials, and a token printed back is a token in the
scrollback. Two mutations were applied and watched to fail: echoing the
value back, and swapping Compile for MustCompile so a bad pattern panics
instead of reporting NOT checked.

An unreadable wizard directory reports and exits 1 rather than saying there
are no wizards. Nothing found and nothing readable are different answers.