### PR TITLE
feat: what an agent talks itself into, and the way in

### DIFF
--- a/.agents/rules/procoder.md
+++ b/.agents/rules/procoder.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.clinerules/procoder.md
+++ b/.clinerules/procoder.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.cursor/rules/procoder.mdc
+++ b/.cursor/rules/procoder.mdc
@@ -100,6 +100,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -156,3 +201,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.kilo/rules/procoder.md
+++ b/.kilo/rules/procoder.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.kilocode/rules/procoder.md
+++ b/.kilocode/rules/procoder.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.kiro/steering/procoder.md
+++ b/.kiro/steering/procoder.md
@@ -99,6 +99,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -155,3 +200,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.qoder/rules/procoder.md
+++ b/.qoder/rules/procoder.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.roo/rules/procoder.md
+++ b/.roo/rules/procoder.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/.windsurf/rules/procoder.md
+++ b/.windsurf/rules/procoder.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -151,3 +196,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to

--- a/internal/portability/portability.go
+++ b/internal/portability/portability.go
@@ -90,7 +90,7 @@ metadata:
 // `procoder release` reports when the skill body changed since the last
 // tag and this did not, so a contract change cannot ship silently. Bumping
 // it is a deliberate act: see docs/commands.md.
-const ContractVersion = "1"
+const ContractVersion = "2"
 
 // versionedManifests are the plugin-tier manifests whose version field
 // must match .claude-plugin/plugin.json — a release where every manifest

--- a/skills/procoder/SKILL.md
+++ b/skills/procoder/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 metadata:
   category: development
   author: pascal-watteel
-  contract: "1"
+  contract: "2"
 ---
 
 # Procoder
@@ -112,6 +112,51 @@ until its own gap is closed.
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
 
+## Which command, right now
+
+Read down; take the first row that matches. The chain above is the detail;
+this is the way in.
+
+| Where you are                                | Start here               |
+| -------------------------------------------- | ------------------------ |
+| A repo procoder has never governed           | `procoder audit`         |
+| An idea not yet worth a spec                 | `procoder analyze brief` |
+| Non-trivial work, no spec yet                | `procoder spec template` |
+| A spec that checks COMPLETE                  | `procoder backlog seed`  |
+| Work already committed to, no spec behind it | `procoder todo add`      |
+| A story to build, no plan yet                | `procoder plan template` |
+| Mid-change, about to say it is done          | `procoder check`         |
+| A decision that is not yours                 | `procoder ask`           |
+| A durable choice worth keeping               | `procoder adr new`       |
+| Ready to tag                                 | `procoder release`       |
+| Lost in an unfamiliar codebase               | `procoder index find`    |
+
+## What you talk yourself into
+
+Every row is a thing that has actually been said. The left column is the
+sentence; the right is what is true when it is said.
+
+| The thought                                         | What is true                                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| "Small fix, I will skip `procoder check` this once" | The gate exists for changes too small to look worth checking. That is precisely when it gets skipped and something ships broken.   |
+| "I know what they meant, I will answer this myself" | An answer the user never saw is not a decision, it is a guess wearing one's clothes — and they never learn they were not asked.    |
+| "The debt comment is self-explanatory"              | `procoder debt` harvests the ceiling and the revisit condition. A marker without them is unharvestable, which is to say invisible. |
+| "Tests are slow, I will run the gate without them"  | NOT run is never green. "I will add tests after" is how untested code ships permanently.                                           |
+| "The suite was green before my change"              | Before is not after. The one run that matters is the one over what you are about to commit.                                        |
+| "It is only a docs change"                          | Documentation that is wrong is worse than documentation that is missing, because somebody acts on it.                              |
+| "I will fix the conflict by keeping my side"        | Both sides were somebody's work. Keeping one silently is how a feature vanishes between two green runs.                            |
+| "I am nearly out of context, I will wrap up here"   | Stopping is fine; saying it is finished is not. Say where you stopped.                                                             |
+
+## Before you call it done
+
+Not prose to agree with — five things with an answer.
+
+- [ ] `procoder check` ran clean over this change, this turn
+- [ ] `procoder test` ran, and passed, over what is about to be committed
+- [ ] every `debt:` marker added names a ceiling AND a revisit condition
+- [ ] `.procoder/ask/decisions.md` has no heading the user has not answered
+- [ ] every claim made in the report traces to a command that produced it
+
 ## Build principles
 
 Climb this ladder and stop at the first rung that holds: does it need to
@@ -168,3 +213,4 @@ text).
 Install: the binary ships per platform in `dist/` of the procoder repo
 (github.com/azrtydxb/procoder); put the one for your platform on PATH,
 or use the Claude Code plugin which wires everything automatically.
+


### PR DESCRIPTION
Closes #189, except its progressive-disclosure criterion — see below.

Three of the four asked-for changes, and they could not go where the issue
put them. SKILL.md's body is generated from AGENTS.md and internal/
portability compares the whole body, so a section only SKILL.md carries is
drift and the gate blocks it. Measured before writing anything: the two
bodies were byte-identical, 8854 against 8852 characters. So these land in
AGENTS.md and reach all twelve host files, Cursor and Copilot and Codex
included.

A routing table: where you are, and the first command that fits. It exists
for the case procoder is worst at today — a repo it has never governed,
where the chain reads as a list of subcommands rather than a way in.

A rationalization table. Every row is a sentence that has actually been
said, several of them in this repository's own history: keeping one side of
a merge conflict is how a feature vanished between two green runs, and
'the suite was green before my change' is the shape of a check that was
never re-run.

A five-item checklist with answers rather than prose to nod along to.

That is a change to what the contract REQUIRES, not to its wording, so
ContractVersion goes to 2 — the deliberate bump #196 built it for.

The fourth criterion, splitting per-command detail into references/, is not
done and should not be forced. It asks for SKILL.md under 500 lines; it is
198. And the split it describes is impossible while the body must equal
AGENTS.md byte for byte — tested by adding a skill-only section and
watching the gate call it drift. Changing that generation contract is a
larger decision than this issue scoped.