### PR TITLE
fix: a spec may name the command it introduces, and a value is not a command

### DIFF
--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -62,6 +62,32 @@ type Citation struct {
 	Line int
 }
 
+// declaredCommands returns the top-level procoder commands this spec
+// INTRODUCES: those named in `## Interfaces`, which is where a spec
+// declares the surfaces it exposes.
+//
+// Without this, a spec proposing a new command cannot name it. The
+// citation check resolves against the command registry, and the command is
+// the thing the spec proposes — so every mention was refused, and the
+// workaround was to drop the backticks and lose exactly the checkability
+// the rule protects (#230). Specs extending an existing command never hit
+// it: `procoder backlog bug` resolves because `backlog` is registered.
+//
+// Only while the spec is a draft. A spec marked complete describes work
+// that is done, and a command that still does not exist by then is a real
+// gap rather than a forward reference — so the declaration stops excusing
+// it at exactly the moment it should.
+func declaredCommands(text string) map[string]bool {
+	if statusOf(text) != "draft" {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, m := range commandRe.FindAllStringSubmatch(sectionOf(text, "Interfaces"), -1) {
+		out[m[1]] = true
+	}
+	return out
+}
+
 // UnresolvedCitations returns the citations a document makes that do not
 // exist in the tree.
 //
@@ -71,6 +97,7 @@ type Citation struct {
 // what turns the second into the first.
 func UnresolvedCitations(root, text string) []Citation {
 	symbols := repoSymbols(root)
+	declared := declaredCommands(text)
 	var out []Citation
 	for _, section := range claimSections {
 		body := sectionOf(text, section)
@@ -87,7 +114,7 @@ func UnresolvedCitations(root, text string) []Citation {
 				out = append(out, Citation{Text: cite, Line: lineOf(text, section, i)})
 			}
 			for _, m := range commandRe.FindAllStringSubmatch(line, -1) {
-				if Commands[m[1]] {
+				if Commands[m[1]] || declared[m[1]] {
 					continue
 				}
 				out = append(out, Citation{Text: "procoder " + m[1], Line: lineOf(text, section, i)})
@@ -547,7 +574,16 @@ var hedged = regexp.MustCompile(`(?i)\b(mostly|generally|as appropriate|reasonab
 // the whole group made `--help`, `--version` and `-h` match nothing at all
 // while the tests passed on `echo` alone — raised in review on #218, and
 // verified by probing each shape before the fix.
-var fixedOutput = regexp.MustCompile("`[^`]*(\\becho\\b|\\btrue\\b|\\bcat\\s+[^`]*README|--help\\b|--version\\b|(?:^|\\s)-h\\b)[^`]*`")
+// A command only counts in COMMAND POSITION: at the start of the
+// backticked span, or after a shell separator. `\btrue\b` anywhere inside
+// backticks also matched a TOML value, a JSON field and a Go literal — a
+// criterion asserting `[learn] record = true` was refused as checking a
+// command whose output cannot differ, when it is a setting with a
+// perfectly good failing branch (#231). Flags keep matching anywhere:
+// `--help` is a flag wherever it appears.
+var fixedOutput = regexp.MustCompile(
+	"`(?:[^`]*[|;&]\\s*)?\\$?\\s*(?:echo\\b|true\\b|cat\\s+[^`]*README)[^`]*`" +
+		"|`[^`]*(?:--help\\b|--version\\b|(?:^|\\s)-h\\b)[^`]*`")
 
 // unmeasured is a bar nobody can hold a result against. "Fast enough" and
 // "not too many" name a threshold without giving one, so two people

--- a/internal/spec/truth_test.go
+++ b/internal/spec/truth_test.go
@@ -563,3 +563,105 @@ func TestAMeasuredCriterionIsSilent(t *testing.T) {
 		}
 	}
 }
+
+// #231. The `true` alternative in fixedOutput was matching anywhere inside
+// a backticked span, so a TOML value, a JSON field and a Go literal all
+// read as the shell builtin. Every shape is probed on both sides, because
+// this pattern has silently matched nothing before and the tests passed
+// on `echo` alone.
+//
+// proved by: put `\btrue\b` back as a bare alternative in fixedOutput —
+// the config, JSON and YAML shapes match again and this fails.
+func TestFixedOutputCountsACommandOnlyInCommandPosition(t *testing.T) {
+	weak := []string{
+		"- [ ] `echo hi` prints",
+		"- [ ] `true` returns",
+		"- [ ] `$ echo hi` prints",
+		"- [ ] `cat README.md` shows",
+		"- [ ] `procoder --help` prints",
+		"- [ ] `procoder --version` prints",
+		"- [ ] `foo | true` succeeds",
+		"- [ ] `procoder -h` prints",
+	}
+	fine := []string{
+		"- [ ] `[learn] record = true` enables it",
+		"- [ ] `record = true` in the config",
+		"- [ ] `{\"blocking\": true}` is written",
+		"- [ ] `blocking: true` appears",
+		"- [ ] `procoder check` exits 1",
+		"- [ ] `TestTrueThing` asserts it",
+	}
+	for _, s := range weak {
+		if !fixedOutput.MatchString(s) {
+			t.Errorf("stopped catching a real weak oracle: %s", s)
+		}
+	}
+	for _, s := range fine {
+		if fixedOutput.MatchString(s) {
+			t.Errorf("a value read as a command: %s", s)
+		}
+	}
+}
+
+// #230. A spec that INTRODUCES a command must be able to name it.
+//
+// proved by: drop `|| declared[m[1]]` from UnresolvedCitations — the
+// forward reference is refused again and this fails.
+func TestASpecMayCiteTheCommandItDeclares(t *testing.T) {
+	const draft = `# learn
+
+Status: draft
+
+## Interfaces
+
+- ` + "`procoder learn measure`" + ` — the ranked cost report.
+
+## In scope
+
+- [S-1] ` + "`procoder learn propose`" + ` prints a config change.
+`
+	if got := UnresolvedCitations(t.TempDir(), draft); len(got) != 0 {
+		t.Errorf("a declared command was refused: %#v", got)
+	}
+}
+
+// The declaration is a forward reference, and it expires. A spec marked
+// complete describes work that is done.
+//
+// proved by: remove the `statusOf(text) != "draft"` guard in
+// declaredCommands — the complete spec's citation is excused too, and this
+// fails.
+func TestADeclaredCommandStopsBeingExcusedOnceTheSpecIsComplete(t *testing.T) {
+	const done = `# learn
+
+Status: complete
+
+## Interfaces
+
+- ` + "`procoder learn measure`" + ` — the ranked cost report.
+`
+	got := UnresolvedCitations(t.TempDir(), done)
+	if len(got) == 0 {
+		t.Fatal("a complete spec still excused a command that does not exist")
+	}
+	if got[0].Text != "procoder learn" {
+		t.Errorf("named %q, want `procoder learn`", got[0].Text)
+	}
+}
+
+// proved by: have declaredCommands scan the whole text instead of the
+// Interfaces section — the In scope mention alone declares it and this
+// fails.
+func TestOnlyInterfacesDeclares(t *testing.T) {
+	const draft = `# learn
+
+Status: draft
+
+## In scope
+
+- [S-1] ` + "`procoder learn propose`" + ` prints a config change.
+`
+	if got := UnresolvedCitations(t.TempDir(), draft); len(got) == 0 {
+		t.Error("a command named only in In scope was treated as declared")
+	}
+}


### PR DESCRIPTION
Closes #230, #231. Both were found by writing the spec for #190 and both
were worked around there rather than papered over; this removes the need
for the workaround.

#230: UnresolvedCitations resolved a cited command against the registry,
so a spec proposing a NEW top-level command could not name it — the thing
being proposed is exactly what does not exist yet. The escape is narrow: a
command named in ## Interfaces, which is where a spec declares what it
exposes, is not a dangling citation for the rest of that spec.

It expires. Only while the spec is a draft — a spec marked complete
describes work that is done, and a command that still does not exist by
then is a real gap, not a forward reference. A command named only in
In scope is not declared either; Interfaces is the declaration.

#231: fixedOutput matched \btrue\b anywhere inside backticks, meant for
the shell builtin. A TOML value, a JSON field and a YAML field all read as
a command whose output cannot differ, so a criterion asserting a config
setting was refused for having no failing branch. A command now only counts
in command position: at the start of the span or after a shell separator.
Flags still match anywhere, because --help is a flag wherever it sits.

Every shape is probed on both sides in one test. That file already carries
a comment about this pattern silently matching nothing while the tests
passed on echo alone, so all eight weak shapes and all six legitimate ones
are asserted rather than sampled.

Three mutations applied, compiled, and watched to fail: the bare true
alternative restored (names all four false positives), the declaration
escape emptied, and the draft-only guard removed.