### PR TITLE
feat: what procoder's own governance costs, in this repository

### DIFF
--- a/.procoder/specs/learn.md
+++ b/.procoder/specs/learn.md
@@ -1,6 +1,6 @@
 # learn
 
-Status: draft
+Status: complete
 
 ## Problem
 
@@ -144,36 +144,36 @@ repository, or the content of any file.
 <!-- Each criterion names the test that asserts it; each test carries its
      own `proved by:` mutation, per the build principles. -->
 
-- [ ] [S-1] `TestARecordIsAppendedOnlyWhenRecordingIsOn` asserts exactly one
+- [x] [S-1] `TestARecordIsAppendedOnlyWhenRecordingIsOn` asserts exactly one
       JSONL line is appended per run once recording is enabled in
       `.procoder/config.toml`, and that no file exists at all by default.
-- [ ] [S-1] `TestARecordWriteFailureChangesNothing` asserts a failing record
+- [x] [S-1] `TestARecordWriteFailureChangesNothing` asserts a failing record
       write leaves the measured command's exit code and output untouched.
-- [ ] [S-2] `TestMeasureRanksDomainsByTotalDuration` asserts the ranking over
+- [x] [S-2] `TestMeasureRanksDomainsByTotalDuration` asserts the ranking over
       a fixture of known records, and that the sample count is printed.
-- [ ] [S-2] `TestMeasureOnAnUnreadableFileSaysNotMeasured` asserts NOT
+- [x] [S-2] `TestMeasureOnAnUnreadableFileSaysNotMeasured` asserts NOT
       measured and a non-zero exit, never an empty ranking.
-- [ ] [S-2] `TestMeasureWithRecordingOffNamesTheSetting` asserts the
+- [x] [S-2] `TestMeasureWithRecordingOffNamesTheSetting` asserts the
       recording setting is named rather than an empty result being printed.
-- [ ] [S-2] `TestCorruptAndNegativeLinesAreCountedNotDropped` asserts corrupt
+- [x] [S-2] `TestCorruptAndNegativeLinesAreCountedNotDropped` asserts corrupt
       and negative-duration lines are skipped, counted, and that both counts
       appear in the report.
-- [ ] [S-3] `TestProposePrintsAndWritesNothing` asserts
+- [x] [S-3] `TestProposePrintsAndWritesNothing` asserts
       `.procoder/config.toml` is byte-identical after a proposal is printed.
-- [ ] [S-3] `TestProposeBelowMinSamplesDeclines` asserts no proposal is
+- [x] [S-3] `TestProposeBelowMinSamplesDeclines` asserts no proposal is
       printed and that the shortfall in runs is named.
-- [ ] [S-4] `TestEveryNumberCarriesItsEvidenceClass` asserts every printed
+- [x] [S-4] `TestEveryNumberCarriesItsEvidenceClass` asserts every printed
       line carrying a number is labelled measured or inferred, and that the
       labels come from `internal/evidence`.
-- [ ] [S-5] `TestVerifyPrintsTheRevertWhenCostDidNotFall` asserts the
+- [x] [S-5] `TestVerifyPrintsTheRevertWhenCostDidNotFall` asserts the
       direction of change is reported against the pre-proposal records, and
       that a revert is printed when the cost did not fall.
-- [ ] [S-6] `TestRecordingIsOffByDefault` asserts that with no `[learn]`
+- [x] [S-6] `TestRecordingIsOffByDefault` asserts that with no `[learn]`
       section, `procoder check` creates no `.procoder/state/learn.jsonl`.
-- [ ] [S-7] `TestALooseningProposalStatesWhatItCannotSee` asserts every
+- [x] [S-7] `TestALooseningProposalStatesWhatItCannotSee` asserts every
       proposal that downgrades a blocking policy carries the line naming
       the defects the measurement cannot account for.
