### PR TITLE
fix: the gate job had no headroom, so a slow run read as a failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,14 @@ jobs:
     # procoder's own gate over its own tree: the dogfood job. Formatting
     # gaps, git hygiene, and workflow lint all fail this leg.
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Measured, not guessed: this job ran 8m53s and 9m10s on the two most
+    # recent merges — 89% and 92% of a ten-minute budget — and timed out at
+    # 10m09s on #228 inside `procoder security --deep`. A timeout surfaces
+    # as `cancelled`, which is indistinguishable from a real failure at the
+    # merge gate and sends whoever sees it hunting a defect that is not
+    # there. Twenty gives the deep pass room to be slow without turning a
+    # green tree red.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 gitleaks:allow
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7 gitleaks:allow


### PR DESCRIPTION

#228's gate ran 10m09s against timeout-minutes: 10 and was reported
CANCELLED. I first blamed my own branch pushes for cancelling it through
the concurrency group; that was wrong, and the timestamps say so.

The two most recent merges ran this job for 8m53s and 9m10s — 89% and 92%
of its budget. That is not a flaky run, it is a budget with no room in it,
and the next slow semgrep crosses the line whatever the change was.

A timeout surfaces as "cancelled", which at the merge gate is
indistinguishable from a real failure. Worse than a red build: a red that
sends somebody hunting a defect that does not exist, in a repository whose
rule is that a check which could not run is never reported as one that
passed. The inverse deserves the same care.

Twenty minutes, with the measurement written next to the number so the next
person changing it knows what it was set from.