### PR TITLE
perf: the gate's independent passes run at once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,17 @@ jobs:
         run: |
           echo "{\"executablePath\": \"$(which google-chrome)\", \"args\": [\"--no-sandbox\"], \"timeout\": 120000, \"protocolTimeout\": 180000}" > /tmp/puppeteer.json
           echo "PROCODER_PUPPETEER_CONFIG=/tmp/puppeteer.json" >> "$GITHUB_ENV"
+      # What this runner actually has. Two concurrency changes (#237, #240)
+      # cut the gate's wall time substantially on a ten-core laptop and did
+      # nothing measurable here, and the standing explanation is that the
+      # work is CPU-bound with no spare cores to fan out into. That was a
+      # hypothesis nobody could check, because nothing recorded the machine
+      # the number came from. One line, so the next person comparing a
+      # local timing against a CI one knows what they are comparing.
+      - name: what this runner has
+        run: |
+          echo "cores: $(nproc)"
+          echo "memory: $(free -g 2>/dev/null | awk '/^Mem:/{print $2 " GB"}')"
       - name: doctor
         run: procoder doctor
       - name: gate over the tracked tree

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -52,18 +52,31 @@ func houseRules(root string, cfg config.Config, paths []string) []gitx.Finding {
 		// default, blocking when the repo opted in ([lint] policy = "block").
 		// A house rule by definition: it is procoder's choice of linter, and a
 		// project that picked another one did not ask to be told about this.
-		func() []gitx.Finding { return lint.Files(root, paths, cfg.LintBlock) },
+		// Lint and complexity share golangci-lint, and golangci-lint
+		// refuses to run twice at once — it takes a lock and the second
+		// instance dies with "parallel golangci-lint is running", which
+		// this gate then reports as a blocking complexity failure. They
+		// are one leg for that reason, run in order inside it. CI caught
+		// this on the change that made these concurrent; locally the two
+		// happened never to overlap.
+		//
+		// The wording above is deliberate: the no-silent-green audit reads
+		// this file as text, and the phrase it looks for inside a comment
+		// here reads as an unblocked finding.
+		func() []gitx.Finding {
+			out := lint.Files(root, paths, cfg.LintBlock)
+			// Complexity on the files this commit carries. Reported unless
+			// the repository asked for block: these are judgement calls,
+			// and a threshold that blocks by surprise stops work on
+			// exactly the files that need the refactor.
+			return append(out, maintain.ComplexityChanged(root, paths, cfg.MaintainBlock)...)
+		},
 		// Domain 1, the SAST leg: findings on the files this commit carries.
 		// It costs seconds rather than milliseconds — semgrep's rule loading
 		// is a fixed cost that scoping cannot remove — and it is here because
 		// a commit is not a keystroke, and a finding caught now is caught
 		// before it leaves the machine.
 		func() []gitx.Finding { return security.SastChanged(root, paths) },
-		// Complexity on the files this commit carries. Reported unless the
-		// repository asked for block: these are judgement calls, and a
-		// threshold that blocks by surprise stops work on exactly the files
-		// that need the refactor.
-		func() []gitx.Finding { return maintain.ComplexityChanged(root, paths, cfg.MaintainBlock) },
 		// Known vulnerabilities, when the commit touches a dependency
 		// manifest. Only then: the scan answers about the manifests, so a
 		// commit that edits a comment would pay nearly a second to be told the

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -35,40 +35,77 @@ import (
 // They are grouped so the gate has one place to ask "did this repository
 // ask for procoder's opinions", rather than nine.
 func houseRules(root string, cfg config.Config, paths []string) []gitx.Finding {
+	// Each leg shells out to a different tool and none reads another's
+	// answer, so they wait on each other for no reason. Measured over this
+	// repository's 787 tracked files: gitleaks 41.2s, the suite 35.0s,
+	// semgrep 25.3s, then lint 2.8s, osv 2.6s, complexity 1.1s, debt 0.2s
+	// — 108s in a row, against 41s if the longest one sets the pace.
+	//
+	// The ORDER OF THE RESULTS is fixed regardless. Findings are printed
+	// straight out of this slice, and a gate whose report reordered itself
+	// between runs would make "did my change alter this?" unanswerable —
+	// see #236 for what that costs when it happens by accident. Each leg
+	// writes its own slot; the concatenation below is in declaration
+	// order, whatever order they finished in.
+	legs := []func() []gitx.Finding{
+		// Domain 2: the canonical linters over the changed set — report by
+		// default, blocking when the repo opted in ([lint] policy = "block").
+		// A house rule by definition: it is procoder's choice of linter, and a
+		// project that picked another one did not ask to be told about this.
+		func() []gitx.Finding { return lint.Files(root, paths, cfg.LintBlock) },
+		// Domain 1, the SAST leg: findings on the files this commit carries.
+		// It costs seconds rather than milliseconds — semgrep's rule loading
+		// is a fixed cost that scoping cannot remove — and it is here because
+		// a commit is not a keystroke, and a finding caught now is caught
+		// before it leaves the machine.
+		func() []gitx.Finding { return security.SastChanged(root, paths) },
+		// Complexity on the files this commit carries. Reported unless the
+		// repository asked for block: these are judgement calls, and a
+		// threshold that blocks by surprise stops work on exactly the files
+		// that need the refactor.
+		func() []gitx.Finding { return maintain.ComplexityChanged(root, paths, cfg.MaintainBlock) },
+		// Known vulnerabilities, when the commit touches a dependency
+		// manifest. Only then: the scan answers about the manifests, so a
+		// commit that edits a comment would pay nearly a second to be told the
+		// same thing it was told last time.
+		func() []gitx.Finding { return security.DepsChanged(root, paths) },
+		// Debt markers with no revisit condition, in the files this commit
+		// carries. The whole ledger is the tree's and belongs to CI; what
+		// belongs here is the shortcut being taken right now, while the reason
+		// for it is still in the author's head.
+		func() []gitx.Finding { return debt.GateCheck(root, paths) },
+		// The suite, narrowed to the packages this commit touches: the whole
+		// suite cold is a minute on this repository and one package is a
+		// second. A failing test blocks where the repository asked; a suite
+		// that could not run blocks regardless, because the policy governs
+		// whether a FAILING test stops a commit and "no answer" is not a
+		// verdict it has an opinion about.
+		func() []gitx.Finding { return testrun.GateCheck(root, paths, cfg.TestBlock) },
+	}
+	return concurrently(legs)
+}
+
+// concurrently runs every leg at once and returns their findings
+// concatenated IN DECLARATION ORDER, not completion order.
+//
+// Unbounded on purpose, unlike the per-file fan-out: this is a handful of
+// legs fixed at compile time, not one unit of work per file in the tree.
+func concurrently(legs []func() []gitx.Finding) []gitx.Finding {
+	results := make([][]gitx.Finding, len(legs))
+	var wg sync.WaitGroup
+	for i, leg := range legs {
+		wg.Add(1)
+		go func(i int, leg func() []gitx.Finding) {
+			defer wg.Done()
+			// Distinct index per goroutine, read by none of them: no lock.
+			results[i] = leg()
+		}(i, leg)
+	}
+	wg.Wait()
 	var out []gitx.Finding
-	// Domain 2: the canonical linters over the changed set — report by
-	// default, blocking when the repo opted in ([lint] policy = "block").
-	// A house rule by definition: it is procoder's choice of linter, and a
-	// project that picked another one did not ask to be told about this.
-	out = append(out, lint.Files(root, paths, cfg.LintBlock)...)
-	// Domain 1, the SAST leg: findings on the files this commit carries.
-	// It costs seconds rather than milliseconds — semgrep's rule loading
-	// is a fixed cost that scoping cannot remove — and it is here because
-	// a commit is not a keystroke, and a finding caught now is caught
-	// before it leaves the machine.
-	out = append(out, security.SastChanged(root, paths)...)
-	// Complexity on the files this commit carries. Reported unless the
-	// repository asked for block: these are judgement calls, and a
-	// threshold that blocks by surprise stops work on exactly the files
-	// that need the refactor.
-	out = append(out, maintain.ComplexityChanged(root, paths, cfg.MaintainBlock)...)
-	// Known vulnerabilities, when the commit touches a dependency
-	// manifest. Only then: the scan answers about the manifests, so a
-	// commit that edits a comment would pay nearly a second to be told the
-	// same thing it was told last time.
-	out = append(out, security.DepsChanged(root, paths)...)
-	// Debt markers with no revisit condition, in the files this commit
-	// carries. The whole ledger is the tree's and belongs to CI; what
-	// belongs here is the shortcut being taken right now, while the reason
-	// for it is still in the author's head.
-	out = append(out, debt.GateCheck(root, paths)...)
-	// The suite, narrowed to the packages this commit touches: the whole
-	// suite cold is a minute on this repository and one package is a
-	// second. A failing test blocks where the repository asked; a suite
-	// that could not run blocks regardless, because the policy governs
-	// whether a FAILING test stops a commit and "no answer" is not a
-	// verdict it has an opinion about.
-	out = append(out, testrun.GateCheck(root, paths, cfg.TestBlock)...)
+	for _, r := range results {
+		out = append(out, r...)
+	}
 	return out
 }
 
@@ -121,44 +158,52 @@ func checkAll(paths []string) []format.Result {
 }
 
 func hygieneFor(root string, cfg config.Config, paths []string, commitMessage string, scope Scope) []gitx.Finding {
-	// Domain 9: git hygiene, workflow lint, message checks — same rules as
-	// `procoder git`, via the shared Collect, so the two cannot drift apart.
-	//
-	// In a non-adopting repository only its universal half runs: conflict
-	// markers, junk, oversized files and the attribution trailer. The rest
-	// of it — the agent layer, release and documentation hygiene,
-	// procoder's own templates, the planning chain — is procoder's house
-	// style, and a project that never asked for it is not answerable to it.
-	var hygiene []gitx.Finding
-	if scope == Adopted {
-		hygiene = gitcmd.CollectFor(root, cfg, paths, commitMessage)
-	} else {
-		hygiene = gitcmd.CollectUniversal(root, cfg, paths, commitMessage)
-	}
-	// Domain 1: a secret in a changed file blocks, always — in any
-	// repository. What narrows outside an adopting one is WHERE it looks:
-	// only the lines this commit wrote, because four thousand lines
-	// somebody else wrote are not this commit's to answer for.
-	if scope == Adopted {
-		// Conflict markers are not added here: CollectFor already ran
-		// them whole-file, which is what an adopting repository asked for.
-		hygiene = append(hygiene, security.SecretsChangedFiles(root, paths)...)
-	} else {
-		hygiene = append(hygiene, security.SecretsInDiff(root, paths)...)
-		// The same narrowing, for the same reason: a marker four thousand
-		// lines away in somebody else's file is not this commit's doing.
-		hygiene = append(hygiene, gitx.NarrowToDiff(root, paths, gitx.ConflictMarkers(paths))...)
-	}
-	// Everything from here to the suite is procoder's opinion about how
-	// code should be written, and runs only where that was asked for. One
-	// block rather than a flag on each: a repository either wanted these
-	// or it did not, and a per-domain matrix would be configuration for
-	// repositories that by definition carry no configuration.
-	if scope == Adopted {
-		hygiene = append(hygiene, houseRules(root, cfg, paths)...)
-	}
-
-	return hygiene
+	// Three independent blocks, run at once. Measured over 787 tracked
+	// files: the secret scan is ~41s and the house rules ~46s, and neither
+	// reads the other's answer, so waiting was costing the sum of them.
+	// Order of the findings is fixed by declaration, not by which finished.
+	return concurrently([]func() []gitx.Finding{
+		// Domain 9: git hygiene, workflow lint, message checks — same rules as
+		// `procoder git`, via the shared Collect, so the two cannot drift apart.
+		//
+		// In a non-adopting repository only its universal half runs: conflict
+		// markers, junk, oversized files and the attribution trailer. The rest
+		// of it — the agent layer, release and documentation hygiene,
+		// procoder's own templates, the planning chain — is procoder's house
+		// style, and a project that never asked for it is not answerable to it.
+		func() []gitx.Finding {
+			if scope == Adopted {
+				return gitcmd.CollectFor(root, cfg, paths, commitMessage)
+			}
+			return gitcmd.CollectUniversal(root, cfg, paths, commitMessage)
+		},
+		// Domain 1: a secret in a changed file blocks, always — in any
+		// repository. What narrows outside an adopting one is WHERE it looks:
+		// only the lines this commit wrote, because four thousand lines
+		// somebody else wrote are not this commit's to answer for.
+		func() []gitx.Finding {
+			if scope == Adopted {
+				// Conflict markers are not added here: CollectFor already ran
+				// them whole-file, which is what an adopting repository asked for.
+				return security.SecretsChangedFiles(root, paths)
+			}
+			out := security.SecretsInDiff(root, paths)
+			// The same narrowing, for the same reason: a marker four thousand
+			// lines away in somebody else's file is not this commit's doing.
+			return append(out, gitx.NarrowToDiff(root, paths, gitx.ConflictMarkers(paths))...)
+		},
+		// Everything here is procoder's opinion about how code should be
+		// written, and runs only where that was asked for. One block rather
+		// than a flag on each: a repository either wanted these or it did
+		// not, and a per-domain matrix would be configuration for
+		// repositories that by definition carry no configuration.
+		func() []gitx.Finding {
+			if scope != Adopted {
+				return nil
+			}
+			return houseRules(root, cfg, paths)
+		},
+	})
 }
 
 // Run checks the given paths, or the repository's changed files when none are
@@ -205,6 +250,16 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	// procoder's taste is exactly the overreach #172 reported.
 	scope, why := ScopeFor(root, cfg.GateScope)
 
+	// The formatting pass and the hygiene pass are the two halves of the
+	// gate and neither reads the other, so they run at once. They were the
+	// last two big blocks still waiting in line: ~45s of formatter startup
+	// and ~46s of hygiene on this repository's 787 files.
+	//
+	// Started here and collected below, where its findings are first
+	// needed — the formatting results are printed before them.
+	hygieneDone := make(chan []gitx.Finding, 1)
+	go func() { hygieneDone <- hygieneFor(root, cfg, paths, commitMessage, scope) }()
+
 	var unformatted, unchecked []format.Result
 	clean, skipped := 0, 0
 	// Not "clean" and not "out of scope" — neither is true of a file
@@ -233,7 +288,7 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 		fmt.Fprintf(stdout, "UNCHECKED    %s — %s\n", r.File, r.Reason)
 	}
 
-	hygiene := hygieneFor(root, cfg, paths, commitMessage, scope)
+	hygiene := <-hygieneDone
 
 	fmt.Fprintf(stdout, "gate scope: %s (%s)\n", scope, why)
 	if scope == Universal {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -292,3 +292,44 @@ func TestConcurrentlyKeepsALegThatFoundNothing(t *testing.T) {
 		t.Errorf("got %#v", got)
 	}
 }
+
+// golangci-lint takes a lock and the second concurrent instance dies with
+// "parallel golangci-lint is running", which the gate reports as a
+// BLOCKING "complexity NOT checked". Two legs used to call it — lint and
+// complexity — and making the legs concurrent made them collide. CI caught
+// it; locally they happened never to overlap, which is the worst way for a
+// race to behave.
+//
+// Source-level because the collision needs a real golangci-lint and two
+// real invocations to reproduce, and a test that needs the tool installed
+// passes by not running.
+//
+// proved by: split maintain.ComplexityChanged back into its own entry in
+// the legs slice — two legs then call golangci-lint and this fails.
+func TestOneLegOwnsGolangciLint(t *testing.T) {
+	src, err := os.ReadFile("gate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+	start := strings.Index(body, "legs := []func() []gitx.Finding{")
+	if start < 0 {
+		t.Fatal("the legs slice is gone; this test is pinning something that no longer exists")
+	}
+	end := strings.Index(body[start:], "\n\t}\n")
+	if end < 0 {
+		t.Fatal("could not find the end of the legs slice")
+	}
+	legs := body[start : start+end]
+
+	// Each `func() []gitx.Finding {` inside the slice is one leg.
+	var callers int
+	for _, leg := range strings.Split(legs, "func() []gitx.Finding")[1:] {
+		if strings.Contains(leg, "lint.Files(") || strings.Contains(leg, "maintain.ComplexityChanged(") {
+			callers++
+		}
+	}
+	if callers != 1 {
+		t.Errorf("%d legs reach golangci-lint; exactly one may, or they race for its lock", callers)
+	}
+}

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"procoder/internal/gitx"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // stubGitleaks puts a fake gitleaks on PATH that reports no leaks, so the
@@ -242,5 +244,51 @@ func TestCheckAllPreservesTheOrderGiven(t *testing.T) {
 func TestCheckAllOnNoPathsReturnsNothing(t *testing.T) {
 	if got := checkAll(nil); len(got) != 0 {
 		t.Errorf("got %d results for no paths", len(got))
+	}
+}
+
+// The gate prints findings straight out of what concurrently returns, so
+// completion order would make the same tree print a different report twice
+// — the accidental version of which is #236, and the cost of it is that
+// "did my change alter this?" stops being answerable.
+//
+// Leg 0 is the slowest, so a version that appended as legs finished would
+// put it last.
+//
+// proved by: append into a shared slice under a mutex instead of writing
+// results[i] — this fails on the first element.
+func TestConcurrentlyReturnsResultsInDeclarationOrder(t *testing.T) {
+	mk := func(name string, d time.Duration) func() []gitx.Finding {
+		return func() []gitx.Finding {
+			time.Sleep(d)
+			return []gitx.Finding{{Message: name}}
+		}
+	}
+	got := concurrently([]func() []gitx.Finding{
+		mk("first", 60*time.Millisecond),
+		mk("second", 30*time.Millisecond),
+		mk("third", 0),
+	})
+	want := []string{"first", "second", "third"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d findings, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Message != w {
+			t.Errorf("position %d is %q, want %q — declaration order not preserved", i, got[i].Message, w)
+		}
+	}
+}
+
+// proved by: drop the `results[i] = leg()` write and return `out` built
+// only from non-nil legs — the nil leg vanishes, the slice shortens, and
+// callers that index by leg lose their alignment.
+func TestConcurrentlyKeepsALegThatFoundNothing(t *testing.T) {
+	got := concurrently([]func() []gitx.Finding{
+		func() []gitx.Finding { return nil },
+		func() []gitx.Finding { return []gitx.Finding{{Message: "only"}} },
+	})
+	if len(got) != 1 || got[0].Message != "only" {
+		t.Errorf("got %#v", got)
 	}
 }

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -311,7 +311,12 @@ func TestOneLegOwnsGolangciLint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body := string(src)
+	// CRLF first. Windows checks the tree out with \r\n, so a pattern
+	// written as "\n\t}\n" matches nothing there and this test failed
+	// with "could not find the end of the legs slice" on Windows alone —
+	// a test reporting that it cannot see what it is pinning, which is the
+	// same silent green it exists to prevent.
+	body := strings.ReplaceAll(strings.ReplaceAll(string(src), "\r\n", "\n"), "\r", "\n")
 	start := strings.Index(body, "legs := []func() []gitx.Finding{")
 	if start < 0 {
 		t.Fatal("the legs slice is gone; this test is pinning something that no longer exists")


### PR DESCRIPTION
The tracked-tree gate was a queue of external tools waiting on each other
for no reason. Measured over this repository's 787 files before touching
anything, rather than guessed at: gitleaks 41s, the suite 35s, semgrep 25s,
then lint 2.8s, osv 2.6s, complexity 1.1s, debt 0.2s — and the formatting
pass another 45s on top. None of them reads another's answer.

Three levels of the same fix. The house-rule legs run together. The three
blocks inside hygieneFor — git hygiene, the secret scan, the house rules —
run together. And the formatting pass, which was the other half of the
gate, now runs alongside hygiene instead of before it.

136.3s to 73.7s, mean of three runs each, alternating: 155.0/130.8/123.2
against 73.6/74.5/72.9. No overlap between the two ranges. Verdicts
identical, compared line by line.

Order is the risk and it is pinned in two places. The gate prints findings
straight out of these slices, so a version appending as legs finished would
make the same tree print a different report twice — the accidental version
of that is #236, and its cost is that "did my change alter this?" stops
being answerable. Every leg writes its own slot and the concatenation is in
declaration order. TestConcurrentlyReturnsResultsInDeclarationOrder makes
leg zero the slowest so completion order and declaration order disagree;
the append-under-mutex mutation reverses the result and was watched to
fail. TestConcurrentlyKeepsALegThatFoundNothing pins that a leg finding
nothing still occupies its position. Race detector clean over the package.

MEASURED IN CI, and it does not help there: 411s for that step, against a
baseline of 508s, 407s and 402s on recent main runs. Inside the spread, so
this is NOT a CI speedup and must not be cited as one — the same result
#237 got, for what looks like the same reason.

The likely cause, stated as a hypothesis rather than a finding: the gate is
CPU-bound, and concurrency only pays where there are spare cores. Ten cores
here have slack; a hosted runner has very little, and running gitleaks,
semgrep and the suite at once does not reduce the total CPU work, it only
stops them queueing. Verifying that needs the runner core count, which
nothing in the workflow currently prints.

Merged on the local benefit: 63 seconds off every `procoder check` a person
waits on, and the passes had no reason to queue.

---


CI caught a defect in the change that made the gate's legs concurrent.
golangci-lint takes a lock and refuses a second instance: the two legs that
call it collided, the loser died with "parallel golangci-lint is running",
and the gate reported that as a blocking complexity failure. Locally the
two happened never to overlap, which is the worst way for a race to behave
— it looked fine on every run here.

They are one leg now, run in order inside it. TestOneLegOwnsGolangciLint
reads the legs slice and counts how many reach the tool; splitting them
back apart fails it, and the mutation was applied and watched.

Source-level because reproducing the collision needs a real golangci-lint
and two real invocations, and a test that needs the tool installed passes
by not running.

One comment reworded rather than the audit relaxed. The comment quoted the
CI error verbatim, and the no-silent-green audit reads this file as text: a
slice-of-functions returning findings opens what its pattern takes for a
finding literal, so the quoted phrase inside the function body read as an
unblocked "NOT checked". Narrowing the pattern to exclude that shape also
excluded the ordinary slice-of-findings literal, which is the common form —
the mutation that unblocks a real finding in internal/infra stopped
failing. Weakening a safety check to accommodate a comment is the wrong
trade, so the comment moved instead and the audit is byte-for-byte as it
was.