### PR TITLE
fix: the unasked-decision hook switched itself off after the first decision

### DIFF
--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,8 +1,22 @@
 # What a human decided
 
-Written 2026-08-26 14:01 UTC. procoder reads this
+Written 2026-08-27 16:18 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
+
+## [decision] decisions.md
+
+Key: 04896a8efa23
+Question: PR #241 is a probe that must not merge
+
+It adds timing steps to the gate job and exists only to answer where the
+441s went. It has answered.
+
+- revert the probe steps and close #241 unmerged.
+- keep the runner-cores line, drop the rest: the cores line is a permanent
+  diagnostic; the PROBE steps are not.
+
+Answer: Revert all of it, including the runner-cores line, and close #241 unmerged.
 
 ## (no longer asked)
 
@@ -10,6 +24,72 @@ Key: 0489b93052fa
 Question: Is v3.1.1 tagged once the PRs are merged?
 
 Answer: merge only — do NOT tag. The maintainer will say when.
+
+## [decision] decisions.md
+
+Key: 2101f169020f
+Question: #211 asks for a claim the issue record contradicts
+
+**Decided: write it accurately.** Sources are named as sources; the
+convergence argument is made only where it holds.
+
+#211's acceptance criteria require a "framing paragraph [that] makes the
+'independent convergence as evidence' argument explicit" about unlazy,
+addyosmani/agent-skills and mattpocock/skills.
+
+Checked against this repo's own issue record, that framing is false for
+those three. #199 (leases), #200 (approval binding), #201 (never-execute),
+#202 (dispatch waves) and #207 (depth scaling) each open with
+"## Source — Leonxlnx/unlazy's ..." and were all filed on 2026-08-26 in one
+research sweep. #189's anti-rationalization table cites addyosmani's repo
+the same way. Procoder did not converge on these independently; it read
+them and took them, deliberately and recently.
+
+Verified against each project's own repo today: unlazy does ship the Depth
+Tree, lease coordination, a Stop hook, and pre-execution PATH disclosure;
+addyosmani/agent-skills does ship per-skill rationalization tables, a
+docs/comparison.md and a docs/skill-anatomy.md.
+
+A convergence claim is still available, but only for what procoder had
+BEFORE the sweep — the gate, the quality controllers, evidence-gated
+closes — which unlazy arrived at separately. That is a narrower and
+checkable claim.
+
+- write it accurately: name unlazy and agent-skills as SOURCES in
+  influences.md (a fifth relationship: borrowed from, recently), and make
+  the convergence argument only for the pre-sweep features where it holds.
+- follow the criteria as written: make the broad convergence argument.
+  Publishing a claim this repo's own issues contradict, in a document whose
+  purpose is credibility.
+- split: comparable-projects.md lists the projects factually with no
+  convergence framing; the argument moves to #209's research page or is
+  dropped.
+
+Answer: Write it accurately. unlazy and agent-skills are named as SOURCES in influences.md; the convergence argument is made only for the gate and evidence-gated closes, which predate the 2026-08-26 research sweep.
+
+## [decision] decisions.md
+
+Key: 2d2e81cade64
+Question: The tracked-tree gate is 787 gitleaks process startups — batch it?
+
+`Secrets` calls `scanOne` once per path, and `scanOne` starts a gitleaks
+process. Over 787 tracked files that is 787 startups. A probe scanned the
+whole tree with ONE invocation in about a second, which accounts for the
+~290s of the 341s CI step that four other explanations did not.
+
+`SastChanged` in the same file already solves this shape: scan the tree
+once, then filter the FINDINGS to the paths asked about, rather than naming
+targets. Its comment says why — naming targets made semgrep scan files its
+own default selection skips.
+
+- batch above a threshold: one scan when the path set is large, per-file
+  when it is small. Keeps a three-file commit from scanning a monorepo.
+- always scan the tree and filter, like SastChanged: one rule, no
+  threshold, no heuristic to tune — and a large repository pays it on
+  every commit.
+- leave it: the local cost is 41s and only CI sees the full tree.
+
+Answer: Batch above a threshold — one whole-tree gitleaks scan when the path set is large, per-file below it, so a three-file commit does not scan a monorepo.
 
 ## (no longer asked)
 
@@ -56,6 +136,29 @@ Answer: #181 (procoder prune) — already specified with guardrails agreed, star
 
 ## [decision] decisions.md
 
