### PR TITLE
ci: the gate job scanned the tree twice, and split it silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,13 @@ jobs:
           echo "PROCODER_PUPPETEER_CONFIG=/tmp/puppeteer.json" >> "$GITHUB_ENV"
       - name: doctor
         run: procoder doctor
+      # One invocation, not a pipeline into xargs. xargs splits a long
+      # list into batches and runs the command once per batch, and each
+      # run pays a full semgrep and osv-scanner pass while reporting as
+      # though it were the only one. 787 files fits in a single batch
+      # today — silently, and only until it does not.
       - name: gate over the tracked tree
-        run: git ls-files | xargs procoder check
-      - name: security, the deep pass
-        run: procoder security --deep
+        run: git ls-files | procoder check --paths-from -
       - name: documentation report, external links included
         run: procoder docs --external
         env:

--- a/cmd/procoder/flags.go
+++ b/cmd/procoder/flags.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 )
 
@@ -22,6 +23,7 @@ import (
 // applied to the other seventy-seven.
 var knownFlags = map[string][]string{
 	"ask":          {"--file"},
+	"check":        {"--paths-from"},
 	"backlog":      {"--epic", "--milestone", "--severity"},
 	"bench":        {"--save"},
 	"ci":           {"--runs"},
@@ -158,4 +160,50 @@ func flagValue(args []string, name string) string {
 		}
 	}
 	return ""
+}
+
+// pathsFrom reads `--paths-from <file>` (or `-` for stdin) into a path
+// list. It returns (nil, false, 0) when the flag is absent, so the caller
+// falls through to its positional paths unchanged.
+//
+// One path per line. A blank line is skipped; nothing else is
+// interpreted, because a file name is whatever git printed.
+func pathsFrom(args []string, stdin io.Reader, out func(string)) (paths []string, handled bool, code int) {
+	src := ""
+	for i, a := range args {
+		if a == "--paths-from" {
+			if i+1 >= len(args) {
+				out("--paths-from needs a file, or - for stdin")
+				return nil, true, 2
+			}
+			src = args[i+1]
+		}
+	}
+	if src == "" {
+		return nil, false, 0
+	}
+	var raw []byte
+	var err error
+	if src == "-" {
+		raw, err = io.ReadAll(stdin)
+	} else {
+		raw, err = os.ReadFile(src)
+	}
+	if err != nil {
+		// Unknown is never none: a list that could not be read must not
+		// become an empty list, which the gate would read as "nothing
+		// changed" and report clean.
+		out("--paths-from could not read " + src + " (" + err.Error() + ") — nothing was checked")
+		return nil, true, 2
+	}
+	for _, line := range strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			paths = append(paths, line)
+		}
+	}
+	if len(paths) == 0 {
+		out("--paths-from " + src + " listed no files — nothing was checked")
+		return nil, true, 2
+	}
+	return paths, false, 0
 }

