### PR TITLE
fix: golangci-lint was choosing which findings to show, differently each run

### DIFF
--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -283,7 +283,18 @@ func lintGo(root string, files []string, block bool) []gitx.Finding {
 			dirs["./"+filepath.ToSlash(d)] = true
 		}
 	}
-	args := []string{"run", "--output.text.path=stdout", "--show-stats=false"}
+	// No issue caps. golangci-lint defaults to --max-issues-per-linter 50
+	// and --max-same-issues 3, and it lints packages concurrently — so
+	// WHICH issues survive those caps depends on which package finished
+	// first. Two runs over an unchanged tree reported forty-eight findings
+	// each and disagreed about their members, which made "did my change
+	// alter this?" unanswerable (#236).
+	//
+	// The caps were also hiding work: max-same-issues 3 keeps three of any
+	// near-identical message, and errcheck emits almost nothing else, so
+	// most of them never reached the report at all.
+	args := []string{"run", "--output.text.path=stdout", "--show-stats=false",
+		"--max-issues-per-linter=0", "--max-same-issues=0"}
 	// the project's own config always wins; without one, procoder supplies
 	// a curated baseline strong enough to catch the bug classes reviewers
 	// keep finding (security edges, error handling, loop allocations) —

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -286,3 +286,46 @@ func TestUnlintedLanguagesHonourLintPolicy(t *testing.T) {
 		t.Fatalf("policy=block must block: %+v", blocked)
 	}
 }
+
+// golangci-lint caps its own output — 50 issues per linter and 3 with the
+// same text — and lints packages concurrently, so which issues survive
+// those caps depends on which package finished first. Two runs over an
+// unchanged tree reported 48 findings each and disagreed about their
+// members (#236).
+//
+// The caps also hid work rather than merely shuffling it: errcheck's
+// messages are near-identical, so max-same-issues kept three of them and
+// dropped the rest. Disabling both made the set complete AND stable —
+// verified by running the gate twice over the same tree.
+//
+// proved by: drop either flag from lintGo's args — this names the one that
+// went.
+func TestGolangciLintIsRunWithoutIssueCaps(t *testing.T) {
+	dir := t.TempDir()
+	seen := filepath.Join(dir, "args.txt")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + seen + "\nexit 0\n"
+	bin := filepath.Join(dir, "golangci-lint")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("HOME", dir)
+
+	root := t.TempDir()
+	src := filepath.Join(root, "main.go")
+	if err := os.WriteFile(src, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lintGo(root, []string{src}, false)
+
+	raw, err := os.ReadFile(seen)
+	if err != nil {
+		t.Skipf("the stub was not reached (%v) — this asserts flags, and NOT run is not a pass", err)
+	}
+	args := string(raw)
+	for _, want := range []string{"--max-issues-per-linter=0", "--max-same-issues=0"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("golangci-lint ran without %s — its own cap then picks which findings to show, and picks differently each run:\n%s", want, args)
+		}
+	}
+}


### PR DESCRIPTION
Closes #236.

Two runs of the unchanged binary over the unchanged tree reported
forty-eight lint findings each and disagreed about their members. The cause
is not procoder's ordering, which is fixed: golangci-lint caps its own
output at fifty issues per linter and three with the same text, and it
lints packages concurrently — so which issues survive those caps depends on
which package finished first.

The issue I filed said the set was capped by procoder and guessed at
sorting before truncation as the fix. Both were wrong. Nothing in procoder
truncates: all one hundred and seventeen info lines are printed.

The caps hid work rather than shuffling it. max-same-issues keeps three of
any near-identical message and errcheck emits almost nothing else, so most
errcheck findings never reached the report at all — which is why every line
that moved between runs was an errcheck one. Both caps are now disabled.

Verified the way the defect was found: the gate run twice over the same
tree, sorted and diffed. Identical sets.

TestGolangciLintIsRunWithoutIssueCaps puts a stub on PATH that records its
arguments, so it asserts what was actually passed rather than reading the
source. Dropping either flag names the one that went, and the mutation was
applied and watched.