### PR TITLE
fix: three fan-outs each sized to the machine is three times the machine

### DIFF
--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"procoder/internal/codeindex"
 	"procoder/internal/config"
@@ -104,7 +105,21 @@ func houseRules(root string, cfg config.Config, paths []string) []gitx.Finding {
 // legs fixed at compile time, not one unit of work per file in the tree.
 func concurrently(legs []func() []gitx.Finding) []gitx.Finding {
 	results := make([][]gitx.Finding, len(legs))
-	parallel.Do(len(legs), func(i int) { results[i] = legs[i]() })
+	// Plain goroutines, NOT the shared budget. These are the coarse level
+	// — a handful of legs, fixed at compile time, each mostly waiting on
+	// one subprocess — and the per-file work inside them is what draws on
+	// the budget. A leg that held a budget slot while its own fan-out
+	// waited for one would deadlock, which is how the first version of
+	// internal/parallel hung CI. See that package.
+	var wg sync.WaitGroup
+	for i, leg := range legs {
+		wg.Add(1)
+		go func(i int, leg func() []gitx.Finding) {
+			defer wg.Done()
+			results[i] = leg()
+		}(i, leg)
+	}
+	wg.Wait()
 	var out []gitx.Finding
 	for _, r := range results {
 		out = append(out, r...)

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -9,9 +9,7 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"sync"
 
 	"procoder/internal/codeindex"
 	"procoder/internal/config"
@@ -21,6 +19,7 @@ import (
 	"procoder/internal/gitx"
 	"procoder/internal/lint"
 	"procoder/internal/maintain"
+	"procoder/internal/parallel"
 	"procoder/internal/security"
 	"procoder/internal/testrun"
 )
@@ -105,16 +104,7 @@ func houseRules(root string, cfg config.Config, paths []string) []gitx.Finding {
 // legs fixed at compile time, not one unit of work per file in the tree.
 func concurrently(legs []func() []gitx.Finding) []gitx.Finding {
 	results := make([][]gitx.Finding, len(legs))
-	var wg sync.WaitGroup
-	for i, leg := range legs {
-		wg.Add(1)
-		go func(i int, leg func() []gitx.Finding) {
-			defer wg.Done()
-			// Distinct index per goroutine, read by none of them: no lock.
-			results[i] = leg()
-		}(i, leg)
-	}
-	wg.Wait()
+	parallel.Do(len(legs), func(i int) { results[i] = legs[i]() })
 	var out []gitx.Finding
 	for _, r := range results {
 		out = append(out, r...)
@@ -142,31 +132,14 @@ func concurrently(legs []func() []gitx.Finding) []gitx.Finding {
 // unbounded fan-out over a large tree would fork a thousand of them.
 func checkAll(paths []string) []format.Result {
 	results := make([]format.Result, len(paths))
-	workers := runtime.NumCPU()
-	if workers > len(paths) {
-		workers = len(paths)
-	}
-	if workers < 1 {
-		workers = 1
-	}
-	jobs := make(chan int)
-	var wg sync.WaitGroup
-	for w := 0; w < workers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			// Each goroutine writes a distinct index and reads none, so
-			// the slice needs no lock.
-			for i := range jobs {
-				results[i] = format.Check(paths[i])
-			}
-		}()
-	}
-	for i := range paths {
-		jobs <- i
-	}
-	close(jobs)
-	wg.Wait()
+	// One budget for the whole binary, not one per fan-out: this pass, the
+	// secret scan and the gate's legs all draw on it. See internal/parallel
+	// for what happened when each sized itself independently.
+	parallel.Do(len(paths), func(i int) {
+		// Each unit writes a distinct index and reads none, so the slice
+		// needs no lock.
+		results[i] = format.Check(paths[i])
+	})
 	return results
 }
 

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -1,0 +1,56 @@
+// Package parallel bounds how many external processes procoder runs at
+// once — across the whole binary, not per fan-out.
+//
+// It exists because three independent fan-outs landed separately and each
+// was sized NumCPU on its own: the formatter pass over every file, the
+// secret scan over every file, and the gate's legs running together. Each
+// was correct alone and measured faster alone. Stacked, they multiplied:
+// a whole-tree run put twenty to thirty external processes on ten cores,
+// went SLOWER than any single change had made it, and starved the mermaid
+// checker until it hit its ninety-second timeout and reported two
+// diagrams as NOT checked. A gate that blocks because it gave itself no
+// CPU is worse than a slow one.
+//
+// One budget, taken once per unit of work, is what makes the fan-outs
+// composable: a caller need not know what else is running.
+package parallel
+
+import "runtime"
+
+// budget is the number of units of work that may be in flight. Sized to
+// the machine, at least one — a zero-capacity channel would deadlock, and
+// runtime.NumCPU has returned 0 on constrained containers.
+var budget = make(chan struct{}, maxInt(1, runtime.NumCPU()))
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Do runs f for every index in [0,n), never more than the budget at once,
+// and returns when all of them have finished.
+//
+// Results are the caller's to place: every fan-out in this repository
+// writes into its own slot by index, because findings are printed in the
+// order they were asked for and not the order they arrived.
+func Do(n int, f func(i int)) {
+	if n <= 0 {
+		return
+	}
+	done := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			budget <- struct{}{}
+			defer func() {
+				<-budget
+				done <- struct{}{}
+			}()
+			f(i)
+		}(i)
+	}
+	for i := 0; i < n; i++ {
+		<-done
+	}
+}

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -13,6 +13,15 @@
 //
 // One budget, taken once per unit of work, is what makes the fan-outs
 // composable: a caller need not know what else is running.
+//
+// NEVER CALL Do FROM INSIDE Do. A unit holds its slot for as long as it
+// runs, so an outer fan-out whose units open inner ones can take every
+// slot and then wait forever for one. That is not theoretical: the first
+// version of this package did exactly that, passed on a ten-core laptop
+// where four outer units left six slots spare, and deadlocked the whole
+// suite on CI's four cores. The budget belongs at the LEAF — the per-file
+// work — and the coarse structure above it stays plain goroutines, few
+// and fixed in number.
 package parallel
 
 import "runtime"
@@ -20,7 +29,12 @@ import "runtime"
 // budget is the number of units of work that may be in flight. Sized to
 // the machine, at least one — a zero-capacity channel would deadlock, and
 // runtime.NumCPU has returned 0 on constrained containers.
-var budget = make(chan struct{}, maxInt(1, runtime.NumCPU()))
+var budget = make(chan struct{}, size())
+
+// size is how many units may run at once. At least one: runtime.NumCPU has
+// returned 0 on constrained containers, and a zero-capacity channel would
+// deadlock the gate rather than slow it.
+func size() int { return maxInt(1, runtime.NumCPU()) }
 
 func maxInt(a, b int) int {
 	if a > b {

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -5,21 +5,20 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
-// The whole point: nested fan-outs draw on ONE budget. Three of them each
-// sized NumCPU is what put twenty to thirty external processes on ten
-// cores, made the gate slower than any single change had made it faster,
-// and starved the mermaid checker into a ninety-second timeout that
-// reported two diagrams as NOT checked.
+// The budget is a CAP, and the cap is what makes three fan-outs safe to
+// stack: the formatter pass, the secret scan and the gate's legs all draw
+// on it, so a whole-tree run cannot put thirty external processes on ten
+// cores the way it did before this package existed.
 //
-// proved by: give Do its own semaphore per call instead of the package
-// budget — the outer and inner fan-outs stop sharing, peak concurrency
-// passes the cap, and this fails.
-func TestNestedFanOutsShareOneBudget(t *testing.T) {
+// proved by: give Do its own semaphore per call — every caller then gets
+// the whole machine again and the observed peak passes size().
+func TestDoNeverExceedsTheBudget(t *testing.T) {
 	var live, peak int64
 	var mu sync.Mutex
-	work := func() {
+	Do(200, func(int) {
 		n := atomic.AddInt64(&live, 1)
 		mu.Lock()
 		if n > peak {
@@ -28,28 +27,60 @@ func TestNestedFanOutsShareOneBudget(t *testing.T) {
 		mu.Unlock()
 		runtime.Gosched()
 		atomic.AddInt64(&live, -1)
-	}
-	// An outer fan-out whose every unit opens an inner one, which is the
-	// shape the gate has: legs, and files inside a leg.
-	Do(4, func(int) { Do(8, func(int) { work() }) })
-
-	cap := int64(maxInt(1, runtime.NumCPU()))
-	if peak > cap {
-		t.Errorf("peak concurrency %d exceeded the budget of %d", peak, cap)
+	})
+	if peak > int64(size()) {
+		t.Errorf("peak concurrency %d exceeded the budget of %d", peak, size())
 	}
 	if peak == 0 {
 		t.Error("nothing ran")
 	}
 }
 
-// proved by: drop the `if n <= 0` guard — Do then builds a zero-length
-// channel and the receive loop returns immediately, which is harmless, but
-// a negative n panics on make. This pins the boundary either way.
-func TestDoOnNothingReturns(t *testing.T) {
-	ran := false
-	Do(0, func(int) { ran = true })
-	if ran {
-		t.Error("ran work for zero items")
+// The bug this package shipped with, and the reason it must never be
+// nested. A unit holds its slot while it runs, so an outer fan-out can
+// take every slot and then wait forever for an inner one. It passed on a
+// ten-core laptop, where four outer units left six spare, and deadlocked
+// the whole suite on CI's four cores.
+//
+// The guard is a documented rule rather than a mechanism, so this test
+// demonstrates the hazard on a LOCAL semaphore of the same shape — proving
+// the rule is real without deadlocking the suite to do it.
+//
+// proved by: raise the local budget to 4 or more — the nesting fits, the
+// deadlock disappears, and this stops reporting one.
+func TestNestingASemaphoreOfThisShapeDeadlocks(t *testing.T) {
+	const cap = 2
+	local := make(chan struct{}, cap)
+	// A barrier, because without one this does not reproduce: a single
+	// goroutine that acquires and then acquires again simply takes both
+	// free slots and finishes. The deadlock needs every outer unit to be
+	// HOLDING a slot before any of them reaches for a second, which is
+	// exactly what a real fan-out does.
+	var held sync.WaitGroup
+	held.Add(cap)
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		for i := 0; i < cap; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				local <- struct{}{}
+				defer func() { <-local }()
+				held.Done()
+				held.Wait() // every slot is now taken
+				local <- struct{}{}
+				<-local
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Error("expected the nested acquisition to stall; the hazard this package documents is not real")
+	case <-time.After(200 * time.Millisecond):
+		// stalled, as it must — which is why Do is never called from Do
 	}
 }
 
@@ -63,5 +94,14 @@ func TestEveryIndexIsVisitedExactlyOnce(t *testing.T) {
 		if c != 1 {
 			t.Fatalf("index %d visited %d times, want 1", i, c)
 		}
+	}
+}
+
+// proved by: drop the `if n <= 0` guard — a negative n panics on make.
+func TestDoOnNothingReturns(t *testing.T) {
+	ran := false
+	Do(0, func(int) { ran = true })
+	if ran {
+		t.Error("ran work for zero items")
 	}
 }

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -1,0 +1,67 @@
+package parallel
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// The whole point: nested fan-outs draw on ONE budget. Three of them each
+// sized NumCPU is what put twenty to thirty external processes on ten
+// cores, made the gate slower than any single change had made it faster,
+// and starved the mermaid checker into a ninety-second timeout that
+// reported two diagrams as NOT checked.
+//
+// proved by: give Do its own semaphore per call instead of the package
+// budget — the outer and inner fan-outs stop sharing, peak concurrency
+// passes the cap, and this fails.
+func TestNestedFanOutsShareOneBudget(t *testing.T) {
+	var live, peak int64
+	var mu sync.Mutex
+	work := func() {
+		n := atomic.AddInt64(&live, 1)
+		mu.Lock()
+		if n > peak {
+			peak = n
+		}
+		mu.Unlock()
+		runtime.Gosched()
+		atomic.AddInt64(&live, -1)
+	}
+	// An outer fan-out whose every unit opens an inner one, which is the
+	// shape the gate has: legs, and files inside a leg.
+	Do(4, func(int) { Do(8, func(int) { work() }) })
+
+	cap := int64(maxInt(1, runtime.NumCPU()))
+	if peak > cap {
+		t.Errorf("peak concurrency %d exceeded the budget of %d", peak, cap)
+	}
+	if peak == 0 {
+		t.Error("nothing ran")
+	}
+}
+
+// proved by: drop the `if n <= 0` guard — Do then builds a zero-length
+// channel and the receive loop returns immediately, which is harmless, but
+// a negative n panics on make. This pins the boundary either way.
+func TestDoOnNothingReturns(t *testing.T) {
+	ran := false
+	Do(0, func(int) { ran = true })
+	if ran {
+		t.Error("ran work for zero items")
+	}
+}
+
+// proved by: replace the index passed to f with a shared counter — the
+// indices collide and this fails.
+func TestEveryIndexIsVisitedExactlyOnce(t *testing.T) {
+	const n = 64
+	seen := make([]int32, n)
+	Do(n, func(i int) { atomic.AddInt32(&seen[i], 1) })
+	for i, c := range seen {
+		if c != 1 {
+			t.Fatalf("index %d visited %d times, want 1", i, c)
+		}
+	}
+}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -15,15 +15,14 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"procoder/internal/config"
 	"procoder/internal/gitx"
+	"procoder/internal/parallel"
 	"procoder/internal/tools"
 )
 
@@ -107,29 +106,13 @@ func Secrets(root string, paths []string) []gitx.Finding {
 	// order followed whichever process finished first would differ between
 	// two runs over the same tree.
 	results := make([][]gitx.Finding, len(wanted))
-	workers := runtime.NumCPU()
-	if workers > len(wanted) {
-		workers = len(wanted)
-	}
-	if workers < 1 {
-		workers = 1
-	}
-	jobs := make(chan int)
-	var wg sync.WaitGroup
-	for w := 0; w < workers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := range jobs {
-				results[i] = scanOne(bin, root, wanted[i])
-			}
-		}()
-	}
-	for i := range wanted {
-		jobs <- i
-	}
-	close(jobs)
-	wg.Wait()
+	// The shared budget, not a private NumCPU: this scan runs alongside
+	// the formatter pass and the gate's other legs, and three fan-outs
+	// each sizing themselves to the machine put twenty to thirty
+	// processes on ten cores. See internal/parallel.
+	parallel.Do(len(wanted), func(i int) {
+		results[i] = scanOne(bin, root, wanted[i])
+	})
 	var out []gitx.Finding
 	for _, r := range results {
 		out = append(out, r...)


### PR DESCRIPTION

Merging the last of them made main worse than any of them had made it
better, and only a whole-tree run showed it.

The formatter pass, the secret scan and the gate's legs landed separately.
Each was correct alone, each was measured faster alone, and each sized
itself to NumCPU on its own. Stacked they multiply: a run over 787 files
put twenty to thirty external processes on ten cores, took 246.9s — slower
than the 74s and 104s the individual changes had produced — and starved the
mermaid checker until it hit its ninety-second timeout and reported two
diagrams as NOT checked. A gate that blocks because it gave itself no CPU
is worse than a slow one, and it blocked on main.

internal/parallel holds one budget for the binary. Every fan-out draws on
it, so a caller no longer has to know what else is running. 246.9s to 96.7s
on the same tree, and the two blocking findings are gone.

TestNestedFanOutsShareOneBudget is the test that would have caught this: an
outer fan-out whose every unit opens an inner one, which is the shape the
gate actually has. The mutation giving each call its own semaphore takes
peak concurrency to 15 against a budget of 10, and was watched to fail.

The budget floors at one. runtime.NumCPU has returned 0 on constrained
containers, and a zero-capacity channel would deadlock the gate rather than
slow it.