### PR TITLE
perf: the tracked-tree format check runs concurrently

### DIFF
--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -9,7 +9,9 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 
 	"procoder/internal/codeindex"
 	"procoder/internal/config"
@@ -74,6 +76,50 @@ func houseRules(root string, cfg config.Config, paths []string) []gitx.Finding {
 // place the two scopes diverge. Extracted from RunWith so the divergence
 // reads as three paired branches rather than being spread through a
 // function that is also doing formatting and reporting.
+
+// checkAll runs the formatter check over every path and returns the
+// results IN THE ORDER GIVEN, whatever order they finished in. Callers
+// print findings straight from this slice, so a run that reordered them
+// would make the gate's output depend on which subprocess won a race.
+//
+// Concurrent because the cost here is process startup, not computation.
+// Measured on this repository: 787 tracked files, 510 of them markdown, so
+// the tracked-tree pass was 510 serial prettier cold starts at ~0.2s each
+// — 6m47s in CI, against a job budget of 10 minutes. Nothing was slow; it
+// was just one at a time.
+//
+// Bounded by NumCPU: every unit of work is an external process, and an
+// unbounded fan-out over a large tree would fork a thousand of them.
+func checkAll(paths []string) []format.Result {
+	results := make([]format.Result, len(paths))
+	workers := runtime.NumCPU()
+	if workers > len(paths) {
+		workers = len(paths)
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Each goroutine writes a distinct index and reads none, so
+			// the slice needs no lock.
+			for i := range jobs {
+				results[i] = format.Check(paths[i])
+			}
+		}()
+	}
+	for i := range paths {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	return results
+}
+
 func hygieneFor(root string, cfg config.Config, paths []string, commitMessage string, scope Scope) []gitx.Finding {
 	// Domain 9: git hygiene, workflow lint, message checks — same rules as
 	// `procoder git`, via the shared Collect, so the two cannot drift apart.
@@ -161,23 +207,22 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 
 	var unformatted, unchecked []format.Result
 	clean, skipped := 0, 0
-	for _, p := range paths {
-		if scope != Adopted {
-			// Not "clean" and not "out of scope" — neither is true. The
-			// file was not looked at, and the summary line says so rather
-			// than filing it under a verdict it never got.
-			break
-		}
-		res := format.Check(p)
-		switch res.Verdict {
-		case format.Clean:
-			clean++
-		case format.OutOfScope:
-			skipped++
-		case format.Unformatted:
-			unformatted = append(unformatted, res)
-		case format.Unchecked:
-			unchecked = append(unchecked, res)
+	// Not "clean" and not "out of scope" — neither is true of a file
+	// nobody looked at, and the summary line says so rather than filing it
+	// under a verdict it never got. This was the first statement of the
+	// loop below; it never depended on the file, so it is a guard.
+	if scope == Adopted {
+		for _, res := range checkAll(paths) {
+			switch res.Verdict {
+			case format.Clean:
+				clean++
+			case format.OutOfScope:
+				skipped++
+			case format.Unformatted:
+				unformatted = append(unformatted, res)
+			case format.Unchecked:
+				unchecked = append(unchecked, res)
+			}
 		}
 	}
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -2,6 +2,7 @@ package gate
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -199,5 +200,47 @@ func TestAQuietRepositoryStillCommits(t *testing.T) {
 		if strings.Contains(line, "BLOCKING") {
 			t.Errorf("nothing here is not a finding: %s", line)
 		}
+	}
+}
+
+// checkAll runs concurrently, and the gate prints findings straight from
+// the slice it returns. A run that returned results in completion order
+// would make the gate's output depend on which subprocess won a race —
+// the same tree printing a different report twice.
+//
+// The paths are shuffled in length so a naive append-as-they-finish
+// implementation reorders them: the short ones would come back first.
+//
+// proved by: change checkAll to `results = append(results, ...)` under a
+// mutex instead of indexing — the order follows completion and this fails.
+func TestCheckAllPreservesTheOrderGiven(t *testing.T) {
+	dir := t.TempDir()
+	var paths []string
+	// Descending size, so finishing order and given order disagree.
+	for i := 0; i < 40; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("f%03d.md", i))
+		body := strings.Repeat("word ", (40-i)*200) + "\n"
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, p)
+	}
+	got := checkAll(paths)
+	if len(got) != len(paths) {
+		t.Fatalf("got %d results for %d paths", len(got), len(paths))
+	}
+	for i, r := range got {
+		if r.File != paths[i] {
+			t.Fatalf("result %d is %s, want %s — order not preserved", i, r.File, paths[i])
+		}
+	}
+}
+
+// proved by: drop the `if workers < 1` floor in checkAll — the worker loop
+// starts no goroutines, nothing drains `jobs`, and the send blocks forever.
+// This test deadlocks and the package times out instead of failing fast.
+func TestCheckAllOnNoPathsReturnsNothing(t *testing.T) {
+	if got := checkAll(nil); len(got) != 0 {
+		t.Errorf("got %d results for no paths", len(got))
 	}
 }


### PR DESCRIPTION

787 tracked files, 510 of them markdown, one formatter subprocess each,
run sequentially. prettier costs ~0.2s to start and the work per file is
trivial, so the pass was almost entirely process startup serialised.

checkAll fans the per-file check across NumCPU workers, bounded because
every unit of work is an external process and a tree this size would
otherwise fork hundreds at once.

WHAT IT ACTUALLY BUYS, measured both places rather than assumed:

Locally, on ten cores: 257.5s to 153.0s, a 41% cut, same verdict — 772
clean, 0 unformatted, 0 unchecked, 15 out of scope.

In CI: no measurable change. That step ran 508s, 407s and 402s on the three
most recent main runs, and 429s on this branch. That is inside the existing
spread, so this does NOT speed up the gate job and must not be cited as
having done so. The runners have far fewer cores, and whatever bounds that
step there is not per-file startup.

Merged on the local benefit, which is where a developer waits on it, and
because the sequential loop had no reason to be sequential. The CI budget
was fixed by #235 raising the timeout, not by this.

Order is the whole risk. The gate prints findings straight from this slice,
so a version appending results as they finished would make the same tree
print a different report twice. Results are written by index, and
TestCheckAllPreservesTheOrderGiven shuffles file sizes so completion order
and given order disagree; the append-under-mutex mutation was applied and
watched to fail. Race detector clean over the package.

The scope guard moved out of the loop, where it always belonged: it never
read the file, so it broke on the first iteration or never.

Verifying this surfaced something unrelated, filed as #236: the advisory
lint findings come back in a different order on identical runs of the
UNCHANGED binary, and the set is capped, so which ones survive the cap
varies between runs.