### PR TITLE
perf: the secret scan starts 787 processes, one at a time

### DIFF
--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,6 +1,6 @@
 # What a human decided
 
-Written 2026-08-26 14:01 UTC. procoder reads this
+Written 2026-08-27 16:28 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
 
@@ -95,6 +95,31 @@ Key: aa8ea1f17c0c
 Question: Do the four large features stay open as a roadmap?
 
 Answer: keep open, but label them roadmap/large so they stop reading as queued work
+
+## [decision] decisions.md
+
+Key: b2c54f852d82
+Question: Remove the cached 3.1.0 plugin too, or keep it as the rollback?
+
+**Decided: keep 3.1.0.** The rollback is worth 45 MB; prune's
+active-plus-one-previous policy stands as written.
+
+`procoder prune --apply` removed 3.0.0 and reclaimed 45 MB. It kept 3.1.0
+deliberately: the policy is the active version plus one previous, so a
+release that misbehaves has somewhere to fall back to. Removing 3.1.0 is
+outside what prune will do — it would be a manual `rm -rf` of
+`~/.claude/plugins/cache/procoder/procoder/3.1.0`.
+
+The trade is a fixed ~45 MB against the one-step rollback. Note that 3.1.0
+is now three releases behind and predates `release.maintainers`, so as a
+rollback target it would reintroduce the false positive that blocked the
+3.3.0 release commit.
+
+- keep 3.1.0: prune's own policy, and a rollback that costs 45 MB.
+- remove 3.1.0: reclaims the space; rollback then means reinstalling from
+  the marketplace rather than a local directory.
+
+Answer: Run the per-file scans concurrently. It attacks process startup directly, scans exactly what it scans today, and does not depend on the whole-tree figure I got wrong.
 
 ## (no longer asked)
 

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -146,3 +146,27 @@ checkable claim.
 - split: comparable-projects.md lists the projects factually with no
   convergence framing; the argument moves to #209's research page or is
   dropped.
+
+## The gitleaks batching premise was wrong — batch, or run concurrently?
+
+CORRECTION. The decision to "batch above a threshold" was taken on my
+figure that one whole-tree gitleaks call costs about a second, from a CI
+probe. Measured locally it costs 27.8s, and the CI step carried `|| true`,
+so whether it scanned anything at all is unknown.
+
+The real local numbers: per-file 0.05s × 787 = 39.4s, whole tree 27.8s. A
+30% saving, not the ~290s I implied. And the whole-tree scan reads `.git`,
+`dist` and ignored directories the per-file scan never looks at — it finds
+115 leaks there, all outside the tracked set.
+
+Which of the ~240s unaccounted for in CI is gitleaks remains unproven. I
+attributed it to per-file startup; that was inference, not measurement.
+
+- run the per-file scans concurrently: attacks process startup directly,
+  scans exactly what it scans today, helps whether the leg is 41s or 240s,
+  and is the pattern already used for the formatter pass.
+- batch above a threshold as originally agreed: fewer processes, but 30%
+  locally rather than the number the decision was made on, and it changes
+  WHAT is scanned.
+- measure gitleaks in CI properly first, then decide: one more probe cycle
+  before any code changes.

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -15,9 +15,11 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"procoder/internal/config"
@@ -77,12 +79,60 @@ func Secrets(root string, paths []string) []gitx.Finding {
 		return []gitx.Finding{{Blocking: true,
 			Message: "NOT checked — gitleaks is not installed; run `procoder init` (security)"}}
 	}
-	var out []gitx.Finding
+	// One gitleaks process per path, run concurrently. The cost here is
+	// process startup, not scanning: measured on this repository, a single
+	// file costs 0.05s and 787 of them cost 39.4s, which is 787 startups
+	// and almost no reading.
+	//
+	// Scanning the tree in ONE call was the obvious alternative and is
+	// worse. It costs 27.8s here — a 30% saving, not the order of
+	// magnitude the shape suggests — and it reads `.git`, `dist` and every
+	// ignored directory, where it finds 115 leaks that are in nobody's
+	// commit. Narrowing afterwards would mean paying to find things only
+	// to discard them.
+	//
+	// Bounded by NumCPU: every unit of work is an external process.
+	var wanted []string
 	for _, p := range paths {
 		if _, err := os.Stat(p); err != nil {
 			continue
 		}
-		out = append(out, scanOne(bin, root, p)...)
+		wanted = append(wanted, p)
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+	// Results by index, concatenated in the order the paths were given: the
+	// gate prints findings straight from this slice, and a report whose
+	// order followed whichever process finished first would differ between
+	// two runs over the same tree.
+	results := make([][]gitx.Finding, len(wanted))
+	workers := runtime.NumCPU()
+	if workers > len(wanted) {
+		workers = len(wanted)
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				results[i] = scanOne(bin, root, wanted[i])
+			}
+		}()
+	}
+	for i := range wanted {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	var out []gitx.Finding
+	for _, r := range results {
+		out = append(out, r...)
 	}
 	return out
 }