+Key: 6684d6433b84
+Question: What is next after v3.3.0?
+
+**Decided: all of them.** Working the six roadmap issues in dependency
+order: #194, then #211, then #209 (the docs cluster, which cross-reference
+each other), then #192, then #189, then #190 last as the largest.
+
+The ordinary queue is empty; all six open issues are roadmap-labelled.
+
+- #189 SKILL.md hardening: smallest, and its own research note calls it the
+  single highest-leverage change. Three of its four criteria still apply.
+- #194 + #211 docs cluster: pitfalls tables, honest-limits, positioning,
+  comparable projects. Medium, low risk, aimed at a skeptical adopter.
+- #209 research bibliography: needs real external citations, verified. The
+  one item where the failure mode is fabricating a source in a document
+  whose entire purpose is evidentiary honesty.
+- #190 `procoder learn`: largest by far, and the issue itself says it needs
+  a spec before any implementation.
+
+Answer: All six roadmap issues. Done: #194/#209/#211 in #227, #189 in #229, #192 in #228, #190's spec in #232 and #234.
+
+## [decision] decisions.md
+
 Key: 815c92a8de33
 Question: Close #206, whose premise does not hold for procoder?
 
@@ -96,6 +199,31 @@ Question: Do the four large features stay open as a roadmap?
 
 Answer: keep open, but label them roadmap/large so they stop reading as queued work
 
+## [decision] decisions.md
+
+Key: b2c54f852d82
+Question: Remove the cached 3.1.0 plugin too, or keep it as the rollback?
+
+**Decided: keep 3.1.0.** The rollback is worth 45 MB; prune's
+active-plus-one-previous policy stands as written.
+
+`procoder prune --apply` removed 3.0.0 and reclaimed 45 MB. It kept 3.1.0
+deliberately: the policy is the active version plus one previous, so a
+release that misbehaves has somewhere to fall back to. Removing 3.1.0 is
+outside what prune will do — it would be a manual `rm -rf` of
+`~/.claude/plugins/cache/procoder/procoder/3.1.0`.
+
+The trade is a fixed ~45 MB against the one-step rollback. Note that 3.1.0
+is now three releases behind and predates `release.maintainers`, so as a
+rollback target it would reintroduce the false positive that blocked the
+3.3.0 release commit.
+
+- keep 3.1.0: prune's own policy, and a rollback that costs 45 MB.
+- remove 3.1.0: reclaims the space; rollback then means reinstalling from
+  the marketplace rather than a local directory.
+
+Answer: Keep 3.1.0. prune's active-plus-one-previous policy stands; the rollback is worth ~45 MB.
+
 ## (no longer asked)
 
 Key: b55269facb93
@@ -116,6 +244,36 @@ Key: c9c26deda0a7
 Question: Which is the next piece of work?
 
 Answer: #193, merge-conflict discipline