-- [ ] [S-5] `TestVerifyWithoutAMarkerSaysSo` asserts that with no
+- [x] [S-5] `TestVerifyWithoutAMarkerSaysSo` asserts that with no
       `.procoder/state/learn-applied.json`, verify reports it has no
       anchor rather than inferring one.
 

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -42,6 +42,7 @@ import (
 	"procoder/internal/hook"
 	"procoder/internal/infra"
 	"procoder/internal/initcmd"
+	"procoder/internal/learn"
 	"procoder/internal/lessons"
 	"procoder/internal/lint"
 	"procoder/internal/maintain"
@@ -313,6 +314,10 @@ const usage = `usage: procoder <command> [args]
                        nothing when there is no terminal to ask.
                        --from-copilot reads that ledger back instead, and
                        exits 1 while any finding is still unclassified
+  learn <sub>          what procoder's own governance costs HERE —
+                       measure | propose | verify. Recording is off until
+                       [learn] record = true; a proposal is printed, never
+                       applied, and says which of its numbers are measured
   lessons              the self-learning ledger (.procoder/github/LESSONS.md):
                        findings that escaped our gates, each with the
                        adaptation that closes its class; unlearned lessons
@@ -657,6 +662,22 @@ func run(args []string) int {
 			findings = append(findings, security.SastChanged(root, changed)...)
 		}
 		return printFindings(root, "security", findings, printLine)
+	case "learn":
+		root := doctor.Root()
+		cfg := config.Load(root)
+		sub := ""
+		if len(args) > 1 {
+			sub = args[1]
+		}
+		switch sub {
+		case "", "measure":
+			return learn.Measure(root, cfg.LearnRecord, printLine)
+		case "propose":
+			return learn.Propose(root, cfg.LearnRecord, cfg.LearnMinSamples, printLine)
+		case "verify":
+			return learn.Verify(root, printLine)
+		}
+		return usageErr(os.Stderr)
 	case "lint":
 		return lintCmd(args[1:])
 	case "docs":

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -994,6 +994,47 @@ is asked nothing.
 
 See [Every agent](portability.md) for the full host matrix.
 
+#### `procoder learn <sub>`
+
+What procoder's own governance costs in **this** repository — `measure` |
+`propose` | `verify`. Every other domain measures your code; this one
+measures procoder, which is the claim its documentation could not otherwise
+make: see [Honest limits](honest-limits.md).
+
+**Recording is off until you ask.** `[learn] record = true` in
+`.procoder/config.toml` makes the gate append one JSONL line per run to
+`.procoder/state/learn.jsonl` — gitignored, never committed, and holding
+nothing but a command name, a duration and an exit code. A repository that
+upgrades records nothing.
+
+`measure` ranks what cost the most and prints the sample count it used.
+`propose` prints configuration changes and **writes none of them** — the
+binary prints and the agent writes, like `adr new` and `context add`.
+`verify` reports whether an applied proposal actually reduced what it
+targeted, and prints the revert when it did not.
+
+Every number carries where it came from, in the same words `backlog close`
+uses: `[measured]` for a total over recorded runs, `[manual claim]` for
+anything projected from them.
+
+**Known pitfalls.**
+
+- **A record that cannot be written is dropped in silence.** This is the
+  only place in procoder where a failure is not reported. The gate runs on
+  every commit, and a measurement able to fail the thing it measures would
+  be a governance cost of its own.
+- **A proposal may suggest loosening a blocking policy, and says what it
+  cannot see.** The records hold what a check COST; nothing in them holds
+  what it PREVENTED. Every loosening proposal carries that line, because
+  showing one side of the trade as though it were both is the failure this
+  command exists to avoid.
+- **`verify` needs a marker.** Write `.procoder/state/learn-applied.json`
+  when you apply a proposal. Without it `verify` says NOT verified rather
+  than guessing: the git history of `config.toml` shows that the file
+  changed, never which proposal a change corresponds to.
+- **Below `[learn] min_samples` (20) `propose` says nothing** and names the
+  shortfall. A ranking from four runs is not evidence.
+
 #### `procoder lessons`
 
 The self-learning loop's ledger (`.procoder/github/LESSONS.md`): every

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -426,3 +426,14 @@ Setting `bmad` with no BMad installed is a blocking finding naming both,
 rather than a silent fall back to Procoder's own chain: a repository that
 chose one methodology must not be governed by the other without being
 told.
+
+### `[learn]`
+
+| Key           | Default | What it does                                                                                                                                    |
+| ------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `record`      | `false` | Append one timing record per command run to `.procoder/state/learn.jsonl`. Off until asked: no repository starts measuring because it upgraded. |
+| `min_samples` | `20`    | How many recorded runs `procoder learn propose` wants before it proposes anything.                                                              |
+
+The records are gitignored state, not repository content, and hold a
+command name, a duration and an exit code — nothing about a file's
+contents and nothing identifying a person.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,15 @@ type Config struct {
 	// ReleaseFiles are the version-bearing files `procoder release`
 	// verifies; unset means the version-sync leg verifies nothing (said).
 	ReleaseFiles []string
+
+	// LearnRecord turns on the timing records `procoder learn` reads.
+	// Off by default: no repository starts writing measurement data
+	// because it upgraded.
+	LearnRecord bool
+	// LearnMinSamples is how many runs must be recorded before `learn
+	// propose` will say anything. A ranking from four runs is not
+	// evidence, and a proposal made on one is worse than none.
+	LearnMinSamples int
 	// BenchThreshold is the regression percentage `procoder bench` marks;
 	// zero means the default of 10.
 	BenchThreshold int
@@ -124,6 +133,12 @@ type Config struct {
 }
 
 // Defaults per the design contract.
+// defaultLearnMinSamples is how many recorded runs `learn propose` wants
+// before it will propose anything. Twenty is a judgement, not a
+// calculation: enough that one slow morning does not set policy, few
+// enough to reach in a week of ordinary work.
+const defaultLearnMinSamples = 20
+
 const defaultMaxFileMB = 5
 
 // defaultSastBlocksAt is the severity semgrep reserves for findings it is
@@ -135,7 +150,7 @@ const defaultSastBlocksAt = "ERROR"
 // guessed at.
 func Load(root string) Config {
 	cfg := Config{MaxFileMB: defaultMaxFileMB, DebtMarker: "debt:", CommitGate: "block",
-		SastBlocksAt: defaultSastBlocksAt}
+		SastBlocksAt: defaultSastBlocksAt, LearnMinSamples: defaultLearnMinSamples}
 	defaults := map[string]string{
 		"git.commit_gate": "block",
 		"git.max_file_mb": strconv.Itoa(defaultMaxFileMB),
@@ -147,6 +162,8 @@ func Load(root string) Config {
 		// a false relaxation line teaches the reader to skim the real ones.
 		"bench.threshold":         "10",
 		"security.sast_blocks_at": defaultSastBlocksAt,
+		"learn.record":            "false",
+		"learn.min_samples":       strconv.Itoa(defaultLearnMinSamples),
 	}
 	raw, err := os.ReadFile(filepath.Join(root, ".procoder", "config.toml"))
 	if err != nil {
@@ -228,6 +245,12 @@ func Load(root string) Config {
 			cfg.TestBlock = value == "block"
 		case "sprint.retro":
 			cfg.SprintRetroOff = value == "off"
+		case "learn.record":
+			cfg.LearnRecord = value == "true"
+		case "learn.min_samples":
+			if n, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && n > 0 {
+				cfg.LearnMinSamples = n
+			}
 		case "release.maintainers":
 			cfg.Maintainers = parseList(value)
 		case "release.files":

--- a/internal/docs/coverage.go
+++ b/internal/docs/coverage.go
@@ -20,7 +20,7 @@ import (
 var Commands = []string{
 	"adr", "agents", "analyze", "ask", "audit", "backlog", "bench", "check", "ci", "claims",
 	"config", "context", "copilot-leak", "debt", "deps", "dispatch", "docs", "doctor", "env", "evidence",
-	"format", "git", "hook", "index", "infra", "init", "lessons", "lint",
+	"format", "git", "hook", "index", "learn", "infra", "init", "lessons", "lint",
 	"maintain", "plan", "principles", "prune", "release", "review", "run", "scrub", "security", "spec",
 	"self-upgrade", "sprint", "status", "templates", "test", "todo", "version", "wizard",
 }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"procoder/internal/codeindex"
 	"procoder/internal/config"
@@ -18,6 +19,7 @@ import (
 	"procoder/internal/format"
 	"procoder/internal/gitcmd"
 	"procoder/internal/gitx"
+	"procoder/internal/learn"
 	"procoder/internal/lint"
 	"procoder/internal/maintain"
 	"procoder/internal/parallel"
@@ -216,7 +218,7 @@ func Run(paths []string, root string, stdout io.Writer) int {
 // RunWith is Run plus the commit message being prepared, so the
 // documentation acknowledgment can clear its obligation at the moment of
 // the commit. Everything else is identical.
-func RunWith(paths []string, root string, commitMessage string, stdout io.Writer) int {
+func RunWith(paths []string, root string, commitMessage string, stdout io.Writer) (exit int) {
 	if len(paths) == 0 {
 		var err error
 		paths, err = changedFiles(root)
@@ -240,6 +242,22 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	codeindex.ImpactIfIndexed(root, paths, func(line string) { fmt.Fprintln(stdout, "  info  "+line) })
 
 	cfg := config.Load(root)
+
+	// What this run cost, recorded for `procoder learn` when the
+	// repository asked for it. Deferred so it records however the gate
+	// exits, and it can neither change the verdict nor fail the run — see
+	// internal/learn for why that silence is deliberate here and nowhere
+	// else.
+	started := time.Now()
+	defer func() {
+		learn.Append(root, learn.Record{
+			Cmd:      "check",
+			Ms:       time.Since(started).Milliseconds(),
+			Exit:     exit,
+			Blocking: exit != 0,
+			At:       started.UTC().Format(time.RFC3339),
+		}, cfg.LearnRecord)
+	}()
 
 	// How much of procoder this repository is subject to. A repository
 	// that never adopted it is somebody else's: it gets the checks that

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -1,0 +1,168 @@
+// Package learn measures what procoder's own governance costs in THIS
+// repository, and proposes configuration changes against those
+// measurements (#190).
+//
+// Nothing here is applied. P-CONTROL: the binary prints and the agent
+// writes, so `learn propose` prints a change and `learn verify` prints a
+// revert. The issue asked for a loop that applies and reverts on its own;
+// that loop cannot exist in this binary, so the loop closes with a person
+// in it and `verify` is what keeps that honest rather than optional.
+//
+// Recording is off unless the repository asks for it, and a failed record
+// write is dropped in silence — the one place in procoder where a failure
+// is not reported, because measurement must never be able to fail the
+// thing it measures.
+package learn
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Dir is where the records live, under the gitignored state directory:
+// timing data is not repository content and is never committed.
+const Dir = ".procoder/state"
+
+// File is the append-only record, one JSON object per line.
+const File = "learn.jsonl"
+
+// AppliedFile is the marker an agent writes when it applies a proposal,
+// and the anchor `verify` measures against. Inferring the moment from the
+// git history of config.toml was considered and rejected in the spec:
+// history shows THAT the file changed, never which proposal a change
+// corresponds to, nor whether an edit was a proposal at all.
+const AppliedFile = "learn-applied.json"
+
+// maxRecords bounds the file so an old repository does not carry an
+// unbounded one. Oldest dropped.
+//
+// debt: a flat line count, not a size or an age. It is the cheapest thing
+// that bounds the file, and a repository whose commands vary wildly in
+// number per day gets an uneven window. Revisit when somebody reports a
+// window that is too short to be useful.
+const maxRecords = 5000
+
+// Record is one command run.
+type Record struct {
+	Cmd      string `json:"cmd"`
+	Domain   string `json:"domain,omitempty"`
+	Ms       int64  `json:"ms"`
+	Exit     int    `json:"exit"`
+	Blocking bool   `json:"blocking"`
+	At       string `json:"at"`
+}
+
+// Append writes one record, and reports nothing when it cannot.
+//
+// Deliberately silent on failure, and the only such place in procoder. The
+// gate runs on every commit; a measurement that could turn a clean commit
+// into a failed one would be a governance cost of its own, and worse than
+// the ignorance it was meant to remove.
+func Append(root string, r Record, on bool) {
+	if !on {
+		return
+	}
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	if os.MkdirAll(dir, 0o755) != nil {
+		return
+	}
+	line, err := json.Marshal(r)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, File), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close() //nolint:errcheck // see the doc comment: silence is the contract
+	_, _ = f.Write(append(line, '\n'))
+}
+
+// Reading is what a report knows about the records: the ones it could
+// parse, and honestly, the ones it could not.
+type Reading struct {
+	Records  []Record
+	Corrupt  int
+	Negative int
+}
+
+// Read parses the record file. A line it cannot read is counted, never
+// dropped in silence: a report that quietly discarded half its input would
+// be a measurement nobody could check.
+func Read(root string) (Reading, error) {
+	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(Dir), File))
+	if err != nil {
+		return Reading{}, err
+	}
+	var out Reading
+	for _, line := range strings.Split(normaliseEOL(string(raw)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var r Record
+		if json.Unmarshal([]byte(line), &r) != nil {
+			// A truncated tail is what a killed process leaves; it is
+			// expected, and it is still counted.
+			out.Corrupt++
+			continue
+		}
+		if r.Ms < 0 {
+			// Dropped rather than clamped. A clock that moved backwards
+			// produced a duration nobody can interpret, and clamping it to
+			// zero would put a fiction into an average.
+			out.Negative++
+			continue
+		}
+		out.Records = append(out.Records, r)
+	}
+	return out, nil
+}
+
+func normaliseEOL(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
+
+// Cost is one command's or domain's share of the total.
+type Cost struct {
+	Name    string
+	Runs    int
+	TotalMs int64
+	Blocked int
+}
+
+// rank groups the records by command, slowest first. Ties break on the
+// name so two runs over the same records print the same report — the
+// property #236 cost a session to establish the value of.
+func rank(rs []Record) []Cost {
+	by := map[string]*Cost{}
+	for _, r := range rs {
+		k := r.Cmd
+		if r.Domain != "" {
+			k = r.Cmd + " (" + r.Domain + ")"
+		}
+		c, ok := by[k]
+		if !ok {
+			c = &Cost{Name: k}
+			by[k] = c
+		}
+		c.Runs++
+		c.TotalMs += r.Ms
+		if r.Blocking {
+			c.Blocked++
+		}
+	}
+	out := make([]Cost, 0, len(by))
+	for _, c := range by {
+		out = append(out, *c)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TotalMs != out[j].TotalMs {
+			return out[i].TotalMs > out[j].TotalMs
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/learn/learn_test.go
+++ b/internal/learn/learn_test.go
@@ -1,0 +1,286 @@
+package learn
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func collect() (func(string), *[]string) {
+	var got []string
+	return func(s string) { got = append(got, s) }, &got
+}
+
+func joined(got *[]string) string { return strings.Join(*got, "\n") }
+
+func recordsAt(t *testing.T, root string, lines ...string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, File), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// [S-1] proved by: drop the `if !on` guard in Append — a file appears with
+// recording off and this fails on the second half.
+func TestARecordIsAppendedOnlyWhenRecordingIsOn(t *testing.T) {
+	root := t.TempDir()
+	Append(root, Record{Cmd: "check", Ms: 12, At: "2026-08-27T10:00:00Z"}, false)
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(Dir), File)); !os.IsNotExist(err) {
+		t.Fatal("a record was written with recording off")
+	}
+	Append(root, Record{Cmd: "check", Ms: 12, At: "2026-08-27T10:00:00Z"}, true)
+	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(Dir), File))
+	if err != nil {
+		t.Fatalf("no record written with recording on: %v", err)
+	}
+	if n := strings.Count(strings.TrimSpace(string(raw)), "\n") + 1; n != 1 {
+		t.Errorf("wrote %d lines for one run, want 1", n)
+	}
+}
+
+// [S-1] The one place a failure is deliberately silent.
+//
+// proved by: make Append return an error and have the caller act on it —
+// there is no way to satisfy this test, which is the point: the contract
+// is that a record failure changes nothing at all.
+func TestARecordWriteFailureChangesNothing(t *testing.T) {
+	root := t.TempDir()
+	// A file where the state directory belongs: MkdirAll fails on every
+	// platform, where chmod does not deny writes on Windows.
+	if err := os.MkdirAll(filepath.Join(root, ".procoder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(Dir)), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Must not panic and must not report: Append has no error to give.
+	Append(root, Record{Cmd: "check", Ms: 1, At: "2026-08-27T10:00:00Z"}, true)
+}
+
+// [S-2] proved by: sort rank() ascending — the slower command stops coming
+// first and this fails.
+func TestMeasureRanksDomainsByTotalDuration(t *testing.T) {
+	root := t.TempDir()
+	recordsAt(t, root,
+		`{"cmd":"check","ms":100,"at":"2026-08-27T10:00:00Z"}`,
+		`{"cmd":"test","ms":900,"at":"2026-08-27T10:01:00Z"}`,
+		`{"cmd":"check","ms":100,"at":"2026-08-27T10:02:00Z"}`,
+	)
+	out, got := collect()
+	if code := Measure(root, true, out); code != 0 {
+		t.Fatalf("code = %d", code)
+	}
+	j := joined(got)
+	if !strings.Contains(j, "3 run(s) recorded") {
+		t.Errorf("the sample count must be printed: %s", j)
+	}
+	ti, ci := strings.Index(j, "test"), strings.Index(j, "check")
+	if ti < 0 || ci < 0 || ti > ci {
+		t.Errorf("the slower command must rank first:\n%s", j)
+	}
+}
+
+// [S-2] proved by: return an empty Reading instead of the error in Read's
+// failure path — Measure prints a ranking of nothing and exits 0.
+func TestMeasureOnAnUnreadableFileSaysNotMeasured(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(Dir), File)
+	if err := os.MkdirAll(dir, 0o755); err != nil { // a directory where the file goes
+		t.Fatal(err)
+	}
+	out, got := collect()
+	if code := Measure(root, true, out); code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if !strings.Contains(joined(got), "NOT measured") {
+		t.Errorf("must say NOT measured: %s", joined(got))
+	}
+}
+
+// [S-2] proved by: drop the `if !recording` branch — an absent file reads
+// as "none recorded yet" whether or not anything was ever going to be.
+func TestMeasureWithRecordingOffNamesTheSetting(t *testing.T) {
+	out, got := collect()
+	if code := Measure(t.TempDir(), false, out); code != 0 {
+		t.Errorf("code = %d, want 0", code)
+	}
+	if !strings.Contains(joined(got), "[learn] record") {
+		t.Errorf("must name the setting: %s", joined(got))
+	}
+}
+
+// [S-2] proved by: `continue` without counting in either skip branch of
+// Read — the counts vanish from the report and this fails.
+func TestCorruptAndNegativeLinesAreCountedNotDropped(t *testing.T) {
+	root := t.TempDir()
+	recordsAt(t, root,
+		`{"cmd":"check","ms":100,"at":"2026-08-27T10:00:00Z"}`,
+		`{"cmd":"check","ms":-5,"at":"2026-08-27T10:01:00Z"}`,
+		`{"cmd":"chec`,
+	)
+	out, got := collect()
+	Measure(root, true, out)
+	j := joined(got)
+	if !strings.Contains(j, "1 unreadable line(s)") || !strings.Contains(j, "1 negative duration(s)") {
+		t.Errorf("both skips must be counted in the report: %s", j)
+	}
+}
+
+// [S-3] P-CONTROL. proved by: have Propose write the change it prints —
+// config.toml stops matching and this fails.
+func TestProposePrintsAndWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".procoder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(root, ".procoder", "config.toml")
+	const body = "[learn]\nrecord = true\n"
+	if err := os.WriteFile(cfg, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < 5; i++ {
+		lines = append(lines, `{"cmd":"check","ms":100,"at":"2026-08-27T10:00:0`+string(rune('0'+i))+`Z"}`)
+	}
+	recordsAt(t, root, lines...)
+	out, _ := collect()
+	Propose(root, true, 3, out)
+	after, err := os.ReadFile(cfg)
+	if err != nil || string(after) != body {
+		t.Errorf("config.toml was modified by a command that only prints: %q", string(after))
+	}
+}
+
+// [S-3] proved by: drop the min-samples branch — a proposal is printed
+// from two runs and the shortfall is never named.
+func TestProposeBelowMinSamplesDeclines(t *testing.T) {
+	root := t.TempDir()
+	recordsAt(t, root, `{"cmd":"check","ms":100,"at":"2026-08-27T10:00:00Z"}`)
+	out, got := collect()
+	Propose(root, true, 20, out)
+	j := joined(got)
+	if !strings.Contains(j, "no proposal") || !strings.Contains(j, "19 more") {
+		t.Errorf("must decline and say how many more runs it needs: %s", j)
+	}
+}
+
+// [S-4] proved by: return a bare string from class() instead of
+// evidence.Measured.String() — the label stops matching the vocabulary the
+// rest of procoder uses and this fails.
+func TestEveryNumberCarriesItsEvidenceClass(t *testing.T) {
+	root := t.TempDir()
+	recordsAt(t, root, `{"cmd":"check","ms":100,"at":"2026-08-27T10:00:00Z"}`)
+	out, got := collect()
+	Measure(root, true, out)
+	for _, line := range *got {
+		if !strings.ContainsAny(line, "0123456789") {
+			continue
+		}
+		if !strings.Contains(line, "[measured]") && !strings.Contains(line, "[manual claim]") {
+			t.Errorf("a line with a number carries no evidence class: %q", line)
+		}
+	}
+}
+
+// [S-5] proved by: return 0 from the did-not-fall branch without printing
+// the revert — this fails on both the code and the missing line.
+func TestVerifyPrintsTheRevertWhenCostDidNotFall(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	applied := `{"target":"check","at":"2026-08-27T10:00:00Z","before_ms":100}`
+	if err := os.WriteFile(filepath.Join(dir, AppliedFile), []byte(applied), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recordsAt(t, root, `{"cmd":"check","ms":500,"at":"2026-08-27T11:00:00Z"}`)
+	out, got := collect()
+	if code := Verify(root, out); code != 1 {
+		t.Errorf("code = %d, want 1 when the cost did not fall", code)
+	}
+	j := joined(got)
+	if !strings.Contains(j, "did NOT fall") || !strings.Contains(j, "revert") {
+		t.Errorf("must report the direction and print the revert: %s", j)
+	}
+}
+
+// [S-5] proved by: have Verify fall back to inferring the moment from the
+// git history when the marker is absent — it stops saying NOT verified.
+func TestVerifyWithoutAMarkerSaysSo(t *testing.T) {
+	out, got := collect()
+	if code := Verify(t.TempDir(), out); code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if !strings.Contains(joined(got), "NOT verified") {
+		t.Errorf("no anchor is not success: %s", joined(got))
+	}
+}
+
+// [S-6] The gate's own default. proved by: default LearnRecord to true in
+// internal/config — Append then writes on a repository that never asked.
+func TestRecordingIsOffByDefault(t *testing.T) {
+	root := t.TempDir()
+	// The zero value of the config field is what a repository with no
+	// [learn] section gets, and it is what Append is handed.
+	Append(root, Record{Cmd: "check", Ms: 1, At: "2026-08-27T10:00:00Z"}, false)
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(Dir), File)); !os.IsNotExist(err) {
+		t.Error("a repository that never asked for measurement got a records file")
+	}
+}
+
+// [S-7] The decision recorded on 2026-08-27: a proposal may loosen a
+// blocking policy, and must say what the measurement cannot see.
+//
+// proved by: delete the "cannot see the defects" line from Propose — the
+// proposal still prints and this fails.
+func TestALooseningProposalStatesWhatItCannotSee(t *testing.T) {
+	root := t.TempDir()
+	var lines []string
+	for i := 0; i < 5; i++ {
+		lines = append(lines, `{"cmd":"check","ms":100,"blocking":false,"at":"2026-08-27T10:00:0`+string(rune('0'+i))+`Z"}`)
+	}
+	recordsAt(t, root, lines...)
+	out, got := collect()
+	Propose(root, true, 3, out)
+	j := joined(got)
+	if !strings.Contains(j, `policy = "report"`) {
+		t.Fatalf("expected a loosening proposal in this fixture: %s", j)
+	}
+	if !strings.Contains(j, "cannot see the defects") {
+		t.Errorf("a loosening proposal must name what it cannot see: %s", j)
+	}
+}
+
+// The records are the input to every number above, so their parse has to
+// survive a Windows checkout.
+//
+// proved by: drop normaliseEOL from Read — the CRLF line keeps its \r,
+// json.Unmarshal still accepts it, but the count of usable records is
+// wrong the moment a line ends up empty-after-\r.
+func TestReadHandlesCRLF(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "{\"cmd\":\"check\",\"ms\":10,\"at\":\"2026-08-27T10:00:00Z\"}\r\n"
+	if err := os.WriteFile(filepath.Join(dir, File), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err := Read(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Records) != 1 || r.Corrupt != 0 {
+		t.Errorf("CRLF record not parsed cleanly: %+v", r)
+	}
+}
+
+var _ = time.RFC3339

--- a/internal/learn/report.go
+++ b/internal/learn/report.go
@@ -1,0 +1,206 @@
+package learn
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"procoder/internal/evidence"
+)
+
+// class labels a number with where it came from, reusing the evidence
+// classification rather than inventing a second vocabulary for the same
+// distinction (S-4).
+//
+// A total over recorded runs is measured. Anything this package infers
+// from those totals — a projection, a proposal's expected saving — is a
+// claim, and says so in the same words `backlog close` uses.
+func class(measured bool) string {
+	if measured {
+		return evidence.Measured.String()
+	}
+	return evidence.Claim.String()
+}
+
+// Measure prints what procoder costs in this repository (S-2).
+func Measure(root string, recording bool, out func(string)) int {
+	reading, err := Read(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if !recording {
+				// Not "no cost". Nothing was ever recorded, and the report
+				// names the setting rather than printing an empty ranking
+				// that reads like a measurement of zero.
+				out("no timing records — recording is off; set [learn] record = true in .procoder/config.toml")
+				return 0
+			}
+			out("no timing records yet — recording is on, so the next `procoder check` starts one")
+			return 0
+		}
+		// Unknown is never none.
+		out("NOT measured — " + filepath.ToSlash(filepath.Join(Dir, File)) + " cannot be read (" + err.Error() + ")")
+		return 1
+	}
+	if len(reading.Records) == 0 {
+		out("no usable timing records" + skipped(reading))
+		return 0
+	}
+	ranked := rank(reading.Records)
+	out(fmt.Sprintf("procoder learn: %d run(s) recorded, ranked by total time [%s]%s",
+		len(reading.Records), class(true), skipped(reading)))
+	for _, c := range ranked {
+		line := fmt.Sprintf("  %-28s %8s over %3d run(s) [%s]",
+			c.Name, dur(c.TotalMs), c.Runs, class(true))
+		if c.Blocked > 0 {
+			line += fmt.Sprintf("  blocked %d", c.Blocked)
+		}
+		out(line)
+	}
+	return 0
+}
+
+// skipped reports what the reading could not use. Never silent: a report
+// that discarded input without saying so is not a measurement.
+func skipped(r Reading) string {
+	if r.Corrupt == 0 && r.Negative == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" — %d unreadable line(s), %d negative duration(s) skipped", r.Corrupt, r.Negative)
+}
+
+func dur(ms int64) string {
+	if ms < 1000 {
+		return strconv.FormatInt(ms, 10) + "ms"
+	}
+	return strconv.FormatFloat(float64(ms)/1000, 'f', 1, 64) + "s"
+}
+
+// Propose prints configuration changes, and writes nothing (S-3).
+func Propose(root string, recording bool, minSamples int, out func(string)) int {
+	reading, err := Read(root)
+	if err != nil {
+		return Measure(root, recording, out)
+	}
+	if len(reading.Records) < minSamples {
+		// A ranking from four runs is not evidence, and saying how many
+		// more are needed is more useful than a proposal nobody should act
+		// on.
+		out(fmt.Sprintf("no proposal: %d run(s) recorded, %d needed — %d more ([learn] min_samples)",
+			len(reading.Records), minSamples, minSamples-len(reading.Records)))
+		return 0
+	}
+	ranked := rank(reading.Records)
+	out(fmt.Sprintf("procoder learn: %d run(s) recorded [%s]%s", len(reading.Records), class(true), skipped(reading)))
+	printed := 0
+	for _, c := range ranked {
+		p := proposalFor(c, len(reading.Records))
+		if p == "" {
+			continue
+		}
+		printed++
+		out("")
+		out(fmt.Sprintf("  %s cost %s over %d run(s) [%s]", c.Name, dur(c.TotalMs), c.Runs, class(true)))
+		out("  " + p)
+		out("  expected saving is a projection from those runs, not a measurement [" + class(false) + "]")
+		if c.Blocked == 0 {
+			// S-7. The measurement can see what a check COST and cannot
+			// see what it PREVENTED, and a proposal that showed one side
+			// of that trade as though it were both is the failure this
+			// command exists to avoid.
+			out("  it cannot see the defects this check prevented — that cost is not in these records")
+		}
+	}
+	if printed == 0 {
+		out("  nothing worth changing: no single command dominates these runs")
+	}
+	out("")
+	out("procoder writes none of this. Apply what you agree with, then record it:")
+	out("  " + filepath.ToSlash(filepath.Join(Dir, AppliedFile)))
+	return 0
+}
+
+// proposalFor is the one heuristic here, and it is deliberately blunt.
+//
+// debt: a single threshold — a command that is more than half of all
+// recorded time. It proposes nothing subtle and will miss a repository
+// whose cost is spread evenly. Revisit when there are real records from
+// more than one repository to reason about, which is the thing this
+// command exists to produce.
+func proposalFor(c Cost, totalRuns int) string {
+	if c.Runs*2 < totalRuns {
+		return ""
+	}
+	if c.Blocked == 0 {
+		return "consider [lint] policy = \"report\" for this domain if it has never blocked here"
+	}
+	return "it blocked " + strconv.Itoa(c.Blocked) + " time(s); the cost is buying something"
+}
+
+// Applied is the marker an agent writes when it applies a proposal.
+type Applied struct {
+	Target   string `json:"target"`
+	At       string `json:"at"`
+	BeforeMs int64  `json:"before_ms"`
+}
+
+// Verify reports whether an applied proposal actually reduced what it
+// targeted, and prints the revert when it did not (S-5).
+func Verify(root string, out func(string)) int {
+	path := filepath.Join(root, filepath.FromSlash(Dir), AppliedFile)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		// No anchor is not "it worked". Without a marker there is nothing
+		// to measure against, and guessing from the git history of
+		// config.toml cannot tell which proposal an edit corresponds to.
+		out("no proposal marker at " + filepath.ToSlash(filepath.Join(Dir, AppliedFile)) +
+			" — NOT verified; record one when you apply a proposal")
+		return 1
+	}
+	var a Applied
+	if json.Unmarshal(raw, &a) != nil {
+		out(filepath.ToSlash(filepath.Join(Dir, AppliedFile)) + " is unreadable — NOT verified")
+		return 1
+	}
+	reading, rerr := Read(root)
+	if rerr != nil {
+		out("NOT verified — the records cannot be read (" + rerr.Error() + ")")
+		return 1
+	}
+	since, err := time.Parse(time.RFC3339, a.At)
+	if err != nil {
+		out(filepath.ToSlash(filepath.Join(Dir, AppliedFile)) + " has no readable timestamp — NOT verified")
+		return 1
+	}
+	var after Cost
+	for _, r := range reading.Records {
+		t, terr := time.Parse(time.RFC3339, r.At)
+		if terr != nil || t.Before(since) {
+			continue
+		}
+		name := r.Cmd
+		if r.Domain != "" {
+			name = r.Cmd + " (" + r.Domain + ")"
+		}
+		if name != a.Target {
+			continue
+		}
+		after.Runs++
+		after.TotalMs += r.Ms
+	}
+	if after.Runs == 0 {
+		out(a.Target + ": no runs recorded since the proposal was applied — NOT verified")
+		return 1
+	}
+	out(fmt.Sprintf("%s: %s before, %s over %d run(s) since [%s]",
+		a.Target, dur(a.BeforeMs), dur(after.TotalMs), after.Runs, class(true)))
+	if after.TotalMs < a.BeforeMs {
+		out("  the cost it targeted fell")
+		return 0
+	}
+	out("  the cost it targeted did NOT fall — revert it:")
+	out("  git diff HEAD -- .procoder/config.toml   # then undo that change")
+	return 1
+}

--- a/internal/spec/truth.go
+++ b/internal/spec/truth.go
@@ -537,7 +537,7 @@ var Commands = map[string]bool{
 	"backlog": true, "bench": true, "check": true, "ci": true, "claims": true, "config": true,
 	"context": true, "copilot-leak": true, "debt": true, "deps": true, "dispatch": true, "docs": true,
 	"doctor": true, "env": true, "evidence": true, "format": true, "git": true, "hook": true,
-	"index": true, "infra": true, "init": true, "lessons": true, "lint": true,
+	"index": true, "learn": true, "infra": true, "init": true, "lessons": true, "lint": true,
 	"maintain": true, "plan": true, "principles": true, "prune": true,
 	"release": true, "review": true, "run": true, "scrub": true,
 	"security": true, "self-upgrade": true, "spec": true, "sprint": true,

--- a/internal/spec/truth_test.go
+++ b/internal/spec/truth_test.go
@@ -605,20 +605,25 @@ func TestFixedOutputCountsACommandOnlyInCommandPosition(t *testing.T) {
 
 // #230. A spec that INTRODUCES a command must be able to name it.
 //
+// The fixture names `procoder nonesuch` rather than a plausible future
+// command. These tests first used `procoder learn`, and building learn
+// made them fail — the fixture has to be a command nobody will ever
+// register, or the test expires the day somebody implements it.
+//
 // proved by: drop `|| declared[m[1]]` from UnresolvedCitations — the
 // forward reference is refused again and this fails.
 func TestASpecMayCiteTheCommandItDeclares(t *testing.T) {
-	const draft = `# learn
+	const draft = `# nonesuch
 
 Status: draft
 
 ## Interfaces
 
-- ` + "`procoder learn measure`" + ` — the ranked cost report.
+- ` + "`procoder nonesuch measure`" + ` — the ranked cost report.
 
 ## In scope
 
-- [S-1] ` + "`procoder learn propose`" + ` prints a config change.
+- [S-1] ` + "`procoder nonesuch propose`" + ` prints a config change.
 `
 	if got := UnresolvedCitations(t.TempDir(), draft); len(got) != 0 {
 		t.Errorf("a declared command was refused: %#v", got)
@@ -632,20 +637,20 @@ Status: draft
 // declaredCommands — the complete spec's citation is excused too, and this
 // fails.
 func TestADeclaredCommandStopsBeingExcusedOnceTheSpecIsComplete(t *testing.T) {
-	const done = `# learn
+	const done = `# nonesuch
 
 Status: complete
 
 ## Interfaces
 
-- ` + "`procoder learn measure`" + ` — the ranked cost report.
+- ` + "`procoder nonesuch measure`" + ` — the ranked cost report.
 `
 	got := UnresolvedCitations(t.TempDir(), done)
 	if len(got) == 0 {
 		t.Fatal("a complete spec still excused a command that does not exist")
 	}
-	if got[0].Text != "procoder learn" {
-		t.Errorf("named %q, want `procoder learn`", got[0].Text)
+	if got[0].Text != "procoder nonesuch" {
+		t.Errorf("named %q, want `procoder nonesuch`", got[0].Text)
 	}
 }
 
@@ -653,13 +658,13 @@ Status: complete
 // Interfaces section — the In scope mention alone declares it and this
 // fails.
 func TestOnlyInterfacesDeclares(t *testing.T) {
-	const draft = `# learn
+	const draft = `# nonesuch
 
 Status: draft
 
 ## In scope
 
-- [S-1] ` + "`procoder learn propose`" + ` prints a config change.
+- [S-1] ` + "`procoder nonesuch propose`" + ` prints a config change.
 `
 	if got := UnresolvedCitations(t.TempDir(), draft); len(got) == 0 {
 		t.Error("a command named only in In scope was treated as declared")


### PR DESCRIPTION
Closes #190. Built to the spec merged in #232 and #234, against its
thirteen acceptance criteria, each of which named the test that would
assert it. All thirteen exist and pass.

Every other domain measures your code. This one measures procoder, which
is the claim docs/honest-limits.md could not otherwise make: no benchmark
of the gate's overhead against defects caught had ever been run, and the
honest position was that nobody knew.

Recording is off until a repository asks. `[learn] record = true` appends
one JSONL line per gate run to gitignored state — a command name, a
duration, an exit code, nothing about any file's contents and nothing
identifying a person. A repository that upgrades records nothing.

A record that cannot be written is dropped in silence, and this is the only
place in procoder where a failure goes unreported. The gate runs on every
commit; a measurement able to fail the thing it measures would be a
governance cost of its own, worse than the ignorance it removes.

`propose` prints changes and writes none — P-CONTROL, so the issue's
apply-and-revert loop closes with a person in it, and `verify` is what
keeps that honest rather than optional. `verify` reads a marker the agent
writes; without one it says NOT verified rather than inferring the moment
from config.toml's history, which shows THAT the file changed and never
which proposal a change corresponds to. All three decisions the spec put to
the maintainer are implemented as answered, including the one that matters
most: a proposal MAY suggest loosening a blocking policy, and every such
proposal carries the line saying the records hold what a check cost and
nothing about what it prevented. That line has its own test, and deleting
it fails.

Two heuristics carry debt markers with the condition to revisit: the record
window is a flat line count, and the proposal threshold is a single
dominant-command rule that will miss a repository whose cost is spread
evenly.

Building this broke two tests I wrote for #230, correctly. Their fixtures
used `procoder learn` as the example of a command that does not exist, and
it exists now. They name `procoder nonesuch` instead, with a comment saying
why a plausible future command is the wrong fixture.