@@ -92,7 +142,25 @@ func Secrets(root string, paths []string) []gitx.Finding {
 // report's paths — and therefore .gitleaksignore fingerprints — relative.
 func scanOne(bin, workdir, src string) []gitx.Finding {
 	var out []gitx.Finding
-	report := filepath.Join(os.TempDir(), fmt.Sprintf("procoder-gitleaks-%d.json", time.Now().UnixNano()))
+	// A unique path per scan, from the OS rather than from the clock.
+	// This used to be time.Now().UnixNano(), which was fine while scans
+	// ran one at a time and is not now they run concurrently: two
+	// goroutines reading the same nanosecond share a report path, and one
+	// then reads the other's findings under its own file name. Windows
+	// makes that likely rather than theoretical — its clock granularity is
+	// milliseconds, not nanoseconds.
+	dir, tmpErr := os.MkdirTemp("", "procoder-gitleaks-")
+	if tmpErr != nil {
+		return []gitx.Finding{{File: src, Blocking: true,
+			Message: "gitleaks has nowhere to write its report (" + tmpErr.Error() + ") — the path was NOT checked (security)"}}
+	}
+	defer os.RemoveAll(dir)
+	// A directory, not a reserved file name. os.CreateTemp would also be
+	// unique, and it would CREATE the report — so a gitleaks that died
+	// before writing anything would leave an empty file where "no report"
+	// is the thing that has to be detectable, and the finding would stop
+	// quoting why the scan failed.
+	report := filepath.Join(dir, "report.json")
 	common := []string{"--report-format", "json", "--report-path", report,
 		"--no-banner", "--exit-code", "1"}
 	ctx, cancel := context.WithTimeout(context.Background(), secretsTimeout)
@@ -122,7 +190,6 @@ func scanOne(bin, workdir, src string) []gitx.Finding {
 		}
 	}
 	raw, readErr := os.ReadFile(report)
-	os.Remove(report)
 	if readErr != nil {
 		return []gitx.Finding{{File: src, Blocking: true,
 			Message: "gitleaks produced no report — the path was NOT checked: " + firstLine(errb.String()) + " (security)"}}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -832,5 +833,66 @@ func TestAFailedToolIsReportedByItsDiagnosticNotItsProgress(t *testing.T) {
 	}
 	if got := why("   \n  \n", nil); got != "no output" {
 		t.Errorf("whitespace is not a diagnosis, got %q", got)
+	}
+}
+
+// The secret scan runs one process per path, concurrently. The gate prints
+// its findings straight out of the returned slice, so a run that collected
+// them in completion order would make the same tree print a different
+// report twice.
+//
+// A stub rather than real gitleaks, and deliberately: the fixture has to
+// produce a finding for EVERY path for the order to be observable at all,
+// and a test that skips when the real scanner happens not to fire asserts
+// nothing. The stub sleeps longer for earlier paths, so completion order
+// and the order given disagree on every run.
+//
+// proved by: collect into a shared slice under a mutex in Secrets instead
+// of writing results[i] — the order follows whichever stub exited first
+// and this fails.
+func TestSecretsReturnsFindingsInThePathOrderGiven(t *testing.T) {
+	// $1 is `dir`, $2 the path; --report-path is the fourth flag pair.
+	stub(t, "gitleaks", `
+report=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--report-path" ]; then report="$a"; fi
+  prev="$a"
+done
+src="$2"
+case "$src" in
+  *f00*) sleep 0.30 ;;
+  *f01*) sleep 0.25 ;;
+  *f02*) sleep 0.20 ;;
+  *f03*) sleep 0.15 ;;
+  *f04*) sleep 0.10 ;;
+  *) sleep 0.01 ;;
+esac
+printf '[{"File":"%s","StartLine":1,"RuleID":"stub-rule"}]' "$src" > "$report"
+exit 1
+`)
+	root := t.TempDir()
+	var paths []string
+	for i := 0; i < 6; i++ {
+		p := filepath.Join(root, fmt.Sprintf("f%02d.txt", i))
+		if err := os.WriteFile(p, []byte("x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, p)
+	}
+
+	got := Secrets(root, paths)
+	if len(got) != len(paths) {
+		t.Fatalf("got %d findings for %d paths: %+v", len(got), len(paths), got)
+	}
+	for i, f := range got {
+		if filepath.Base(f.File) != filepath.Base(paths[i]) {
+			var seen []string
+			for _, g := range got {
+				seen = append(seen, filepath.Base(g.File))
+			}
+			t.Fatalf("position %d is %s, want %s — path order not preserved: %v",
+				i, filepath.Base(f.File), filepath.Base(paths[i]), seen)
+		}
 	}
 }


### PR DESCRIPTION

The tracked-tree gate's largest leg was gitleaks, and almost none of it was
scanning. Measured on this repository: one file costs 0.05s and 787 of them
cost 39.4s, which is 787 process startups and very little reading.

They now run concurrently, bounded by NumCPU because every unit of work is
an external process. 172.6s to 104.1s over the whole tree, verdicts
compared line by line and identical.

Scanning the tree in ONE call was the obvious alternative and is worse. It
costs 27.8s here — 30%, not the order of magnitude the shape suggests — and
it reads .git, dist and every ignored directory, where it finds 115 leaks
that are in nobody's commit. I had told the maintainer that call cost about
a second, from a CI probe whose command carried `|| true`; the number was
wrong and the decision was revisited on the measurement rather than left
standing.

Concurrency broke something that only concurrency could break. scanOne
named its report file from time.Now().UnixNano(), which is unique while
scans run one at a time and is not when they overlap — two goroutines
inside the same nanosecond share a report path, and one reads the other's
findings under its own file name. Windows makes that likely rather than
theoretical: its clock granularity is milliseconds. The report now lives in
a temp DIRECTORY per scan.

os.CreateTemp would also have been unique and was tried first. It CREATES
the file, so a gitleaks that died before writing anything left an empty
report where "no report" is exactly what has to be detectable — and the
finding stopped quoting why the scan failed. The repository's own
TestSecretsScannerFailureIsNotChecked caught it.

The ordering test uses a stub rather than real gitleaks, deliberately.
Every path has to produce a finding for the order to be observable, and a
test that skips when the real scanner happens not to fire asserts nothing.
The stub sleeps longest for the earliest path, so completion order and the
order given disagree on every run; the mutation that collects in completion
order returns all six exactly reversed, and was watched to fail. Race
detector clean.