--- a/cmd/procoder/flags_test.go
+++ b/cmd/procoder/flags_test.go
@@ -29,8 +29,25 @@ func TestAFlagTheCommandDoesNotImplementIsRefused(t *testing.T) {
 	if !strings.Contains(errb.String(), "--staged") {
 		t.Errorf("the refusal must name the flag: %q", errb.String())
 	}
-	if !strings.Contains(errb.String(), "no flags") {
+	if !strings.Contains(errb.String(), "--paths-from") {
 		t.Errorf("the refusal must say what check does take: %q", errb.String())
+	}
+}
+
+// The other half of the same message. `check` used to be the example of a
+// command taking no flags at all, and stopped being one when --paths-from
+// landed — so the "no flags" wording needs a command that still is, or the
+// branch goes untested the moment any command gains its first flag.
+//
+// proved by: change the empty-allowed branch in checkFlags to print the
+// same sentence as the non-empty one — this fails.
+func TestACommandWithNoFlagsSaysSo(t *testing.T) {
+	var errb bytes.Buffer
+	if _, ok := checkFlags([]string{"doctor", "--nope"}, &errb); ok {
+		t.Fatal("doctor accepted --nope, which it does not implement")
+	}
+	if !strings.Contains(errb.String(), "no flags") {
+		t.Errorf("a command with no flags must say so: %q", errb.String())
 	}
 }
 

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -253,7 +253,8 @@ const usage = `usage: procoder <command> [args]
                        marked and exit 1; --save records a new baseline
   check [paths...]     the commit gate: changed files (or the given paths) must
                        be formatted; unchecked counts as failing, skipped file
-                       types are counted out loud
+                       types are counted out loud. --paths-from <file|-> reads
+                       the list instead, so a whole tree is ONE invocation
   ci [--runs]          workflow hygiene: pinned actions, job timeouts,
                        concurrency cancellation, tests exist; --runs asks gh
                        for this branch's newest run per workflow instead, and
@@ -571,7 +572,21 @@ func run(args []string) int {
 		}
 		return sprintCmd(args[1:])
 	case "check":
-		return gate.Run(args[1:], doctor.Root(), os.Stdout)
+		// --paths-from reads the file list from a file or stdin, so a
+		// whole-tree run is ONE invocation. `git ls-files | xargs procoder
+		// check` looks equivalent and is not: xargs splits a long list
+		// into batches, and each batch pays a full semgrep and
+		// osv-scanner pass while reporting as though it were the only
+		// one. It fits in one batch today at 787 files, silently, which
+		// is the kind of thing that stops being true without telling you.
+		paths, handled, code := pathsFrom(args[1:], os.Stdin, printLine)
+		if handled {
+			return code
+		}
+		if paths == nil {
+			paths = args[1:]
+		}
+		return gate.Run(paths, doctor.Root(), os.Stdout)
 	case "config":
 		return config.Report(doctor.Root(), os.Stdout)
 	case "doctor":

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -75,7 +75,7 @@ order. Exit 1 while the repository would fail the gate; the
 
 ### Everyday commands
 
-#### `procoder check [paths...]`
+#### `procoder check [paths...] [--paths-from <file|->]`
 
 The commit gate. Over the changed files (or the given paths): formatting
 (unformatted and unchecked both fail), git hygiene (conflict markers, junk
@@ -106,6 +106,15 @@ lenses are pointed at exactly that. Nothing checks that four passes
 happened — nothing on disk could — so this is a discipline, not a gate.
 What it buys is that thoroughness comes from asking four different
 questions rather than asking the same one harder.
+
+`--paths-from` reads the file list from a file, or from stdin with `-`,
+one path per line. It exists so a whole-tree run is a single invocation:
+`git ls-files | xargs procoder check` looks equivalent and is not, because
+xargs splits a long list into batches and runs the command once per batch —
+each one paying a full semgrep and osv-scanner pass while reporting as
+though it were the only one. A list that cannot be read, or that names no
+files, exits 2 rather than becoming an empty list the gate would call
+clean.
 
 **Known pitfalls.**
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -244,3 +244,28 @@ func TestCheckAllOnNoPathsReturnsNothing(t *testing.T) {
 		t.Errorf("got %d results for no paths", len(got))
 	}
 }
+
+// CI no longer runs `procoder security --deep`: it was a second whole-tree
+// semgrep and osv-scanner pass over what the tracked-tree gate had just
+// scanned. That makes the gate the ONLY place CI gets whole-tree SAST and
+// dependency findings, so these legs disappearing from here would take
+// CI's coverage with them and nothing would say so — the report would
+// simply stop mentioning what it no longer looked for.
+//
+// Source-level on purpose. A behavioural test needs semgrep installed and
+// would pass by reporting "NOT checked" on a machine without it, which is
+// exactly the shape of green this repository refuses.
+//
+// proved by: delete either call from Run/hygieneFor — this fails and names
+// the one that went.
+func TestTheGateStillCarriesTheWholeTreeSecurityLegs(t *testing.T) {
+	src, err := os.ReadFile("gate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range []string{"security.SastChanged(", "security.DepsChanged("} {
+		if !strings.Contains(string(src), call) {
+			t.Errorf("gate.go no longer calls %s — CI dropped `security --deep` because the gate covered it, so this is CI losing a check silently", call)
+		}
+	}
+}


### PR DESCRIPTION

Two problems in one step pair, both found by asking what the gate job
actually runs rather than what it looks like it runs.

The deep pass was a duplicate. "gate over the tracked tree" passes every
tracked file to procoder check, and check runs security.SastChanged and
security.DepsChanged unconditionally. SastChanged calls the same whole-tree
semgrep scan the deep pass calls and then filters its findings to the files
it was given — which, given the whole tree, filters nothing. DepsChanged
returns Deps(root), the whole tree, whenever a manifest is among them, and
all of them are. So semgrep and osv-scanner each ran twice per gate job,
the second time producing findings the first had already reported.

The pipeline could split. xargs runs the command once per batch when the
list is long, and each batch would pay its own full semgrep and
osv-scanner pass while its report read as though it were the only run. 787
paths fits in one batch today. That is a property of the current file
count, not a guarantee, and nothing would announce the day it changed.

check now takes --paths-from <file|->, so the tree goes in as one
invocation with no length limit. A list that cannot be read, or that names
no files, exits 2 — an unreadable list must not become an empty one, which
the gate would report as clean.

Removing the deep step makes the gate the only place CI gets whole-tree
SAST and dependency findings, so TestTheGateStillCarriesTheWholeTreeSecurityLegs
fails if either call leaves gate.go, naming which one went. It reads the
source rather than running semgrep on purpose: a behavioural test passes by
reporting "NOT checked" on a machine without the tool, which is the shape
of green this repository refuses. The mutation was applied and watched.

TestAFlagTheCommandDoesNotImplementIsRefused used check as its example of
a command taking no flags, which check has now stopped being. Both branches
are covered rather than one: check refuses --staged and names
--paths-from, and doctor still says "it takes no flags".

This is not a speed change. Semgrep is about six seconds of a seven-minute
job and the second pass was six more; the point is that the report said a
thing twice and would have quietly said it five times on a bigger tree.