### PR TITLE
probe: time the gate's legs in CI (temporary, do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,16 +247,18 @@ jobs:
           echo "PROCODER_PUPPETEER_CONFIG=/tmp/puppeteer.json" >> "$GITHUB_ENV"
       - name: doctor
         run: procoder doctor
-      - name: PROBE cores
-        run: echo "cores: $(nproc)"
       - name: PROBE the suite alone
-        run: time procoder test || true
+        run: |
+          time procoder test || true
       - name: PROBE the suite again, cache warm
-        run: time procoder test || true
+        run: |
+          time procoder test || true
       - name: PROBE semgrep alone
-        run: time procoder security --deep || true
+        run: |
+          time procoder security --deep || true
       - name: gate over the tracked tree
-        run: time (git ls-files | xargs procoder check)
+        run: |
+          time sh -c 'git ls-files | xargs procoder check'
       - name: security, the deep pass
         run: procoder security --deep
       - name: documentation report, external links included

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,17 @@ jobs:
       - name: PROBE semgrep alone
         run: |
           time procoder security --deep || true
+      - name: PROBE 50 prettier invocations
+        run: |
+          command -v prettier && prettier --version
+          time (for f in $(git ls-files '*.md' | head -50); do prettier "$f" > /dev/null; done)
+      - name: PROBE gitleaks over the tree
+        run: |
+          command -v gitleaks && gitleaks version
+          time gitleaks detect --no-git --source . --no-banner || true
+      - name: PROBE golangci-lint
+        run: |
+          time procoder lint || true
       - name: gate over the tracked tree
         run: |
           time sh -c 'git ls-files | xargs procoder check'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,8 +247,16 @@ jobs:
           echo "PROCODER_PUPPETEER_CONFIG=/tmp/puppeteer.json" >> "$GITHUB_ENV"
       - name: doctor
         run: procoder doctor
+      - name: PROBE cores
+        run: echo "cores: $(nproc)"
+      - name: PROBE the suite alone
+        run: time procoder test || true
+      - name: PROBE the suite again, cache warm
+        run: time procoder test || true
+      - name: PROBE semgrep alone
+        run: time procoder security --deep || true
       - name: gate over the tracked tree
-        run: git ls-files | xargs procoder check
+        run: time (git ls-files | xargs procoder check)
       - name: security, the deep pass
         run: procoder security --deep
       - name: documentation report, external links included


### PR DESCRIPTION
Temporary probe, not for merge.

Two explanations for the tracked-tree gate step costing ~411s in CI against ~78s locally have been measured and **disproved**:

- **CPU saturation** — the concurrent gate uses 207 CPU-seconds at 2.6 cores busy; on 4 cores that floors at ~52s.
- **semgrep rule caching** — cold 22.1s vs warm 21.3s, and `~/.semgrep` is 4KB, so it was never a rule cache.

Rather than a third guess, this times the suite, a second suite run with the build cache warm, and semgrep, as separate steps. The warm/cold pair is the point: if run one is expensive and run two is cheap, the cost is Go compilation — and the gate job is recompiling what the `test` matrix already built.

Reverted once it has answered.