+
+## [decision] decisions.md
+
+Key: d9cc806ecc55
+Question: `procoder wizard` (#192): what shape may it take?
+
+CORRECTED after reading the code. An earlier pass here claimed #192
+contradicts AGENTS.md and that #200 shipped a fingerprinted approval to
+gate it on. Both were wrong, and both came from grepping a summary line
+instead of reading what shipped.
+
+The rule reads "never executed AUTOMATICALLY", and it names `procoder run`
+as the shape to copy: prints the candidates, executes only under `--exec`,
+refuses when more than one candidate exists. `procoder run --exec` already
+executes a command the repository declared. So a human typing
+`procoder wizard run <name>` is the sanctioned shape, not a violation.
+
+What #200 actually shipped is ten lines in internal/runcmd/runcmd.go that
+print which binary `--exec` resolved to on PATH. There is no fingerprint
+store and no approval record. Anything needing one builds it first.
+
+**Decided: the `procoder run` shape.** Print by default, execute under an
+explicit flag, refuse rather than guess. No new boundary, no new mechanism.
+
+- build it in the `procoder run` shape: print by default, execute under an
+  explicit flag, refuse rather than guess. No new boundary needed.
+- build the fingerprinted approval first, then the wizard on top of it.
+- close #192: the manual procedures it targets (#66-#73) are one-offs.
+
+Answer: Copy the `procoder run` shape — print by default, execute under an explicit flag, refuse rather than guess. Shipped in #228 as declarative markdown that executes nothing.
 
 ## [decision] decisions.md
 

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -146,3 +146,31 @@ checkable claim.
 - split: comparable-projects.md lists the projects factually with no
   convergence framing; the argument moves to #209's research page or is
   dropped.
+
+## The tracked-tree gate is 787 gitleaks process startups — batch it?
+
+`Secrets` calls `scanOne` once per path, and `scanOne` starts a gitleaks
+process. Over 787 tracked files that is 787 startups. A probe scanned the
+whole tree with ONE invocation in about a second, which accounts for the
+~290s of the 341s CI step that four other explanations did not.
+
+`SastChanged` in the same file already solves this shape: scan the tree
+once, then filter the FINDINGS to the paths asked about, rather than naming
+targets. Its comment says why — naming targets made semgrep scan files its
+own default selection skips.
+
+- batch above a threshold: one scan when the path set is large, per-file
+  when it is small. Keeps a three-file commit from scanning a monorepo.
+- always scan the tree and filter, like SastChanged: one rule, no
+  threshold, no heuristic to tune — and a large repository pays it on
+  every commit.
+- leave it: the local cost is 41s and only CI sees the full tree.
+
+## PR #241 is a probe that must not merge
+
+It adds timing steps to the gate job and exists only to answer where the
+441s went. It has answered.
+
+- revert the probe steps and close #241 unmerged.
+- keep the runner-cores line, drop the rest: the cores line is a permanent
+  diagnostic; the PROBE steps are not.

--- a/internal/hook/unasked.go
+++ b/internal/hook/unasked.go
@@ -95,16 +95,26 @@ func unaskedDecision(root, message string) (bool, string) {
 		return false, ""
 	}
 	pending, notes, err := ask.PendingDecisions(root)
-	if err != nil || len(notes) > 0 || len(pending) > 0 {
-		// Three reasons to say nothing, and only one of them is "the agent
-		// already recorded a decision".
-		//
+	if err != nil || len(notes) > 0 {
 		// A note means the decisions file exists and could not be read, or
 		// holds something in a shape procoder does not recognise. Whether a
 		// decision was recorded is then UNKNOWN, and blocking a turn on not
 		// knowing is a block nobody can act on — the thing this hook exists
 		// to prevent, not to cause. Raised in review on #215, where the
 		// notes were being discarded and unknown read as none.
+		return false, ""
+	}
+	// A recorded decision silences this hook only when it was recorded THIS
+	// TURN. `len(pending) > 0` used to be the whole test, and it meant the
+	// hook switched itself off permanently: the first decision written to
+	// the file satisfied it, and every later turn that buried a DIFFERENT
+	// decision in prose went unchallenged. Measured on this repository
+	// mid-session — six pending, the hook silent since the first one.
+	//
+	// An enforcement that goes quiet exactly when decisions are piling up
+	// unanswered has it backwards. What "the agent already recorded one"
+	// really means is that the file CHANGED while this turn ran.
+	if len(pending) > 0 && decisionsChanged(root) {
 		return false, ""
 	}
 	if alreadyBlocked(root, message) {
@@ -126,6 +136,40 @@ func unaskedDecision(root, message string) (bool, string) {
 		"structured question tool, on its own, before continuing.\n\n" +
 		"If what you wrote is not a decision, record it anyway or reword it: this " +
 		"fires on an explicit ask, and it will not fire twice on the same message."
+}
+
+// decisionsFile is the digest of .procoder/ask/decisions.md as of the last
+// stop, so the next one can tell a decision recorded during this turn from
+// a backlog that was already there.
+const decisionsFile = "last-decisions-digest"
+
+// decisionsChanged reports whether the decisions file differs from what it
+// held at the previous stop, and records the new digest either way.
+//
+// Unknown is not "changed": a digest that cannot be read or written leaves
+// the hook unable to tell a fresh decision from an old one, and the safe
+// direction there is to let the turn end. A hook that blocks on its own
+// broken bookkeeping is one people disable.
+func decisionsChanged(root string) bool {
+	path := filepath.Join(root, filepath.FromSlash(ask.Dir), ask.DecisionsFile)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return true // no file, or unreadable: not evidence of a backlog
+	}
+	sum := sha256.Sum256(raw)
+	now := hex.EncodeToString(sum[:])[:16]
+
+	digestPath := filepath.Join(root, filepath.FromSlash(StateDir), decisionsFile)
+	before, readErr := os.ReadFile(digestPath)
+	if os.MkdirAll(filepath.Dir(digestPath), 0o755) == nil {
+		_ = os.WriteFile(digestPath, []byte(now), 0o644)
+	}
+	if readErr != nil {
+		// First stop in this tree: nothing to compare against, so the
+		// question "was this recorded just now" has no answer yet.
+		return true
+	}
+	return strings.TrimSpace(string(before)) != now
 }
 
 func blockedPath(root string) string {

--- a/internal/hook/unasked_test.go
+++ b/internal/hook/unasked_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"procoder/internal/ask"
 	"strings"
 	"testing"
 )
@@ -223,5 +224,60 @@ func TestAnEmptyDecisionsFileStillBlocks(t *testing.T) {
 	recordDecision(t, root, "   \n")
 	if code, _ := runStop(t, root, "Done. Should I tag it now?"); code != 2 {
 		t.Fatalf("an empty decisions file did not block (exit %d) — empty means nothing was recorded", code)
+	}
+}
+
+// The defect this fixes, reproduced: a decision recorded in an EARLIER
+// turn used to silence the hook for every later turn, whatever they
+// buried. Measured mid-session on this repository — six pending decisions
+// and the hook mute since the first of them.
+//
+// proved by: restore `len(pending) > 0` as an unconditional silencer in
+// unaskedDecision — the second call stops blocking and this fails.
+func TestAStaleBacklogDoesNotSilenceTheHook(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(ask.Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	decisions := filepath.Join(dir, ask.DecisionsFile)
+	write := func(body string) {
+		if err := os.WriteFile(decisions, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Turn one: the agent records a decision, so the hook stays quiet.
+	write("## Ship it now or hold?\n\n- now: ...\n- hold: ...\n")
+	if blocked, _ := unaskedDecision(root, "Should I ship it now, or hold?"); blocked {
+		t.Fatal("blocked a turn that recorded its decision")
+	}
+
+	// Turn two: a DIFFERENT decision, in prose, and the file untouched.
+	// The backlog from turn one must not excuse it.
+	blocked, msg := unaskedDecision(root, "Do you want the cache dropped as well?")
+	if !blocked {
+		t.Fatal("a stale backlog silenced the hook — the whole defect")
+	}
+	if !strings.Contains(msg, "decisions.md") {
+		t.Errorf("the refusal must name the file: %q", msg)
+	}
+}
+
+// proved by: drop the `readErr != nil` arm in decisionsChanged so a
+// missing digest reads as unchanged — the first stop in a fresh tree then
+// blocks, and this fails.
+func TestTheFirstStopInATreeDoesNotBlock(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(ask.Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ask.DecisionsFile),
+		[]byte("## Something already here?\n\n- a: ...\n- b: ...\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if blocked, _ := unaskedDecision(root, "Shall I go ahead?"); blocked {
+		t.Error("blocked on the first stop, with nothing to compare against")
 	}
 }


### PR DESCRIPTION

The hook from #215 exists to stop a turn ending with a decision buried in
prose. It fired once this session and then went silent while the same
failure happened three more times, which is how it was found.

The guard was `len(pending) > 0`, meaning "the agent already recorded a
decision". It does not mean that. It is satisfied by ANY pending decision,
including one written in an unrelated earlier turn — so the first decision
ever written to .procoder/ask/decisions.md disables the hook for every turn
after it. Measured here mid-session: six pending, hook mute since the
first.

An enforcement that goes quiet exactly when decisions are piling up
unanswered has it backwards. What the guard meant to ask is whether the
file changed WHILE THIS TURN RAN, so the digest of decisions.md is now
recorded at each stop and compared at the next.

Unknown is not "changed": a digest that cannot be read or written, or a
first stop with nothing to compare against, lets the turn end. A hook that
blocks on its own broken bookkeeping is one people disable, and this one
already carries that reasoning for its loop guard.

Two tests, both with their mutation applied and watched to fail.
TestAStaleBacklogDoesNotSilenceTheHook records a decision in turn one,
buries a DIFFERENT one in turn two with the file untouched, and requires
the block; restoring the old unconditional guard fails it on exactly that
line. TestTheFirstStopInATreeDoesNotBlock pins the unknown direction.

Separately and not a code defect: six decisions in this repository read as
pending because their answers were written inline as "**Decided: ...**"
rather than recorded with `procoder ask --file`, which is the only thing
that writes answers.md. They are recorded properly now and the count is
zero. Those six were also what kept the broken guard satisfied.