### PR TITLE
feat: one seam for every .procoder/ read and write (#117 phase 0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Golden files are compared byte for byte against output procoder generates
+# at runtime, and procoder emits LF on every platform. Without this, a
+# Windows checkout converts them to CRLF and every golden comparison fails
+# for a difference nobody wrote — which is what happened the first time CI
+# ran the state seam on windows-latest.
+internal/store/testdata/golden/** -text

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -198,3 +198,79 @@ It adds timing steps to the gate job and exists only to answer where the
 - revert the probe steps and close #241 unmerged.
 - keep the runner-cores line, drop the rest: the cores line is a permanent
   diagnostic; the PROBE steps are not.
+
+## Issue #107 is not reachable — close it, or ship the comment too?
+
+Probing the real host inverts the issue. OpenCode and Kilo are Bun binaries;
+Bun auto-detects module format and ignores `type`. A probe project with a
+`type`-less `.opencode/package.json` loaded BOTH an `import`-using plugin and
+one mixing `require()` with `export default` — which Node rejects under every
+setting. The reported failure cannot occur in a host.
+
+Worse, the discovery glob in both loaders is `{plugin,plugins}/*.{ts,js}`:
+`.mjs` is NOT matched, so renaming would silently stop Kilo loading procoder.
+The `.js` extension is load-bearing. And `.kilo/package.json` is Kilo-generated
+and gitignored (`.kilo/.gitignore:2`), so the proposed fix cannot ship at all;
+a root-level `"type"` works only until Kilo writes that file.
+
+The only real casualty is procoder's own Node harness
+(`TestEveryHostAdapterLoadsWithACallableDefault`), which leans on Node's
+syntax-detection fallback for the Kilo entry alone.
+
+- close #107 with the evidence, and add a comment to the plugin header saying
+  why the extension is `.js` and must stay `.js` — the rename risk is the only
+  live one, and nothing in the repo records it.
+- close #107 with the evidence and change no code: a rename already fails
+  loudly (`portability_test.go:307` t.Fatals, `adapter_test.go` names the
+  missing path), so the comment is belt on braces.
+- comment the findings on #107 but leave it open: keep it as the record until
+  someone with a real Kilo install confirms the fork matches OpenCode here.
+
+## Issue #60: who sends the awesome-ai-plugins listing PR, and how far do we go?
+
+The blocking work is one README line in `hashgraph-online/awesome-ai-plugins`,
+under `## Community Plugins` → `### Development & Workflow`, between `Praxis`
+and `Project Autopilot`. Three hard gates: case-insensitive alphabetical order,
+the entry regex, and a reachable public repo — the last already passes.
+
+Everything else they describe is optional and declared so in their own
+CONTRIBUTING.md: scanner CI in procoder's own workflows (absence costs 10% of a
+trust score, blocks nothing), the local `plugin-scanner` preflight, the HOL
+registry ownership claim (a read-only GitHub OAuth grant), and the trust/Guard
+badges.
+
+- I fork and open the listing PR now, listing only, no scanner CI and no
+  registry claim — the smallest thing that satisfies what was already agreed
+  on the issue.
+- I prepare the branch and the exact diff, and you send it: the PR is outward
+  facing under your name in someone else's repository.
+- listing PR plus the pinned-SHA scanner action in procoder's CI: takes the
+  full trust score, at the cost of a third-party action in the pipeline.
+
+## Issue #117 (procoder as a service): the perf case is inverted — what now?
+
+Measured, 3.4.0 binary, 25 runs after warmup: bare spawn floor 2.9ms;
+`procoder hook pre-tool-use` direct 9.2ms; `curl` to a local HTTP service —
+the proposal's own hook command — 11.1ms; via `launcher.sh` 25.8ms;
+`principles --hook` 194ms direct, 235ms via launcher.
+
+A hook command is spawned either way, so the service pays a spawn PLUS a TCP
+round trip and comes out slower than the binary it replaces. The proposal's
+"~10-50ms to ~2-5ms" is wrong at both ends.
+
+"Stateless" conflates process state with system state: `.procoder/` already
+persists adr, ask, backlog, plans, specs, state, todo, index, security, bench.
+The real gap is that nothing is user-global — no `~/.procoder`, no
+`UserConfigDir` anywhere in `internal/`. That is a question of where the store
+lives, not whether a daemon fronts it.
+
+Three items survive: cross-repo memory (small, no daemon), a shared code-index
+cache (a cache-location problem), and inter-repo coordination (the only one
+that genuinely wants a long-lived process, and the least specified).
+
+- close #117 and open one narrow issue for the user-global store: take the
+  gap that is real, drop the architecture that was proposed to reach it.
+- comment the measurements on #117 and rescope it in place to "cross-repo
+  state without a daemon", keeping the discussion in one thread.
+- comment the measurements and leave #117 open as written: the inter-repo
+  coordination case is unproven either way and may still want a service.

--- a/.procoder/github/LESSONS.md
+++ b/.procoder/github/LESSONS.md
@@ -384,3 +384,62 @@ closes #209` — and after merging a PR that claimed to close more than
   improvement somewhere else, measure it there, and get the baseline's
   SPREAD rather than one sample — a single 6m47s reading looked like a
   fixed baseline when the real range was 402-508s.
+
+## 2026-08-30 state seam (self) — a lock that worked everywhere except the one platform nobody ran
+
+- Class: mechanical
+
+- Adaptation: `internal/store`'s lock treated any create error that was not
+  `os.IsExist` as fatal. On Windows a file pending deletion reports "access
+  is denied" instead, so ordinary contention became a hard failure and
+  `TestConcurrentAppendsBothSurvive` lost five of twenty appends — the exact
+  defect the package exists to prevent, on the platform it had never run
+  on. A second one beside it: release removed the lock while the heartbeat
+  could still have it open in `os.Chtimes`, which Windows refuses, so the
+  lock survived and the next caller paid the whole timeout.
+
+  What makes this worth a ledger entry is everything that did NOT catch it.
+  Two fresh-context review passes read the whole diff. A 245-invocation
+  equivalence sweep compared every command, every write path and nineteen
+  broken-input scenarios against the pre-change binary. `go test -race`
+  passed. All of it ran on macOS, and none of it could have found this.
+
+  The rule: filesystem semantics are platform behaviour, not Go behaviour,
+  and no amount of local evidence substitutes for the leg that runs
+  elsewhere. REVIEW.md now names the four shapes — `os.IsExist` alone,
+  removing a file another handle may hold, `os.Chmod` on a directory, and
+  native-versus-slash path comparisons — so the rubric asks the question
+  before CI has to.
+
+## 2026-08-30 state seam (self) — committed goldens failed on line endings nobody wrote
+
+- Class: mechanical
+
+- Adaptation: the parity goldens are compared byte for byte against output
+  procoder generates at runtime, and procoder emits LF everywhere. A
+  Windows checkout converted the committed files to CRLF, so all four
+  golden comparisons failed on a difference no change had made. Fixed with
+  `.gitattributes` pinning them, rather than by teaching the comparison to
+  normalise — a comparison taught to ignore a difference stops being a
+  byte-for-byte comparison.
+
+  The rule: any committed fixture compared byte for byte against generated
+  output needs its line endings pinned. REVIEW.md now says so.
+
+## 2026-08-30 state seam (self) — the same check-then-act race, twice in one branch
+
+- Class: mechanical
+
+- Adaptation: the pre-PR review found that judging a lock stale and removing
+  it were two unbound operations, so two callers could both break one lock
+  and both hold it. The fix serialised breaking behind an `O_EXCL` file. The
+  VERIFICATION pass then found the identical shape reintroduced on that
+  break file — a stat, then a remove, with nothing binding them — one commit
+  after the first was fixed.
+
+  Fixing an instance does not close a class. `removeIfSame` is now the one
+  way this package removes anything it did not just create, and REVIEW.md
+  carries check-then-act on a shared file as its own rubric line, because
+  reading for "is this race fixed" is a different question from reading for
+  "does this shape appear anywhere".
+

--- a/.procoder/github/REVIEW.md
+++ b/.procoder/github/REVIEW.md
@@ -48,6 +48,29 @@ Check every hunk for:
   the terminator variants, the case the happy path skips.
 - Test fixtures that trip our own scanners: assemble marker/secret-like
   content at runtime, never as a literal.
+- CHECK-THEN-ACT on a shared file: a stat (or a read, or an exists test)
+  followed by a remove, rename, or create, with nothing binding the two to
+  the same file. Between them another process can replace what was
+  examined, and the second operation then lands on somebody else's file.
+  Bind them — `os.SameFile` against the `FileInfo` that was judged, or a
+  lock that only one caller can hold — or say in a comment why the race is
+  unreachable here.
+- POSIX ASSUMPTIONS in code and in tests, because CI's Windows leg is the
+  only thing that catches them and it catches them late:
+  - a create or open error tested with `os.IsExist` alone — Windows reports
+    a file pending deletion as "access is denied", so contention reads as a
+    hard failure;
+  - a remove or rename of a file another handle may have open — Windows
+    refuses it, POSIX does not;
+  - `os.Chmod` on a DIRECTORY to make it unwritable — Windows toggles a
+    file's read-only attribute and does not restrict a directory, so the
+    test proves nothing there;
+  - a path compared as a native string where the code deliberately emits
+    slashes (or the reverse).
+- COMMITTED FIXTURES compared byte for byte against generated output need
+  `.gitattributes` to hold their line endings. A Windows checkout converts
+  text files to CRLF, and every golden then fails on a difference nobody
+  wrote.
 - Prose and markdown: code spans unbroken, lists formatted, wording that
   says what the code actually does — names and paths in docs match the
   code exactly (every variant, full paths).

--- a/.procoder/plans/service-state-seam.md
+++ b/.procoder/plans/service-state-seam.md
@@ -1,6 +1,7 @@
 # service-state-seam — implementation plan
 
 Status: complete
+Delivered: 2026-08-29 — all seven tasks closed on feat/service-state-seam
 Spec: .procoder/specs/service-state-seam.md
 
 ## Goal

--- a/.procoder/plans/service-state-seam.md
+++ b/.procoder/plans/service-state-seam.md
@@ -1,0 +1,625 @@
+# service-state-seam — implementation plan
+
+Status: complete
+Spec: .procoder/specs/service-state-seam.md
+
+## Goal
+
+Put every `.procoder/` read and write behind one typed package that locks,
+writes atomically, and knows which repository it is serving.
+
+## Architecture
+
+A new package `internal/store` owns three primitives — a lockfile, an
+atomic write, and a repository identity — and exposes one typed load/save
+pair per `.procoder/` owner on top of them. The twenty-five packages that
+read and write `.procoder/` today keep their exported signatures and lose
+their direct filesystem calls; the only new user-visible surface is one
+line in `procoder config` and one optional key in `.procoder/config.toml`.
+Nothing starts a server and no file format changes.
+
+## Constraints
+
+Every task inherits these.
+
+- **Zero dependencies.** The module file go.mod has no require block. No
+  task may add one. Locking is stdlib only, which is why it is a lockfile
+  and not flock.
+- **P-CONTROL.** The store grants no write the binary could not already
+  make. It is plumbing, not permission.
+- **No behaviour change.** The same inputs produce the same bytes on
+  stdout and the same bytes on disk. Task 7 asserts this.
+- **A hook must never wedge a session.** No lock wait is unbounded.
+- **Windows, macOS, Linux.** Paths compared and sorted as repo-relative
+  slash-separated strings, never as OS paths.
+- **Literal values, fixed here, used verbatim by every task:**
+  - lock directory: `.procoder/state/locks/`
+  - lock file name: first 16 hex characters of the SHA-256 of the
+    repo-relative slash-separated path, plus `.lock`
+  - lock file contents: two lines — the pid in decimal, then the unix
+    time in seconds in decimal
+  - stale threshold: 30 seconds
+  - lock acquire timeout: 5 seconds
+  - lock retry interval: 10 milliseconds
+  - temp file prefix for atomic writes: `.procoder-tmp-`
+  - identity string shape: `host/path`, host lower-cased, path case
+    preserved, no scheme, no `user@`, no trailing `/`, no `.git` suffix
+
+## Task 1: the lockfile
+
+Files:
+
+- `internal/store/lock.go` — acquire, release, stale detection, ordering
+- `internal/store/lock_test.go` — its tests
+
+Interfaces produced, consumed by tasks 5 and 6:
+
+```go
+// Lock takes an exclusive lock on each repo-relative path, in sorted
+// order. The returned func releases every lock it took, and broken names
+// any stale lock this call had to break, for the caller to report. On
+// failure nothing is held and the error says which path and why.
+//
+// broken is returned rather than read from a package-level accessor:
+// concurrent Lock calls would race on shared state, and this package
+// exists precisely because that concurrency is real.
+func Lock(root string, relPaths ...string) (release func(), broken []string, err error)
+```
+
+- [ ] Write `TestLockIsExclusive` in `internal/store/lock_test.go`:
+
+```go
+    func TestLockIsExclusive(t *testing.T) {
+        root := t.TempDir()
+        rel, _, err := Lock(root, ".procoder/state/dispatch.json")
+        if err != nil { t.Fatalf("first lock: %v", err) }
+        defer rel()
+        if _, _, err := Lock(root, ".procoder/state/dispatch.json"); err == nil {
+            t.Fatal("second lock succeeded while the first was held")
+        }
+    }
+```
+
+          Run `go test ./internal/store/` — expect FAIL with
+          `undefined: Lock`.
+
+- [ ] Implement `Lock`: for each path, sort the repo-relative slash paths
+      byte-wise, then for each, `os.MkdirAll(root + "/.procoder/state/locks", 0o755)`
+      and `os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)`.
+      On success write `fmt.Sprintf("%d\n%d\n", os.Getpid(), time.Now().Unix())`
+      and close. On `os.IsExist`, retry every 10ms until 5 seconds have
+      passed, then return an error reading
+      `procoder: could not lock <rel> within 5s — the write was NOT made`.
+      If any path in a multi-path call fails, release the locks already
+      taken before returning.
+- [ ] Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestStaleLockIsBrokenAndReported`:
+
+```go
+    func TestStaleLockIsBrokenAndReported(t *testing.T) {
+        root := t.TempDir()
+        plant(t, root, ".procoder/state/dispatch.json", os.Getpid(), time.Now().Add(-31*time.Second).Unix())
+        rel, broken, err := Lock(root, ".procoder/state/dispatch.json")
+        if err != nil { t.Fatalf("stale lock was not broken: %v", err) }
+        defer rel()
+        if len(broken) != 1 || !strings.Contains(broken[0], "dispatch.json") {
+            t.Fatalf("breaking the lock was not reported: %v", broken)
+        }
+    }
+```
+
+          with a `plant` helper that writes the lock file for a repo-relative
+          path with the given pid and unix time. Run — expect FAIL with
+          `stale lock was not broken: procoder: could not lock ... within 5s`.
+
+- [ ] Implement stale detection: before retrying, read the existing lock
+      file. Break it — remove it and try again — when any of these hold:
+      the contents do not parse as two decimal integers; the timestamp is
+      more than 30 seconds in the past; the timestamp is in the future.
+      When a lock is broken, return its repo-relative path in `broken` so
+      the caller can report it. Empty on the ordinary path.
+
+- [ ] Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestUnreadableLockIsStale`: plant a lock whose contents are
+      `not a lock`, and a second case whose timestamp is
+      `time.Now().Add(time.Hour).Unix()`. Both must be broken and the
+      lock taken. Run — expect FAIL for the future-timestamp case with
+      `could not lock`, because only the age check exists so far.
+- [ ] Extend the stale check with the unparsable and future-timestamp
+      cases. Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestLiveLockRefusesRatherThanBlocks`: plant a lock with
+      `os.Getpid()` and `time.Now().Unix()`, then
+
+```go
+    start := time.Now()
+    _, _, err := Lock(root, ".procoder/state/dispatch.json")
+    if err == nil { t.Fatal("write proceeded while a live lock was held") }
+    if d := time.Since(start); d > 8*time.Second {
+        t.Fatalf("Lock blocked for %v, past its 5s timeout", d)
+    }
+    if !strings.Contains(err.Error(), ".procoder/state/dispatch.json") {
+        t.Fatalf("error does not name the file: %v", err)
+    }
+```
+
+          Run — expect PASS if the timeout is already right; if it hangs, the
+          retry loop has no deadline and the test is what says so.
+
+- [ ] Write `TestLockOrderIsSortedPaths`:
+
+```go
+    func TestLockOrderIsSortedPaths(t *testing.T) {
+        root := t.TempDir()
+        a, b := ".procoder/backlog/stories/s1.md", ".procoder/backlog/sprints/001.md"
+        done := make(chan error, 2)
+        for _, pair := range [][2]string{{a, b}, {b, a}} {
+            go func(p [2]string) {
+                for i := 0; i < 50; i++ {
+                    rel, _, err := Lock(root, p[0], p[1])
+                    if err != nil { done <- err; return }
+                    rel()
+                }
+                done <- nil
+            }(pair)
+        }
+        for i := 0; i < 2; i++ {
+            select {
+            case err := <-done:
+                if err != nil { t.Fatalf("lock failed: %v", err) }
+            case <-time.After(30 * time.Second):
+                t.Fatal("deadlock: locks were not taken in sorted order")
+            }
+        }
+    }
+```
+
+          Run `go test ./internal/store/` — expect PASS.
+
+- [ ] Run `procoder check` and commit.
+
+## Task 2: the atomic write
+
+Files:
+
+- `internal/store/atomic.go` — write-temp-then-rename, temp sweeping
+- `internal/store/atomic_test.go` — its tests
+
+Interfaces produced, consumed by tasks 5 and 6:
+
+```go
+// WriteFile replaces the file at the repo-relative path with data, or
+// leaves it exactly as it was. Creates parent directories as needed.
+func WriteFile(root, relPath string, data []byte, perm os.FileMode) error
+
+// ReadFile reads the file at the repo-relative path. An absent file
+// returns an error satisfying os.IsNotExist, as os.ReadFile does.
+func ReadFile(root, relPath string) ([]byte, error)
+```
+
+- [ ] Write `TestAtomicWriteLeavesOriginalOnRenameFailure` in
+      `internal/store/atomic_test.go`. Make the rename fail by making the
+      destination a directory that cannot be replaced:
+
+```go
+    func TestAtomicWriteLeavesOriginalOnRenameFailure(t *testing.T) {
+        root := t.TempDir()
+        rel := ".procoder/state/claims.json"
+        if err := WriteFile(root, rel, []byte("original"), 0o644); err != nil {
+            t.Fatalf("seed: %v", err)
+        }
+        // a directory where the temp file wants to go cannot be renamed over
+        if err := os.MkdirAll(filepath.Join(root, ".procoder/state/claims.json.d"), 0o755); err != nil {
+            t.Fatal(err)
+        }
+        forceRenameFailure = true
+        t.Cleanup(func() { forceRenameFailure = false })
+        if err := WriteFile(root, rel, []byte("replacement"), 0o644); err == nil {
+            t.Fatal("WriteFile reported success though the rename failed")
+        }
+        got, _ := ReadFile(root, rel)
+        if string(got) != "original" {
+            t.Fatalf("target was modified: %q", got)
+        }
+    }
+```
+
+          Run `go test ./internal/store/` — expect FAIL with
+          `undefined: WriteFile`.
+
+- [ ] Implement `WriteFile`: `os.MkdirAll` the parent, create a temp file
+      in the destination directory with `os.CreateTemp(dir, ".procoder-tmp-*")`,
+      write, `Sync()`, `Close()`, `Chmod(perm)`, then `os.Rename` over the
+      target. On any error remove the temp file and return the error with
+      the target path in it. Add an unexported `forceRenameFailure bool`
+      used only by the test — this is the seam the test needs and there is
+      no portable way to make rename fail otherwise.
+- [ ] Implement `ReadFile` as `os.ReadFile(filepath.Join(root, filepath.FromSlash(relPath)))`.
+- [ ] Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestReaderNeverSeesPartialFile`:
+
+```go
+    func TestReaderNeverSeesPartialFile(t *testing.T) {
+        root := t.TempDir()
+        rel := ".procoder/state/claims.json"
+        old, new := strings.Repeat("a", 1<<16), strings.Repeat("b", 1<<16)
+        if err := WriteFile(root, rel, []byte(old), 0o644); err != nil { t.Fatal(err) }
+        stop := make(chan struct{})
+        go func() {
+            for {
+                select {
+                case <-stop: return
+                default: _ = WriteFile(root, rel, []byte(new), 0o644)
+                    _ = WriteFile(root, rel, []byte(old), 0o644)
+                }
+            }
+        }()
+        for i := 0; i < 2000; i++ {
+            got, err := ReadFile(root, rel)
+            if err != nil { continue }
+            if s := string(got); s != old && s != new {
+                close(stop)
+                t.Fatalf("partial read of %d bytes", len(s))
+            }
+        }
+        close(stop)
+    }
+```
+
+          Run `go test ./internal/store/` — expect PASS. Replacing
+          `WriteFile`'s body with a plain `os.WriteFile` makes it fail, which
+          is what it is for.
+
+- [ ] Write `TestTempFilesAreSwept`: leave a `.procoder-tmp-stale` file in
+      `.procoder/state/`, call `WriteFile` into that directory, assert the
+      stale temp file is gone and the written file is present. Run — expect
+      FAIL with `stale temp file survived`.
+- [ ] Implement the sweep: after a successful rename, remove entries in
+      the destination directory whose name starts with `.procoder-tmp-`
+      and whose modification time is more than 30 seconds old. Run
+      `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestReadOnlyStateRefusesWrite`: `os.Chmod` the
+      `.procoder/state` directory to `0o555`, call `WriteFile` into it,
+      assert the error names the path, and assert the previously written
+      file still holds its old contents. Skip the test when running as
+      root, where the mode does not apply. Run `go test ./internal/store/`
+      — expect PASS.
+- [ ] Run `procoder check` and commit.
+
+## Task 3: repository identity
+
+Files:
+
+- `internal/gitx/remotes.go` — exported remote lookup
+- `internal/gitx/remotes_test.go` — its test
+- `internal/store/identity.go` — the ladder and the normalisation
+- `internal/store/identity_test.go` — its tests
+- `internal/config/config.go` — parse `[service] repo`
+- `internal/config/config_test.go` — its test
+
+Interfaces produced, consumed by task 4:
+
+```go
+// Remotes maps remote name to URL, as git reports them.
+func Remotes(root string) map[string]string          // internal/gitx
+
+// Identity is the repository key and the rung that produced it. Rung is
+// one of "config", "origin", "remote", "path".
+type Identity struct{ Key, Rung, Detail string }     // internal/store
+
+// IdentityFor resolves the ladder: cfgRepo, then origin, then the first
+// remote in alphabetical order, then the resolved absolute root path.
+func IdentityFor(root, cfgRepo string) Identity      // internal/store
+```
+
+`Config` gains one field, set from `[service] repo`:
+
+```go
+// ServiceRepo overrides the computed repository identity. Empty means
+// compute it.
+ServiceRepo string
+```
+
+- [ ] Write `TestRemotes` in `internal/gitx/remotes_test.go`: initialise a
+      temp git repository, `git remote add origin git@example.com:o/r.git`,
+      assert `Remotes(root)["origin"] == "git@example.com:o/r.git"`, and
+      assert `Remotes(t.TempDir())` returns an empty map rather than
+      panicking. Run `go test ./internal/gitx/` — expect FAIL with
+      `undefined: Remotes`.
+- [ ] Implement `Remotes` in `internal/gitx/remotes.go` using the existing
+      unexported helper: `git(root, "config", "--get-regexp", `^remote\..*\.url`)`,
+      splitting each line on the first space and taking the remote name
+      from between the first and last dot of the key. A non-zero exit —
+      no remotes, or not a repository — returns an empty map, never an
+      error, because absence is the answer at that rung.
+- [ ] Run `go test ./internal/gitx/` — expect PASS.
+- [ ] Write `TestIdentityNormalisation` in
+      `internal/store/identity_test.go`:
+
+```go
+    func TestIdentityNormalisation(t *testing.T) {
+        for _, url := range []string{
+            "git@host:o/r.git", "https://host/o/r.git",
+            "ssh://git@host/o/r", "https://HOST/o/r/", "https://host/o/r",
+        } {
+            if got := normalise(url); got != "host/o/r" {
+                t.Errorf("normalise(%q) = %q, want host/o/r", url, got)
+            }
+        }
+    }
+```
+
+          Run `go test ./internal/store/` — expect FAIL with
+          `undefined: normalise`.
+
+- [ ] Implement `normalise`: strip a leading `scheme://`; strip everything
+      up to and including a `@`; replace the first `:` after the host with
+      `/` (the scp-like form); split host from path at the first `/`;
+      lower-case the host; trim trailing `/`; trim a `.git` suffix; return
+      `host + "/" + path`. A string matching none of these shapes is
+      returned trimmed, unchanged.
+- [ ] Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestIdentityLadder`, four cases against temp git repositories:
+      `cfgRepo` set returns `Rung == "config"`; `origin` plus `fork`
+      returns origin's normalised URL and `Rung == "origin"`; `fork` plus
+      `upstream` and no origin returns fork's, `Rung == "remote"`,
+      `Detail == "fork"`; no remotes returns the resolved absolute path
+      and `Rung == "path"`. Run — expect FAIL with
+      `undefined: IdentityFor`.
+- [ ] Implement `IdentityFor` down the ladder. For the path rung use
+      `filepath.EvalSymlinks` and fall back to the unresolved absolute
+      path when that errors, so a path that cannot be resolved is still an
+      answer.
+- [ ] Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestIdentityBlankConfigKeyIgnored`: `IdentityFor(root, "   ")`
+      against a repository with an origin must return the origin rung, not
+      an empty key. Run — expect FAIL if the implementation tests only for
+      the empty string; make it `strings.TrimSpace`.
+- [ ] Write `TestIdentityWithoutGit`: `IdentityFor(t.TempDir(), "")` must
+      return the resolved temp directory and `Rung == "path"`. Run — expect
+      PASS.
+- [ ] Add `ServiceRepo` to `Config` in `internal/config/config.go`, read
+      from the `[service]` section's `repo` key, alongside the existing
+      keys. Add `TestServiceRepoKey` in `internal/config/config_test.go`
+      asserting that `[service]\nrepo = "acme/widgets"\n` loads as
+      `ServiceRepo == "acme/widgets"`. Run `go test ./internal/config/` —
+      expect FAIL with `cfg.ServiceRepo undefined`, then PASS.
+- [ ] Run `procoder check` and commit.
+
+## Task 4: procoder config prints the identity
+
+Files:
+
+- `internal/config/report.go` — one added line
+- `internal/config/report_test.go` — its test
+
+Interfaces consumed: `store.IdentityFor(root, cfgRepo string) store.Identity`
+from Task 3.
+
+- [ ] Write `TestConfigPrintsIdentityRung` in
+      `internal/config/report_test.go`, one case per rung, asserting the
+      output contains a line beginning `repo identity` that carries both
+      the key and the rung wording:
+
+| Rung   | wording in the line                       |
+| ------ | ----------------------------------------- |
+| config | `[service] repo in .procoder/config.toml` |
+| origin | `origin remote`                           |
+| remote | `first remote alphabetically: <name>`     |
+| path   | `no remote — repository root path`        |
+
+          Run `go test ./internal/config/` — expect FAIL with
+          `output has no "repo identity" line`.
+
+- [ ] In `Report`, after the settings table and before the problems block,
+      print one blank line and then
+
+```go
+    id := store.IdentityFor(root, cfg.ServiceRepo)
+    fmt.Fprintf(stdout, "repo identity  %s  (%s)\n", id.Key, id.Source())
+```
+
+          where `Source()` renders the four wordings above. Adding this to
+          `Report` and not to `cfg.Settings` is deliberate: identity is not a
+          setting with a default that can be relaxed, and putting it in the
+          table would make it one.
+
+- [ ] Run `go test ./internal/config/` — expect PASS.
+- [ ] Run `procoder check` and commit.
+
+## Task 5: typed pairs for the five state owners
+
+Files:
+
+- `internal/store/state.go` — the typed pairs listed below
+- `internal/store/state_test.go` — its tests
+- `internal/dispatch/dispatch.go` — `Load`/`Save` bodies call the store
+- `internal/claims/claims.go` — same
+- `internal/envsync/envsync.go` — same
+- `internal/learn/learn.go` — `Append`/`Read` call the store
+- `internal/hook/stop.go` — the handoff and digest files call the store
+
+Interfaces produced:
+
+```go
+func LoadDispatch(root string) ([]byte, error)
+func SaveDispatch(root string, data []byte) error
+func LoadClaims(root string) ([]byte, error)
+func SaveClaims(root string, data []byte) error
+func LoadEnvState(root string) ([]byte, error)
+func SaveEnvState(root string, data []byte) error
+func AppendLearn(root string, line []byte) error
+func LoadLearn(root string) ([]byte, error)
+func LoadHandoff(root string) ([]byte, error)
+func SaveHandoff(root string, data []byte) error
+func LoadMarker(root, name string) ([]byte, error)
+func SaveMarker(root, name string, data []byte) error
+```
+
+`LoadMarker`/`SaveMarker` cover `last-decisions-digest` and
+`last-unasked-decision`, which are one-line files with no structure of
+their own; `name` is the file name, not a path.
+
+Interfaces consumed: `Lock` (Task 1); `ReadFile`, `WriteFile` (Task 2).
+
+- [ ] Write `TestSaveDispatchLocksAndWritesAtomically` in
+      `internal/store/state_test.go`: assert that while a lock on
+      `.procoder/state/dispatch.json` is held by the test,
+      `SaveDispatch` returns an error naming that path rather than
+      writing. Run `go test ./internal/store/` — expect FAIL with
+      `undefined: SaveDispatch`.
+- [ ] Implement every pair above. Each save is `Lock` the one path,
+      `WriteFile`, release. Each load is `ReadFile` with no lock — readers
+      do not serialise, per the spec's Out of scope. `AppendLearn` locks
+      `.procoder/state/learn.jsonl`, reads, appends the line, writes, and
+      releases, so two appends cannot lose one another.
+- [ ] Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestConcurrentAppendsBothSurvive` in
+      `internal/store/state_test.go`:
+
+```go
+    func TestConcurrentAppendsBothSurvive(t *testing.T) {
+        root := t.TempDir()
+        var wg sync.WaitGroup
+        for i := 0; i < 20; i++ {
+            wg.Add(1)
+            go func(i int) {
+                defer wg.Done()
+                if err := AppendLearn(root, []byte(fmt.Sprintf("{\"n\":%d}\n", i))); err != nil {
+                    t.Errorf("append %d: %v", i, err)
+                }
+            }(i)
+        }
+        wg.Wait()
+        got, err := LoadLearn(root)
+        if err != nil { t.Fatal(err) }
+        if n := bytes.Count(got, []byte("\n")); n != 20 {
+            t.Fatalf("%d lines survived, want 20 — an append was lost", n)
+        }
+    }
+```
+
+          Run `go test ./internal/store/` — expect PASS. Removing the `Lock`
+          call from `AppendLearn` makes it fail, which is the race this whole
+          spec exists for.
+
+- [ ] Replace the direct filesystem calls in `internal/dispatch`,
+      `internal/claims`, `internal/envsync`, `internal/learn` and
+      `internal/hook/stop.go` with the pairs above. Exported signatures do
+      not change. Where `Broken()` reports a broken lock, append the
+      sentence `procoder: broke a stale lock on <path>` to the command's
+      existing output rather than inventing a new channel for it.
+- [ ] Run `go test ./...` — expect PASS with no changes to any existing
+      test.
+- [ ] Run `procoder check` and commit.
+
+## Task 6: typed pairs for the twenty content owners
+
+Files:
+
+- `internal/store/content.go` — the typed pairs
+- `internal/store/content_test.go` — its tests
+- the twenty owning packages, each losing its direct filesystem calls:
+  `internal/adr`, `internal/analysis`, `internal/answers`,
+  `internal/backlog`, `internal/bench`, `internal/codeindex`,
+  `internal/config`, `internal/docs`, `internal/glossary`,
+  `internal/gitcmd`, `internal/lessons`, `internal/lint`, `internal/plan`,
+  `internal/principles`, `internal/review`, `internal/security`,
+  `internal/spec`, `internal/templates`, `internal/todo`,
+  `internal/wizard`
+
+Interfaces produced. Directory-backed owners get a triple, single-file
+owners get a pair:
+
+```go
+// Directory owners: adr, analysis, backlog (epics, stories, sprints,
+// milestones), bench, plans, review lenses, review perspectives, specs,
+// templates, todo, wizards, index.
+func ListDir(root, relDir string) ([]string, error)
+func LoadIn(root, relDir, name string) ([]byte, error)
+func SaveIn(root, relDir, name string, data []byte) error
+
+// Single-file owners: config.toml, context.md, PRINCIPLES.md,
+// ask/decisions.md, ask/answers.md, ask/QA.md, docs/RULES.md,
+// docs/mermaid.json, lint/RULES.md, security/RULES.md, and the six
+// files under github/.
+func LoadDoc(root, relPath string) ([]byte, error)
+func SaveDoc(root, relPath string, data []byte) error
+```
+
+Interfaces consumed: `Lock` (Task 1); `ReadFile`, `WriteFile` (Task 2).
+
+- [ ] Write `TestSaveInLocksItsOwnFile` in
+      `internal/store/content_test.go`: hold a lock on
+      `.procoder/backlog/stories/s1.md`, assert `SaveIn(root,
+".procoder/backlog/stories", "s1.md", ...)` returns an error naming
+      that path, and assert a save to `s2.md` in the same directory
+      succeeds — per-file locking, not per-directory. Run
+      `go test ./internal/store/` — expect FAIL with `undefined: SaveIn`.
+- [ ] Implement `ListDir`, `LoadIn`, `SaveIn`, `LoadDoc`, `SaveDoc`. Every
+      save locks exactly the one repo-relative path it writes. `ListDir`
+      returns names sorted, and an absent directory returns an empty slice
+      and a nil error — the same shape the callers already treat as "none".
+- [ ] Run `go test ./internal/store/` — expect PASS.
+- [ ] Write `TestMultiFileSaveTakesSortedLocks` in
+      `internal/store/content_test.go`, driving a story-and-sprint save
+      from two goroutines in opposite argument order fifty times each,
+      failing after a 30 second timeout with `deadlock`. Run — expect PASS,
+      because Task 1's `Lock` already sorts; this test is what keeps a
+      later change from bypassing it.
+- [ ] Replace the direct filesystem calls in each of the twenty packages
+      listed under Files. Exported signatures do not change.
+- [ ] Run `go test ./...` — expect PASS with no changes to any existing
+      test.
+- [ ] Run `procoder check` and commit.
+
+## Task 7: the guard tests
+
+Files:
+
+- `internal/store/coverage_test.go` — the two structural guards
+- `internal/store/deps_test.go` — the dependency guard
+- `internal/store/golden_test.go` — the parity harness
+- `internal/store/testdata/golden/` — the committed expected outputs
+
+Interfaces consumed: everything produced by tasks 1 to 6. This task adds
+no production code — it is the evidence that the previous six did what
+they claimed.
+
+- [ ] Write `TestStoreCoversEveryPathConstant` in
+      `internal/store/coverage_test.go`: walk `internal/` and `cmd/` with
+      `go/parser`, collect every string literal beginning `.procoder/`
+      outside `internal/store` and outside `_test.go` files, and assert
+      each appears in a `storePaths` slice declared in
+      `internal/store/coverage_test.go` that lists the paths the store
+      knows. Fail with `path constant %q has no store pair`. Run
+      `go test ./internal/store/` — expect PASS once the slice is filled;
+      adding a new constant elsewhere without a pair makes it fail.
+- [ ] Write `TestNoDirectProcoderFileIO` in the same file: walk the same
+      trees, and for each call to `os.ReadFile`, `os.WriteFile`,
+      `os.Create`, `os.OpenFile` or `os.Remove` whose first argument
+      mentions a `.procoder` literal or a variable named `path`, `p` or
+      `dir` in a function that also mentions `.procoder`, fail with
+      `%s:%d writes under .procoder/ without the store`. Exempt
+      `internal/store` itself. Run `go test ./internal/store/` — expect
+      PASS.
+- [ ] Write `TestNoModuleDependencies` in `internal/store/deps_test.go`:
+      read `go.mod`, fail if it contains the substring `require`. Run
+      `go test ./internal/store/` — expect PASS.
+- [ ] Build `TestMigrationOutputUnchanged` in
+      `internal/store/golden_test.go`: a
+      fixture repository written into `t.TempDir()` carrying a spec, a
+      story, a sprint, a todo, an ADR, a `config.toml`, one Go file and one
+      Markdown file, with a deterministic git history created by
+      `git init`, `git add`, `git -c user.email=t@t -c user.name=t commit`
+      with `GIT_AUTHOR_DATE` and `GIT_COMMITTER_DATE` fixed to
+      `2026-01-01T00:00:00Z`. Run `procoder status`, `procoder check`,
+      `procoder config` and each of the four hook entrypoints against it,
+      capture stdout, and compare against files in
+      `internal/store/testdata/golden/`.
+- [ ] Generate the golden files from the commit BEFORE task 1 — check that
+      commit out into a worktree, run the harness with `-update`, and
+      commit the results. This ordering is the whole point: goldens taken
+      after the migration would prove nothing.
+- [ ] Run `go test ./internal/store/` — expect PASS. A byte of drift in
+      any of the seven outputs fails with a diff.
+- [ ] Run `procoder check` and commit.

--- a/.procoder/plans/service-state-seam.md
+++ b/.procoder/plans/service-state-seam.md
@@ -576,14 +576,32 @@ Interfaces consumed: `Lock` (Task 1); `ReadFile`, `WriteFile` (Task 2).
       test.
 - [ ] Run `procoder check` and commit.
 
-## Task 7: the guard tests
+## Task 7a: the parity harness — BEFORE task 6
+
+Files:
+
+- `internal/store/golden_test.go` — the parity harness
+- `internal/store/testdata/golden/` — the committed expected outputs
+
+Ordering note: the plan originally put every guard last. That is the wrong
+order for this one. The parity harness is the only thing that would catch a
+behaviour change in task 6's twenty-package migration, and building it
+afterwards means the riskiest task in the plan runs with no net under it.
+The structural guards in Task 7b genuinely do come last, because they
+cannot pass until task 6 is done.
+
+Interfaces consumed: none. This task adds no production code.
+
+- [ ] Run `go test ./internal/store/` — expect PASS. A byte of drift in
+      any captured output fails with a diff.
+- [ ] Run `procoder check` and commit.
+
+## Task 7b: the structural guards
 
 Files:
 
 - `internal/store/coverage_test.go` — the two structural guards
 - `internal/store/deps_test.go` — the dependency guard
-- `internal/store/golden_test.go` — the parity harness
-- `internal/store/testdata/golden/` — the committed expected outputs
 
 Interfaces consumed: everything produced by tasks 1 to 6. This task adds
 no production code — it is the evidence that the previous six did what

--- a/.procoder/plans/service-state-seam.md
+++ b/.procoder/plans/service-state-seam.md
@@ -113,9 +113,13 @@ func Lock(root string, relPaths ...string) (release func(), broken []string, err
           `stale lock was not broken: procoder: could not lock ... within 5s`.
 
 - [ ] Implement stale detection: before retrying, read the existing lock
-      file. Break it — remove it and try again — when any of these hold:
-      the contents do not parse as two decimal integers; the timestamp is
-      more than 30 seconds in the past; the timestamp is in the future.
+      file. Break it — remove it and try again — when the file's own mtime
+      is more than 30 seconds old, or when the contents parse and the
+      recorded timestamp is more than 30 seconds in the past or in the
+      future. Contents that do not parse on a file with a FRESH mtime are a
+      lock being written this instant: O_EXCL creates it empty and the pid
+      and timestamp arrive a moment later, so condemning on contents alone
+      hands two callers the same lock.
       When a lock is broken, return its repo-relative path in `broken` so
       the caller can report it. Empty on the ordinary path.
 

--- a/.procoder/specs/service-state-seam.md
+++ b/.procoder/specs/service-state-seam.md
@@ -197,9 +197,13 @@ name and format.
   what the path rung already provides.
 - **Stale lock from a killed process.** A lock older than the stale
   threshold is broken and taken, and the fact that it was broken is
-  reported, not swallowed.
-- **A lock file whose contents do not parse.** Treated as stale — a lock
-  nobody can interpret cannot be proven live.
+  reported, not swallowed. The file's own mtime is what decides this, not
+  the timestamp written inside it.
+- **A lock file whose contents do not parse.** Stale only if the file's own
+  mtime is older than the threshold. `O_EXCL` creates the file empty and the
+  pid and timestamp land a moment later, so for that moment every LIVE lock
+  is unparsable; condemning on contents alone gave two holders of one lock.
+  A genuinely corrupt lock is condemned by its mtime thirty seconds later.
 - **Lock timestamp in the future** (clock skew, a restored backup). Treated
   as stale, for the same reason.
 - **`.procoder/` does not exist.** No state to protect; the store creates
@@ -266,8 +270,13 @@ name and format.
       stale threshold. Fails if the write is refused, or if it succeeds
       without reporting that the lock was broken.
 - [ ] [S-4] `TestUnreadableLockIsStale` plants a lock whose contents do not
-      parse and one whose timestamp is in the future. Fails if either is
-      treated as live.
+      parse AND whose mtime is older than the stale threshold, and one whose
+      recorded timestamp is in the future. Fails if either is treated as
+      live.
+- [ ] [S-4] `TestNewbornLockIsNotStolen` — an empty lock file with a fresh
+      mtime is NOT stale. Fails if unparsable contents alone condemn a lock,
+      which would let a caller steal one that was created a microsecond ago
+      and is still being written.
 - [ ] [S-4] `TestLiveLockRefusesRatherThanBlocks` holds a lock past the
       timeout from a live process. Fails if the write proceeds unlocked, or
       if the call has not returned a message naming the file by the time

--- a/.procoder/specs/service-state-seam.md
+++ b/.procoder/specs/service-state-seam.md
@@ -1,0 +1,292 @@
+# service-state-seam
+
+Status: complete
+
+## Problem
+
+Every read and write of `.procoder/` today is an `os.ReadFile` or an
+`os.WriteFile` issued from whichever package happens to own that path —
+twenty-five of them, each with its own path constant and its own idea of
+what a failed write means. That was correct while procoder was a
+short-lived process: one hook ran, touched a file, and exited before the
+next one started.
+
+Issue #117 ends that. A daemon serving several sessions and several repos
+has to answer three questions this code cannot answer today.
+
+**Who is writing?** There is no locking anywhere in `internal/` — the only
+mutex in the tree is in a test. `dispatch.json`, `claims.json` and the ask
+ledger are read-modify-write: load the whole file, change one field, write
+the whole file back. Two hooks racing on the same wave lose one of the two
+updates, silently, and today that is rare only because each hook is its own
+short-lived process. The daemon makes it ordinary.
+
+**Which repository is this?** The only answer procoder has is the
+filesystem path from `tools.RepoRoot`. One daemon serving ten checkouts
+needs a key that means the same thing on two machines, and a path does not.
+
+**What did a partial write leave behind?** Every write is a plain
+`os.WriteFile`, which truncates first. A process killed mid-write leaves a
+truncated `claims.json` — valid JSON is not guaranteed, and the next reader
+reports a corrupt ledger for a crash that had nothing to do with it.
+
+None of this is visible from outside procoder today, which is why it has
+survived. It becomes the daemon's first three bugs.
+
+## Users
+
+- **An agent in a session** — needs a hook that writes state to either
+  write it or say it did not. A lost dispatch record or a half-written
+  claims ledger is worse than a refusal, because it looks like success.
+- **A person running two Claude sessions in one repo** — needs the second
+  session's write not to erase the first's. Today it does.
+- **Whoever builds the daemon (#117 phase 1)** — needs one place where
+  state access happens, so the daemon can serialise it, and one stable
+  repo key, so it can tell its ten checkouts apart.
+- **Whoever reviews this change** — needs to see that behaviour did not
+  change, which is why byte-identical output is an acceptance criterion
+  and not a hope.
+
+## In scope
+
+- [S-1] A new `internal/store` package: one typed load/save pair per
+  `.procoder/` owner, covering every path constant in the tree. Typed, not
+  a byte store — each operation names what it reads, so the daemon can
+  reason about it later.
+- [S-2] Migrate all twenty-five owners onto it in one change: adr,
+  analysis, answers, backlog, bench, claims, codeindex, config, dispatch,
+  docs, envsync, glossary, gitcmd, learn, lessons, lint, plan, principles,
+  review, security, spec, `internal/templates`, todo, wizard, and the
+  handoff files in `internal/hook/stop.go`. No behaviour change: the same inputs produce the same
+  bytes on stdout and the same bytes on disk.
+- [S-3] Every write through the store is atomic: write a temp file in the
+  destination directory, fsync, rename over the target. A reader never sees
+  a partial file and a crash never truncates one.
+- [S-4] Per-file advisory locking around read-modify-write, using an
+  an O_EXCL lockfile with stale detection. No new dependency: the module
+  file go.mod has no require block and this change does not add one.
+- [S-5] Multi-file operations acquire their locks in sorted path order,
+  always. One mechanical rule, so a lock cycle cannot be introduced by
+  accident.
+- [S-6] A stable repository identity, resolved down a fixed ladder:
+  `[service] repo` in `.procoder/config.toml`, then the normalised URL of
+  the `origin` remote, then the normalised URL of the first remote in
+  alphabetical order, then the resolved absolute path of the repository
+  root. Each rung says which one answered.
+- [S-7] `procoder config` prints the identity and the rung that produced
+  it, so it is observable without a daemon and testable without one.
+
+## Out of scope
+
+- **The daemon.** No socket, no server, no `procoder serve`. This change
+  adds the seam the daemon needs and nothing that uses it. #117 phase 1.
+- **Team mode.** No network, no remote store, no second implementation of
+  the store interface. #248, parked.
+- **Changing any file format.** Every file keeps its current shape, so a
+  repository that upgrades sees no diff in `.procoder/` and a repository
+  that downgrades keeps working.
+- **Changing what any domain decides.** The gate reaches the same verdict,
+  the hooks emit the same text. Only the plumbing underneath moves.
+- **Read locking.** Writers serialise against writers. A reader may observe
+  a file that a writer is about to replace; the atomic rename in S-3 means
+  what it observes is always a whole file, which is the property that
+  matters.
+- **Distinguishing two clones of the same repository on one machine.** The
+  identity in S-6 is deliberately the same for both — see Edge cases.
+
+## Constraints
+
+- **Zero dependencies.** The module file go.mod has no require block at all. Locking
+  must be pure stdlib, which rules out `golang.org/x/sys` and therefore the
+  portable `flock`/`LockFileEx` pair. Hence the lockfile in S-4.
+- **P-CONTROL.** The store does not acquire the right to write anything the
+  binary could not write before. It is plumbing, not permission.
+- **The gate runs on every commit.** Locking and the atomic rename sit on
+  the hot path. The added cost must not be measurable against the existing
+  gate, whose legs are seconds long.
+- **A hook must never wedge a session.** A lock that cannot be taken fails
+  the operation with a message; it never blocks indefinitely.
+- **Windows, macOS and Linux.** The lockfile, the rename and the identity
+  normalisation all behave the same on all three. `os.Rename` over an
+  existing file is the one that historically differs, and is called out in
+  Failure modes.
+- **No behaviour change is a testable claim, not a promise.** See the
+  acceptance criteria.
+
+## Interfaces
+
+**`internal/store`** — a Go package, internal API only, no CLI surface. One
+typed pair per owner, for example:
+
+```go
+func LoadWaves(root string) ([]dispatch.Wave, error)
+func SaveWaves(root string, ws []dispatch.Wave) error
+```
+
+Callers keep their current signatures. What changes inside each package is
+that the stdlib read/write pair becomes a store call.
+
+**`procoder config`** gains one line, printed with the existing settings:
+
+```
+repo identity  git@github.com:azrtydxb/procoder.git  ([service] repo in .procoder/config.toml)
+repo identity  git@github.com:azrtydxb/procoder.git  (origin remote)
+repo identity  git@github.com:azrtydxb/procoder.git  (first remote alphabetically: upstream)
+repo identity  /Users/x/src/thing                    (no remote — repository root path)
+```
+
+**`.procoder/config.toml`** gains one optional key:
+
+```toml
+[service]
+repo = "acme/widgets"     # overrides the computed identity
+```
+
+## Data
+
+**Lock files** live under `.procoder/state/locks/`, which is already
+gitignored, never beside the file they protect — a lock file next to
+`.procoder/specs/foo.md` would show up in `git status` and in review. One
+lock per protected path, named by a hash of the repo-relative path so the
+name is filesystem-safe on every platform. Contents: the pid and the unix
+timestamp at which the lock was taken, one per line, for the stale check.
+
+**Temp files** for the atomic write live in the destination directory —
+`os.Rename` is only atomic within a filesystem — under a fixed prefix
+(`.procoder-tmp-`), removed on successful rename and swept on the next
+successful write into the same directory.
+
+**The identity** is computed on demand and cached for the lifetime of the
+process. It is not written to disk: a cached file would be one more thing
+to invalidate when somebody adds a remote.
+
+**Nothing else moves.** Every `.procoder/` file keeps its current path,
+name and format.
+
+## Edge cases
+
+- **No `.git` at all.** `tools.RepoRoot` returns the directory it was given.
+  Identity falls back to that resolved absolute path, and says so.
+- **`.git` is a file, not a directory** — a worktree or a submodule.
+  `os.Stat` succeeds for both today, so root resolution already works; the
+  remote lookup must run in that directory and not in the parent.
+- **No remotes.** Falls to the path rung.
+- **`origin` exists alongside others.** `origin` wins, regardless of
+  alphabetical order — this is the case that made the pure alphabetical
+  rule wrong: a colleague who adds a remote named `fork` would otherwise
+  key the same repository differently from everybody else.
+- **`[service] repo` set to an empty or whitespace string.** Treated as
+  unset and the ladder continues, rather than an empty identity.
+- **Remote URL forms.** `git@host:o/r.git`, `https://host/o/r.git`,
+  `ssh://git@host/o/r`, a trailing slash, an uppercase host, a `.git`
+  suffix present or absent — all normalise to one key.
+- **Two clones of the same repository on one machine** produce the same
+  identity, deliberately. Locking is per file path and is unaffected;
+  anything that must tell the two apart uses the repository root, which is
+  what the path rung already provides.
+- **Stale lock from a killed process.** A lock older than the stale
+  threshold is broken and taken, and the fact that it was broken is
+  reported, not swallowed.
+- **A lock file whose contents do not parse.** Treated as stale — a lock
+  nobody can interpret cannot be proven live.
+- **Lock timestamp in the future** (clock skew, a restored backup). Treated
+  as stale, for the same reason.
+- **`.procoder/` does not exist.** No state to protect; the store creates
+  what it needs on first write and reads report absence as absence, exactly
+  as they do today.
+- **Read-only filesystem, or `.procoder/state/` not writable.** Covered in
+  Failure modes.
+- **Two processes racing for the same lock.** `O_EXCL` gives exactly one
+  winner; the loser retries until its timeout.
+- **A multi-file operation whose paths sort differently on two platforms.**
+  The sort is over repo-relative slash-separated paths, byte-wise, so it is
+  identical everywhere.
+
+## Failure modes
+
+- **The lock cannot be taken within the timeout.** The operation reports
+  that it did NOT write, and why. It never proceeds unlocked and never
+  blocks past the timeout — a hook that hung would take the session with
+  it. The timeout is short relative to the gate's own deadline.
+- **The lock directory cannot be created or written** (read-only tree,
+  permissions). Same answer: the write is refused with the reason. A store
+  that fell back to writing unlocked would reintroduce the race it exists
+  to remove, and would do it silently.
+- **`os.Rename` fails.** The temp file is removed and the operation
+  reports failure. The target is untouched — the previous contents survive,
+  which is the whole point of writing this way.
+- **The temp file cannot be created.** Reported. Nothing is truncated,
+  because nothing was opened for writing over the target.
+- **`git` is missing, or the directory is not a repository.** Identity falls
+  to the path rung and says which rung answered. It never reports a
+  computed identity it did not compute.
+- **A remote URL that does not parse as any known form.** Used verbatim
+  after trimming, and the rung reported names the remote, so a surprising
+  key is traceable to its source rather than mysterious.
+- **A crash between temp-write and rename.** A `.procoder-tmp-` file is
+  left behind; the next successful write into that directory sweeps it. The
+  target file was never touched.
+- **A crash while holding a lock.** The lock file is left behind and is
+  broken by the stale check on the next attempt.
+
+## Acceptance criteria
+
+- [ ] [S-1] `TestStoreCoversEveryPathConstant` enumerates every
+      `.procoder/` path constant in the tree and asserts each has a typed
+      store pair. Fails if a constant is added without one.
+- [ ] [S-2] `TestNoDirectProcoderFileIO` greps the tree for stdlib file
+      reads and writes against a `.procoder/` path outside
+      `internal/store`. Fails if any package reintroduces one.
+- [ ] [S-2] `TestMigrationOutputUnchanged` runs `procoder check`,
+      `procoder status` and the four hook entrypoints over a fixture
+      repository and compares stdout against committed golden files. Fails
+      if any byte of any output moves.
+- [ ] [S-3] `TestAtomicWriteLeavesOriginalOnRenameFailure` makes the
+      rename fail after the temp file is written. Fails if the target file
+      differs by a single byte from its previous contents.
+- [ ] [S-3] `TestReaderNeverSeesPartialFile` reads a file in a loop while a
+      writer replaces it repeatedly. Fails if any read returns anything
+      other than the complete old or complete new contents.
+- [ ] [S-4] `TestConcurrentAppendsBothSurvive` runs two processes each
+      appending a wave to `.procoder/state/dispatch.json`. Fails if either
+      wave is missing — and fails today, without the lock, which is what
+      makes it worth writing.
+- [ ] [S-4] `TestStaleLockIsBrokenAndReported` plants a lock older than the
+      stale threshold. Fails if the write is refused, or if it succeeds
+      without reporting that the lock was broken.
+- [ ] [S-4] `TestUnreadableLockIsStale` plants a lock whose contents do not
+      parse and one whose timestamp is in the future. Fails if either is
+      treated as live.
+- [ ] [S-4] `TestLiveLockRefusesRatherThanBlocks` holds a lock past the
+      timeout from a live process. Fails if the write proceeds unlocked, or
+      if the call has not returned a message naming the file by the time
+      the timeout has passed.
+- [ ] [S-4] `TestNoModuleDependencies` reads go.mod. Fails if a require
+      block has appeared.
+- [ ] [S-5] `TestLockOrderIsSortedPaths` drives two operations over the
+      same two files in opposite request order. Fails if either deadlocks,
+      or if locks are taken in anything other than sorted repo-relative
+      path order.
+- [ ] [S-6] `TestIdentityLadder` asserts the order: a `[service] repo`
+      value beats the `origin` remote, `origin` beats an alphabetically
+      earlier remote named `fork`, and a repository with no remote uses its
+      resolved absolute root path. Fails if any rung overtakes the one
+      above it.
+- [ ] [S-6] `TestIdentityNormalisation` feeds `git@host:o/r.git`,
+      `https://host/o/r.git`, `ssh://git@host/o/r`, `https://HOST/o/r/` and
+      `https://host/o/r`. Fails if they do not all produce one identity.
+- [ ] [S-6] `TestIdentityBlankConfigKeyIgnored` sets `[service] repo` to
+      whitespace. Fails if the identity is empty rather than falling to the
+      next rung.
+- [ ] [S-6] `TestIdentityWithoutGit` runs in a directory with no `.git`.
+      Fails if the identity is anything but the resolved absolute path, or
+      if the reported rung does not say so.
+- [ ] [S-7] `TestConfigPrintsIdentityRung` runs `procoder config` against
+      a fixture per rung. Fails if the output omits the identity, or names
+      a rung other than the one that answered.
+- [ ] [S-3] [S-4] `TestReadOnlyStateRefusesWrite` makes
+      `.procoder/state/` unwritable. Fails if the write succeeds, if the
+      refusal does not name the reason, or if any file under `.procoder/`
+      has changed afterwards.
+
+## Open questions

--- a/.procoder/specs/service-state-seam.md
+++ b/.procoder/specs/service-state-seam.md
@@ -233,6 +233,25 @@ name and format.
   permissions). Same answer: the write is refused with the reason. A store
   that fell back to writing unlocked would reintroduce the race it exists
   to remove, and would do it silently.
+
+  This COUPLES every write under `.procoder/` to the writability of
+  `.procoder/state/`, and that is a behaviour change worth stating rather
+  than discovering. With `.procoder/state/` read-only and the rest of the
+  tree writable, `procoder ask` used to write `.procoder/ask/QA.md` and
+  now refuses, because the lock it needs lives under state.
+
+  The condition is narrower than it first reads: it bites only while
+  `.procoder/state/locks/` does not yet exist. Once created — which the
+  first successful write in a repository does — a read-only state
+  directory blocks nothing, because no new entry has to be made inside
+  it. Accepted
+  deliberately: the alternatives are worse. Locks beside their files show
+  up in `git status` and in review; locks in the OS temp directory stop
+  being mutually exclusive the moment two processes have different
+  `TMPDIR` values, which on macOS is the ordinary case across sessions —
+  a lock that silently stops locking is the one failure this package
+  cannot have.
+
 - **`os.Rename` fails.** The temp file is removed and the operation
   reports failure. The target is untouched — the previous contents survive,
   which is the whole point of writing this way.
@@ -320,6 +339,11 @@ name and format.
 - [ ] [S-7] `TestConfigPrintsIdentityRung` runs `procoder config` against
       a fixture per rung. Fails if the output omits the identity, or names
       a rung other than the one that answered.
+- [ ] [S-4] `TestReadOnlyStateBlocksContentWrites` writes a content file
+      with `.procoder/state/` read-only. Fails if the write succeeds — it
+      must refuse, because the lock cannot be taken — and the message must
+      name the lock directory, so the coupling is diagnosable rather than
+      mysterious.
 - [ ] [S-3] [S-4] `TestReadOnlyStateRefusesWrite` makes
       `.procoder/state/` unwritable. Fails if the write succeeds, if the
       refusal does not name the reason, or if any file under `.procoder/`

--- a/.procoder/specs/service-state-seam.md
+++ b/.procoder/specs/service-state-seam.md
@@ -119,9 +119,20 @@ survived. It becomes the daemon's first three bugs.
 typed pair per owner, for example:
 
 ```go
-func LoadWaves(root string) ([]dispatch.Wave, error)
-func SaveWaves(root string, ws []dispatch.Wave) error
+func LoadDispatch(root string) ([]byte, error)
+func SaveDispatch(root string, data []byte) error
 ```
+
+One named pair per owner, carrying bytes. Named rather than generic is the
+point: `SaveDispatch` says which resource is being written, which is what
+lets the daemon lock it, order it, and later account for it. A
+`Put(key, bytes)` would push every one of those decisions back out to the
+callers.
+
+The payload is bytes and not the owner's own type because the owner's type
+lives in the owner's package, and that package imports this one — a store
+returning `[]dispatch.Wave` would be an import cycle. Marshalling stays
+where it already is; only the filesystem call moves.
 
 Callers keep their current signatures. What changes inside each package is
 that the stdlib read/write pair becomes a store call.

--- a/.procoder/specs/service-state-seam.md
+++ b/.procoder/specs/service-state-seam.md
@@ -87,6 +87,12 @@ survived. It becomes the daemon's first three bugs.
   that downgrades keeps working.
 - **Changing what any domain decides.** The gate reaches the same verdict,
   the hooks emit the same text. Only the plumbing underneath moves.
+- **Golden capture of `procoder check`, the PreToolUse hook and the
+  PostToolUse hook.** All three exec gitleaks, semgrep, golangci-lint or
+  the test runner, whose presence and version vary by machine. A golden of
+  those would pin one laptop rather than procoder's behaviour, and would
+  fail in CI for reasons no change caused. The seam under them is covered
+  by the store's own tests and by the structural guards instead.
 - **Read locking.** Writers serialise against writers. A reader may observe
   a file that a writer is about to replace; the atomic rename in S-3 means
   what it observes is always a whole file, which is the property that
@@ -252,10 +258,20 @@ name and format.
 - [ ] [S-2] `TestNoDirectProcoderFileIO` greps the tree for stdlib file
       reads and writes against a `.procoder/` path outside
       `internal/store`. Fails if any package reintroduces one.
-- [ ] [S-2] `TestMigrationOutputUnchanged` runs `procoder check`,
-      `procoder status` and the four hook entrypoints over a fixture
-      repository and compares stdout against committed golden files. Fails
-      if any byte of any output moves.
+- [ ] [S-2] `TestMigrationOutputUnchanged` runs `procoder status`, the
+      SessionStart principles hook, the Stop hook's handoff note and
+      `procoder config` over a fixture repository and compares against
+      committed golden files. Fails if any byte moves.
+- [ ] [S-2] The goldens `TestMigrationOutputUnchanged` reads were captured
+      from a binary built at commit `c4bb353`, before `internal/store`
+      existed: `diff` reports no difference for `status.txt`,
+      `principles-hook.txt` or `handoff.txt`. Fails if one of those three is
+      regenerated from current code, which turns the parity assertion into a
+      snapshot of whatever the code now does.
+- [ ] [S-2] `TestCapturesAreDeterministic` runs every capture twice and
+      fails if two runs differ. A golden taken from a command whose output
+      moves records one roll of the dice and fails for everybody
+      afterwards.
 - [ ] [S-3] `TestAtomicWriteLeavesOriginalOnRenameFailure` makes the
       rename fail after the temp file is written. Fails if the target file
       differs by a single byte from its previous contents.

--- a/.procoder/todo/20260828-config-prints-repo-identity.md
+++ b/.procoder/todo/20260828-config-prints-repo-identity.md
@@ -1,0 +1,26 @@
+# config: procoder config prints the repo identity and its rung
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Plan task 4 of .procoder/plans/service-state-seam.md.
+
+The identity computed in task 3 has no consumer until the daemon exists,
+which would make it untestable new work sitting on phase 1's critical
+path. Printing it in `procoder config` makes it observable and testable
+now, with no daemon.
+
+It goes in Report and deliberately NOT in cfg.Settings: identity is not a
+setting with a default that can be relaxed, and putting it in that table
+would make it look like one.
+
+## Acceptance criteria
+
+- [ ] `TestConfigPrintsIdentityRung` — one case per rung, each asserting a line beginning `repo identity` carrying both the key and the rung wording: `[service] repo in .procoder/config.toml`, `origin remote`, `first remote alphabetically: <name>`, `no remote — repository root path`.
+- [ ] The identity line does not appear in the settings table, and `cfg.Settings` gains no entry for it.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-config-prints-repo-identity.md
+++ b/.procoder/todo/20260828-config-prints-repo-identity.md
@@ -1,6 +1,6 @@
 # config: procoder config prints the repo identity and its rung
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -18,9 +18,23 @@ would make it look like one.
 
 ## Acceptance criteria
 
-- [ ] `TestConfigPrintsIdentityRung` — one case per rung, each asserting a line beginning `repo identity` carrying both the key and the rung wording: `[service] repo in .procoder/config.toml`, `origin remote`, `first remote alphabetically: <name>`, `no remote — repository root path`.
-- [ ] The identity line does not appear in the settings table, and `cfg.Settings` gains no entry for it.
-- [ ] `procoder check` is clean.
+- [x] `TestConfigPrintsIdentityRung` — one case per rung, each asserting a line beginning `repo identity` carrying both the key and the rung wording: `[service] repo in .procoder/config.toml`, `origin remote`, `first remote alphabetically: <name>`, `no remote — repository root path`.
+- [x] The identity line does not appear in the settings table, and `cfg.Settings` gains no entry for it.
+- [x] `procoder check` is clean.
 
 ## Evidence
 
+- `internal/config/report.go` and `internal/config/report_test.go`,
+  committed as 8d60453.
+- TestConfigPrintsIdentityRung covers all four rungs, asserting the line
+  carries both the key and the rung wording. TestIdentityIsNotASetting
+  asserts the identity never appears in `cfg.Settings`.
+- Mutation-checked: printing only `id.Key` and dropping `id.Source()`
+  fails TestConfigPrintsIdentityRung with `line "repo identity
+acme/widgets" does not name the rung`.
+- docs/configuration.md gained the `[service]` section — the ladder table,
+  the URL normalisation, why origin beats an alphabetically earlier
+  remote, and when to set the key by hand. This is the first task in the
+  seam that owed a real doc rather than a `docs: none` line, because it is
+  the first with a user-facing surface.
+- `procoder check` clean; the commit gate passed.

--- a/.procoder/todo/20260828-store-atomic-writes.md
+++ b/.procoder/todo/20260828-store-atomic-writes.md
@@ -1,6 +1,6 @@
 # store: atomic writes with temp sweeping
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -19,11 +19,32 @@ one, and a failure leaves the target untouched.
 
 ## Acceptance criteria
 
-- [ ] `TestAtomicWriteLeavesOriginalOnRenameFailure` — with the rename forced to fail, `WriteFile` errors and the target is byte-identical to its previous contents.
-- [ ] `TestReaderNeverSeesPartialFile` — 2000 reads against a file being rewritten in a loop return only the complete old or complete new contents; replacing the body with `os.WriteFile` makes it fail.
-- [ ] `TestTempFilesAreSwept` — a stale `.procoder-tmp-` file older than 30s in the destination directory is removed by the next successful write.
-- [ ] `TestReadOnlyStateRefusesWrite` — with `.procoder/state` at mode 0555, the write is refused with the path in the message and no file under `.procoder/` changes. Skipped when running as root.
-- [ ] `procoder check` is clean.
+- [x] `TestAtomicWriteLeavesOriginalOnRenameFailure` — with the rename forced to fail, `WriteFile` errors and the target is byte-identical to its previous contents.
+- [x] `TestReaderNeverSeesPartialFile` — 2000 reads against a file being rewritten in a loop return only the complete old or complete new contents; replacing the body with `os.WriteFile` makes it fail.
+- [x] `TestTempFilesAreSwept` — a stale `.procoder-tmp-` file older than 30s in the destination directory is removed by the next successful write.
+- [x] `TestReadOnlyStateRefusesWrite` — with `.procoder/state` at mode 0555, the write is refused with the path in the message and no file under `.procoder/` changes. Skipped when running as root.
+- [x] `procoder check` is clean.
 
 ## Evidence
 
+- `internal/store/atomic.go` and `internal/store/atomic_test.go`,
+  committed as 344a81f. `go test ./internal/store/` passes.
+- Four tests: TestAtomicWriteLeavesOriginalOnRenameFailure,
+  TestReaderNeverSeesPartialFile (2000 reads against a file being
+  rewritten in a loop), TestTempFilesAreSwept,
+  TestReadOnlyStateRefusesWrite (skipped as root, where the mode does not
+  apply).
+- Mutation-checked, snapshot taken and restored around each: inserting
+  `os.WriteFile(target, nil, perm)` at the top of WriteFile — the
+  truncate-first behaviour every write had before this change — fails both
+  TestAtomicWriteLeavesOriginalOnRenameFailure and
+  TestReaderNeverSeesPartialFile; replacing `sweep(dir)` with `_ = dir`
+  fails TestTempFilesAreSwept with `stale temp file survived a successful
+write`.
+- The temp file is created in the destination directory, not os.TempDir:
+  os.Rename is only atomic within a filesystem.
+- KNOWN GAP: no test covers the `f.Sync()`. Its failure mode is power loss
+  between the rename and the data reaching disk, and no harness here can
+  produce that. The call stays because the pattern is only correct with
+  it, but this criterion set does not prove it.
+- `procoder check` clean; the commit gate passed.

--- a/.procoder/todo/20260828-store-atomic-writes.md
+++ b/.procoder/todo/20260828-store-atomic-writes.md
@@ -1,0 +1,29 @@
+# store: atomic writes with temp sweeping
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Plan task 2 of .procoder/plans/service-state-seam.md.
+
+Every .procoder/ write today is a plain os.WriteFile, which truncates
+first. A process killed mid-write leaves a truncated claims.json, and the
+next reader reports a corrupt ledger for a crash that had nothing to do
+with it.
+
+Done means WriteFile writes a temp file in the destination directory
+(os.Rename is only atomic within a filesystem), fsyncs it, and renames it
+over the target — so a reader sees the whole old file or the whole new
+one, and a failure leaves the target untouched.
+
+## Acceptance criteria
+
+- [ ] `TestAtomicWriteLeavesOriginalOnRenameFailure` — with the rename forced to fail, `WriteFile` errors and the target is byte-identical to its previous contents.
+- [ ] `TestReaderNeverSeesPartialFile` — 2000 reads against a file being rewritten in a loop return only the complete old or complete new contents; replacing the body with `os.WriteFile` makes it fail.
+- [ ] `TestTempFilesAreSwept` — a stale `.procoder-tmp-` file older than 30s in the destination directory is removed by the next successful write.
+- [ ] `TestReadOnlyStateRefusesWrite` — with `.procoder/state` at mode 0555, the write is refused with the path in the message and no file under `.procoder/` changes. Skipped when running as root.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-store-repository-identity.md
+++ b/.procoder/todo/20260828-store-repository-identity.md
@@ -1,0 +1,36 @@
+# store: repository identity ladder and normalisation
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Plan task 3 of .procoder/plans/service-state-seam.md.
+
+The only repository key procoder has is the filesystem path from
+tools.RepoRoot, and a path does not mean the same thing on two machines.
+One daemon serving ten checkouts needs a stable key, and #117 flags this
+as the thing most likely to be discovered too late — which is why it
+lands now, with only eight RepoRoot call sites to reckon with.
+
+The ladder is fixed: [service] repo in config.toml, then the origin
+remote, then the first remote in alphabetical order, then the resolved
+absolute root path. origin beats an alphabetically earlier remote
+deliberately — a colleague who adds a remote named "fork" must not key
+the same repository differently from everybody else.
+
+Done means IdentityFor returns both the key and the rung that produced
+it, so a surprising identity is always traceable to its source.
+
+## Acceptance criteria
+
+- [ ] `TestRemotes` — `gitx.Remotes` maps name to URL for a repository with an origin, and returns an empty map (not an error) for a directory that is not a repository.
+- [ ] `TestIdentityNormalisation` — `git@host:o/r.git`, `https://host/o/r.git`, `ssh://git@host/o/r`, `https://HOST/o/r/` and `https://host/o/r` all produce `host/o/r`.
+- [ ] `TestIdentityLadder` — config beats origin; origin beats an alphabetically earlier `fork`; `fork` plus `upstream` with no origin yields fork's URL with `Rung == \"remote\"` and `Detail == \"fork\"`; no remotes yields the resolved path.
+- [ ] `TestIdentityBlankConfigKeyIgnored` — a whitespace-only `[service] repo` falls through to the next rung instead of producing an empty key.
+- [ ] `TestIdentityWithoutGit` — a directory with no `.git` yields the resolved absolute path and `Rung == \"path\"`.
+- [ ] `TestServiceRepoKey` — `[service] repo` parses into `Config.ServiceRepo`.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-store-repository-identity.md
+++ b/.procoder/todo/20260828-store-repository-identity.md
@@ -1,6 +1,6 @@
 # store: repository identity ladder and normalisation
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -24,13 +24,32 @@ it, so a surprising identity is always traceable to its source.
 
 ## Acceptance criteria
 
-- [ ] `TestRemotes` — `gitx.Remotes` maps name to URL for a repository with an origin, and returns an empty map (not an error) for a directory that is not a repository.
-- [ ] `TestIdentityNormalisation` — `git@host:o/r.git`, `https://host/o/r.git`, `ssh://git@host/o/r`, `https://HOST/o/r/` and `https://host/o/r` all produce `host/o/r`.
-- [ ] `TestIdentityLadder` — config beats origin; origin beats an alphabetically earlier `fork`; `fork` plus `upstream` with no origin yields fork's URL with `Rung == \"remote\"` and `Detail == \"fork\"`; no remotes yields the resolved path.
-- [ ] `TestIdentityBlankConfigKeyIgnored` — a whitespace-only `[service] repo` falls through to the next rung instead of producing an empty key.
-- [ ] `TestIdentityWithoutGit` — a directory with no `.git` yields the resolved absolute path and `Rung == \"path\"`.
-- [ ] `TestServiceRepoKey` — `[service] repo` parses into `Config.ServiceRepo`.
-- [ ] `procoder check` is clean.
+- [x] `TestRemotes` — `gitx.Remotes` maps name to URL for a repository with an origin, and returns an empty map (not an error) for a directory that is not a repository.
+- [x] `TestIdentityNormalisation` — `git@host:o/r.git`, `https://host/o/r.git`, `ssh://git@host/o/r`, `https://HOST/o/r/` and `https://host/o/r` all produce `host/o/r`.
+- [x] `TestIdentityLadder` — config beats origin; origin beats an alphabetically earlier `fork`; `fork` plus `upstream` with no origin yields fork's URL with `Rung == \"remote\"` and `Detail == \"fork\"`; no remotes yields the resolved path.
+- [x] `TestIdentityBlankConfigKeyIgnored` — a whitespace-only `[service] repo` falls through to the next rung instead of producing an empty key.
+- [x] `TestIdentityWithoutGit` — a directory with no `.git` yields the resolved absolute path and `Rung == \"path\"`.
+- [x] `TestServiceRepoKey` — `[service] repo` parses into `Config.ServiceRepo`.
+- [x] `procoder check` is clean.
 
 ## Evidence
 
+- `internal/gitx/remotes.go`, `internal/store/identity.go`, and the
+  `service.repo` case in `internal/config/config.go`, committed as 096fa09.
+- Tests: TestRemotes and TestRemotesWithoutRepository (gitx);
+  TestIdentityNormalisation, TestIdentityLadder (four subtests),
+  TestIdentityBlankConfigKeyIgnored, TestIdentityWithoutGit,
+  TestIdentitySource (store); TestServiceRepoKey (config).
+- Mutation-checked, snapshot taken and restored around each of six:
+  dropping `strings.ToLower(host)` fails TestIdentityNormalisation on
+  `https://HOST/o/r/`; removing the origin branch makes the
+  origin-plus-fork case return `host/me/r` instead of `host/o/r`; testing
+  `cfgRepo != ""` instead of trimming yields a whitespace key with rung
+  config; `filepath.Clean` in place of `filepath.EvalSymlinks` returns the
+  `/var` path where the test wants `/private/var`; taking the remote name
+  with `strings.Split(key, ".")[1]` loses the `up.stream` remote;
+  removing the `service.repo` case leaves `ServiceRepo` empty.
+- `Identity.Source()` was implemented here rather than in task 4 so the
+  four rung wordings have a test of their own, TestIdentitySource, rather
+  than being asserted only through the report.
+- `procoder check` clean; the commit gate passed.

--- a/.procoder/todo/20260828-store-the-guard-tests.md
+++ b/.procoder/todo/20260828-store-the-guard-tests.md
@@ -1,0 +1,28 @@
+# store: the guard tests — coverage, no direct IO, no deps, golden parity
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Plan task 7 of .procoder/plans/service-state-seam.md.
+
+This task adds no production code. It is the evidence that the previous
+six did what they claimed, and the thing that stops the seam eroding
+after the change lands.
+
+The golden files matter in one specific way: they must be generated from
+the commit BEFORE task 1, in a worktree checked out at that commit.
+Goldens taken after the migration would prove nothing at all.
+
+## Acceptance criteria
+
+- [ ] `TestStoreCoversEveryPathConstant` — every `.procoder/` string literal in `internal/` and `cmd/` outside `internal/store` and outside `_test.go` files appears in the store's declared path list; a new constant without a pair fails it.
+- [ ] `TestNoDirectProcoderFileIO` — no package outside `internal/store` calls a stdlib read/write/create/remove against a `.procoder/` path; reintroducing one fails it.
+- [ ] `TestNoModuleDependencies` — go.mod contains no `require`.
+- [ ] `TestMigrationOutputUnchanged` — `procoder status`, `procoder check`, `procoder config` and the four hook entrypoints produce stdout byte-identical to committed goldens, over a fixture repository with git dates fixed to 2026-01-01T00:00:00Z.
+- [ ] The goldens were generated at the commit preceding task 1, and the evidence records which commit that was.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-store-the-guard-tests.md
+++ b/.procoder/todo/20260828-store-the-guard-tests.md
@@ -1,6 +1,6 @@
 # store: the guard tests — coverage, no direct IO, no deps, golden parity
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -17,12 +17,40 @@ Goldens taken after the migration would prove nothing at all.
 
 ## Acceptance criteria
 
-- [ ] `TestStoreCoversEveryPathConstant` — every `.procoder/` string literal in `internal/` and `cmd/` outside `internal/store` and outside `_test.go` files appears in the store's declared path list; a new constant without a pair fails it.
-- [ ] `TestNoDirectProcoderFileIO` — no package outside `internal/store` calls a stdlib read/write/create/remove against a `.procoder/` path; reintroducing one fails it.
-- [ ] `TestNoModuleDependencies` — go.mod contains no `require`.
-- [ ] `TestMigrationOutputUnchanged` — `procoder status`, `procoder check`, `procoder config` and the four hook entrypoints produce stdout byte-identical to committed goldens, over a fixture repository with git dates fixed to 2026-01-01T00:00:00Z.
-- [ ] The goldens were generated at the commit preceding task 1, and the evidence records which commit that was.
-- [ ] `procoder check` is clean.
+- [x] `TestStoreCoversEveryPathConstant` — every `.procoder/` string literal in `internal/` and `cmd/` outside `internal/store` and outside `_test.go` files appears in the store's declared path list; a new constant without a pair fails it.
+- [x] `TestNoDirectProcoderFileIO` — no package outside `internal/store` calls a stdlib read/write/create/remove against a `.procoder/` path; reintroducing one fails it.
+- [x] `TestNoModuleDependencies` — go.mod contains no `require`.
+- [x] `TestMigrationOutputUnchanged` — `procoder status`, `procoder check`, `procoder config` and the four hook entrypoints produce stdout byte-identical to committed goldens, over a fixture repository with git dates fixed to 2026-01-01T00:00:00Z.
+- [x] The goldens were generated at the commit preceding task 1, and the evidence records which commit that was.
+- [x] `procoder check` is clean.
 
 ## Evidence
 
+- `internal/store/coverage_test.go` and `internal/store/deps_test.go`,
+  committed as 9720427. No production code — this task is the evidence for
+  the other six.
+- TestNoDirectProcoderFileIO walks internal/ and cmd/ with go/ast. It found
+  the last holdout, status reading the index meta.json, and one false
+  positive worth naming: the self-upgrade's `.procoder-upgrade-*` temp
+  directory is a NAME, not a path. The prefix test now matches
+  `.procoder/` or exactly `.procoder`, never `.procoder-`.
+- os.Stat is deliberately not guarded: asking whether something exists is
+  not reaching past the store, and gate adoption legitimately stats
+  .procoder/ to decide whether a repository opted in.
+- TestStoreCoversEveryPathConstant holds a hand-edited list of 41 paths,
+  each naming the operation that serves it; four say plainly that they are
+  prose or a gitignore prefix rather than a path. A new .procoder/ path
+  cannot be added without deciding which operation serves it.
+- TestNoModuleDependencies reads go.mod. The lock is an O_EXCL file rather
+  than flock because a portable flock/LockFileEx pair costs
+  golang.org/x/sys — reasoning only worth anything while the module really
+  has no dependencies, so it gets a test rather than a comment.
+- Mutation-checked, snapshot taken and restored around each: adding a
+  direct os.ReadFile on .procoder/docs/RULES.md fails the IO guard;
+  deleting one knownPaths entry fails the coverage guard with
+  `path ".procoder/todo" has no store pair`; appending a require block to
+  go.mod fails the dependency guard.
+- One earlier mutation attempt was NOT valid and is recorded as such:
+  reverting the status.go call to os.ReadFile broke the build on unused
+  imports rather than failing the test, so it proved nothing. The valid
+  mutation adds a call to a file that already imports os and filepath.

--- a/.procoder/todo/20260828-store-the-lockfile-with-stale-detection.md
+++ b/.procoder/todo/20260828-store-the-lockfile-with-stale-detection.md
@@ -1,6 +1,6 @@
 # store: the lockfile with stale detection and sorted ordering
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -25,13 +25,36 @@ than blocks when one is live, and reports what it broke.
 
 ## Acceptance criteria
 
-- [ ] `TestLockIsExclusive` — a second `Lock` on a held path returns an error rather than succeeding.
-- [ ] `TestStaleLockIsBrokenAndReported` — a lock older than 30s is broken, the write proceeds, and the returned `broken` slice names the path.
-- [ ] `TestUnreadableLockIsStale` — a lock whose contents do not parse, and one whose timestamp is in the future, are both broken.
-- [ ] `TestLiveLockRefusesRatherThanBlocks` — a live lock held past 5s causes a refusal naming the file, and `Lock` returns inside 8s rather than blocking.
-- [ ] `TestLockOrderIsSortedPaths` — two goroutines requesting the same two paths in opposite order, 50 times each, neither deadlocks within 30s.
-- [ ] A failed acquisition in a multi-path call releases the locks already taken; no partial hold survives the error.
-- [ ] `procoder check` is clean.
+- [x] `TestLockIsExclusive` — a second `Lock` on a held path returns an error rather than succeeding.
+- [x] `TestStaleLockIsBrokenAndReported` — a lock older than 30s is broken, the write proceeds, and the returned `broken` slice names the path.
+- [x] `TestUnreadableLockIsStale` — a lock whose contents do not parse, and one whose timestamp is in the future, are both broken.
+- [x] `TestLiveLockRefusesRatherThanBlocks` — a live lock held past 5s causes a refusal naming the file, and `Lock` returns inside 8s rather than blocking.
+- [x] `TestLockOrderIsSortedPaths` — two goroutines requesting the same two paths in opposite order, 50 times each, neither deadlocks within 30s.
+- [x] A failed acquisition in a multi-path call releases the locks already taken; no partial hold survives the error.
+- [x] `procoder check` is clean.
 
 ## Evidence
 
+- `internal/store/lock.go` (158 lines) and `internal/store/lock_test.go`
+  (146 lines), committed as da8644d. `go test ./internal/store/` passes,
+  15.8s — dominated by the two tests that must wait out the 5s timeout.
+- Six tests: TestLockIsExclusive, TestStaleLockIsBrokenAndReported,
+  TestUnreadableLockIsStale (subtests `unparsable` and `future`),
+  TestLiveLockRefusesRatherThanBlocks, TestLockOrderIsSortedPaths,
+  TestPartialAcquisitionReleasesWhatItTook.
+- Mutation-checked, snapshot taken and restored immediately around each:
+  replacing `sort.Strings(paths)` with `_ = sort.StringSlice(paths)` makes
+  TestLockOrderIsSortedPaths fail in 5.01s with `could not lock
+.procoder/backlog/stories/s1.md within 5s`; dropping `|| age < 0` from
+  `stale` fails the `future` subtest; dropping `os.O_EXCL` fails
+  TestLockIsExclusive with `second lock succeeded while the first was
+held`; replacing the `rel()` on a failed acquisition with `_ = rel`
+  fails TestPartialAcquisitionReleasesWhatItTook.
+- Plan corrected before implementing, per the skill: the plan had
+  specified a package-level `Broken() []string`, which is shared mutable
+  state read by concurrent `Lock` callers — a data race under exactly the
+  concurrency this package exists to handle. `Lock` now returns `broken`
+  as its second value. The plan and this task's criteria were updated
+  first, and `plan check` re-run.
+- `procoder check` clean at commit time; the commit gate passed both
+  commits on this branch.

--- a/.procoder/todo/20260828-store-the-lockfile-with-stale-detection.md
+++ b/.procoder/todo/20260828-store-the-lockfile-with-stale-detection.md
@@ -1,0 +1,37 @@
+# store: the lockfile with stale detection and sorted ordering
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Plan task 1 of .procoder/plans/service-state-seam.md.
+
+There is no locking anywhere in internal/ — the only mutex in the tree is
+in a test. dispatch.json, claims.json and the ask ledger are all
+read-modify-write, so two writers lose one of the two updates. That is
+rare today only because every hook is its own short-lived process; the
+daemon in #117 makes it ordinary.
+
+go.mod has no require block, so golang.org/x/sys and therefore the
+portable flock/LockFileEx pair are unavailable. The lock is an O_EXCL
+lockfile under .procoder/state/locks/, named by the first 16 hex
+characters of the SHA-256 of the repo-relative slash path plus .lock,
+carrying the pid and the unix time on two lines.
+
+Done means Lock(root, relPaths...) takes every named path in sorted
+repo-relative order, breaks locks it can prove are dead, refuses rather
+than blocks when one is live, and reports what it broke.
+
+## Acceptance criteria
+
+- [ ] `TestLockIsExclusive` — a second `Lock` on a held path returns an error rather than succeeding.
+- [ ] `TestStaleLockIsBrokenAndReported` — a lock older than 30s is broken, the write proceeds, and the returned `broken` slice names the path.
+- [ ] `TestUnreadableLockIsStale` — a lock whose contents do not parse, and one whose timestamp is in the future, are both broken.
+- [ ] `TestLiveLockRefusesRatherThanBlocks` — a live lock held past 5s causes a refusal naming the file, and `Lock` returns inside 8s rather than blocking.
+- [ ] `TestLockOrderIsSortedPaths` — two goroutines requesting the same two paths in opposite order, 50 times each, neither deadlocks within 30s.
+- [ ] A failed acquisition in a multi-path call releases the locks already taken; no partial hold survives the error.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-store-the-lockfile-with-stale-detection.md
+++ b/.procoder/todo/20260828-store-the-lockfile-with-stale-detection.md
@@ -58,3 +58,21 @@ held`; replacing the `rel()` on a failed acquisition with `_ = rel`
   first, and `plan check` re-run.
 - `procoder check` clean at commit time; the commit gate passed both
   commits on this branch.
+
+## Correction, 2026-08-28 (after this task closed)
+
+Task 5's TestConcurrentAppendsBothSurvive found a defect in this task's
+lock. `O_EXCL` creates the lock file empty and writes the pid and
+timestamp a moment later, so for that moment every LIVE lock has contents
+that do not parse. The rule shipped here — unparsable contents mean stale
+— let a second caller steal a newborn lock, which is two holders of one
+lock: the exact defect this package exists to remove.
+
+The criterion "a lock file whose contents do not parse is treated as
+stale" was wrong as written, not merely incompletely implemented. It is
+now: the file's own mtime decides staleness first, and the contents get a
+say only when they parse. TestNewbornLockIsNotStolen pins the case
+directly rather than leaving it to surface as a lost append somewhere
+downstream. Fixed in 3ff036d; the spec and plan were corrected rather
+than left reading as though the first attempt had been right.
+

--- a/.procoder/todo/20260828-store-the-parity-harness.md
+++ b/.procoder/todo/20260828-store-the-parity-harness.md
@@ -1,0 +1,39 @@
+# store: the parity harness, before the twenty-package migration
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Task 7a of .procoder/plans/service-state-seam.md, split out of the
+original task 7 and moved AHEAD of task 6.
+
+The plan put every guard last. That is the wrong order for this one: the
+parity harness is the only thing that would catch a behaviour change in
+task 6's twenty-package migration, and building it afterwards means the
+riskiest task in the plan runs with no net under it. The structural
+guards genuinely do come last, because they cannot pass until task 6 is
+done — so task 7 is now 7a here and 7b later.
+
+Done means a committed set of golden outputs, proven byte-identical to
+the binary built before `internal/store` existed, that fails on any
+future drift.
+
+## Acceptance criteria
+
+- [ ] `TestMigrationOutputUnchanged` compares `procoder status`, the
+      SessionStart principles hook, the Stop hook's handoff note and
+      `procoder config` against committed goldens. Fails if any byte moves.
+- [ ] `TestCapturesAreDeterministic` runs every capture twice and fails if
+      the two differ.
+- [ ] `diff` reports no difference between the goldens for status, the
+      principles hook and the handoff note and the output of a binary built
+      at `c4bb353`, the commit before `internal/store` existed.
+- [ ] Nondeterministic values are held out of the goldens by line, not by
+      dropping the line: the handoff's `generated:` timestamp and the
+      config report's absolute root path are replaced, and the fact that
+      each line is printed is still asserted.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-store-the-parity-harness.md
+++ b/.procoder/todo/20260828-store-the-parity-harness.md
@@ -1,6 +1,6 @@
 # store: the parity harness, before the twenty-package migration
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -21,19 +21,44 @@ future drift.
 
 ## Acceptance criteria
 
-- [ ] `TestMigrationOutputUnchanged` compares `procoder status`, the
+- [x] `TestMigrationOutputUnchanged` compares `procoder status`, the
       SessionStart principles hook, the Stop hook's handoff note and
       `procoder config` against committed goldens. Fails if any byte moves.
-- [ ] `TestCapturesAreDeterministic` runs every capture twice and fails if
+- [x] `TestCapturesAreDeterministic` runs every capture twice and fails if
       the two differ.
-- [ ] `diff` reports no difference between the goldens for status, the
+- [x] `diff` reports no difference between the goldens for status, the
       principles hook and the handoff note and the output of a binary built
       at `c4bb353`, the commit before `internal/store` existed.
-- [ ] Nondeterministic values are held out of the goldens by line, not by
+- [x] Nondeterministic values are held out of the goldens by line, not by
       dropping the line: the handoff's `generated:` timestamp and the
       config report's absolute root path are replaced, and the fact that
       each line is printed is still asserted.
-- [ ] `procoder check` is clean.
+- [x] `procoder check` is clean.
 
 ## Evidence
+
+- `internal/store/golden_test.go` and four goldens under
+  `internal/store/testdata/golden/`, committed as 994ed5e.
+- Parity proof, run against a worktree at `c4bb353` built to
+  `pc-old`: `diff` reported no difference for `status.txt`,
+  `principles-hook.txt` and `handoff.txt`. The worktree has been removed;
+  the check is reproducible with `git worktree add <dir> c4bb353` and
+  `go build ./cmd/procoder` inside it.
+- `config.txt` is deliberately NOT a parity golden. Task 4 changed that
+  output on purpose — the identity line is new — so it is captured from
+  current code and guards drift from here.
+- TestCapturesAreDeterministic paid for itself on first run: the handoff
+  note stamps `generated:` with the wall clock, so the first goldens failed
+  a second after being written. Both that line and the config report's
+  absolute root path are now replaced by line rather than dropped, so the
+  presence of each line is still asserted.
+- The harness is `package store_test`, not `package store`: it drives
+  status, principles, the stop hook and the config report, all of which
+  import internal/store, so an in-package test would be an import cycle.
+- KNOWN, deliberate exclusion: `procoder check`, PreToolUse and
+  PostToolUse are not captured. They exec gitleaks, semgrep,
+  golangci-lint or the test runner, whose presence and version vary by
+  machine, so a golden of those pins one laptop rather than procoder's
+  behaviour. Recorded in the spec's Out of scope, not left silent.
+- `procoder check` clean; `go test ./...` green.
 

--- a/.procoder/todo/20260828-store-typed-pairs-content-owners.md
+++ b/.procoder/todo/20260828-store-typed-pairs-content-owners.md
@@ -1,6 +1,6 @@
 # store: typed pairs for the twenty content owners, and migrate them
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -22,12 +22,41 @@ moved.
 
 ## Acceptance criteria
 
-- [ ] `TestSaveInLocksItsOwnFile` — a held lock on `s1.md` blocks a save to `s1.md` but not to `s2.md` in the same directory.
-- [ ] `TestMultiFileSaveTakesSortedLocks` — a story-and-sprint save driven from two goroutines in opposite argument order, 50 times each, does not deadlock within 30s.
-- [ ] `ListDir` returns names sorted, and an absent directory returns an empty slice with a nil error.
-- [ ] All twenty packages listed in the plan's Files make no direct filesystem call under `.procoder/`, and their exported signatures are unchanged.
-- [ ] `go test ./...` passes with no change to any existing test.
-- [ ] `procoder check` is clean.
+- [x] `TestSaveInLocksItsOwnFile` — a held lock on `s1.md` blocks a save to `s1.md` but not to `s2.md` in the same directory.
+- [x] `TestMultiFileSaveTakesSortedLocks` — a story-and-sprint save driven from two goroutines in opposite argument order, 50 times each, does not deadlock within 30s.
+- [x] `ListDir` returns names sorted, and an absent directory returns an empty slice with a nil error.
+- [x] All twenty packages listed in the plan's Files make no direct filesystem call under `.procoder/`, and their exported signatures are unchanged.
+- [x] `go test ./...` passes with no change to any existing test.
+- [x] `procoder check` is clean.
 
 ## Evidence
 
+- `internal/store/content.go` and `internal/store/content_test.go`, plus the
+  migration of adr, analysis, answers, ask, backlog, bench, codeindex,
+  config, docs, glossary, gitcmd, lessons, lint, plan, principles, review,
+  spec, status, templates, todo and wizard. Committed as 56f80aa.
+- Tests: TestSaveInLocksItsOwnFile (a lock on s1.md does not block s2.md),
+  TestMultiFileSaveTakesSortedLocks, TestListDirAbsentIsEmpty,
+  TestListDirIsSortedAndFilesOnly, TestInDirNameIsNotAPath, TestSaveDocLocks,
+  TestRelRefusesOutsideRoot.
+- Verified by the parity harness from task 7a: the goldens captured at
+  c4bb353 still pass, which is what says the migration changed nothing.
+  `go test ./...` green; `procoder check` clean, 39 files, 0 blocking.
+- THREE HELPERS NOT IN THE PLAN, each because the migration ran into
+  something the plan had not looked at:
+  - `Rel` — spec.Files, plan.Files, analysis.Files, Item.Path and Task.Path
+    all hand around ABSOLUTE .procoder/ paths, so their readers would have
+    had to reach past the store to open what they were given. Rel refuses a
+    path outside root, so "read what I was handed" cannot become "read
+    anything".
+  - `OpenIn` — the index tag file runs to megabytes and two readers scan it
+    line by line; handing them the bytes would undo that.
+  - `inDir` — the same separator refusal markerPath already had.
+- TWO MORE HAND-ROLLED ATOMIC WRITES found and removed: internal/ask had one
+  for the answers file and internal/codeindex another for its tag file.
+  Both now take the lock neither had, so an index Refresh from the write
+  hook can no longer race an `index build` in another session.
+- internal/ask had parameters named `store`, shadowing the package; renamed
+  to `decided` and `a`.
+- The spec's Interfaces section was corrected during task 5 to show byte
+  payloads and say why; that shape is what these twenty owners use.

--- a/.procoder/todo/20260828-store-typed-pairs-content-owners.md
+++ b/.procoder/todo/20260828-store-typed-pairs-content-owners.md
@@ -1,0 +1,33 @@
+# store: typed pairs for the twenty content owners, and migrate them
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Plan task 6 of .procoder/plans/service-state-seam.md.
+
+The remaining twenty owners hold repository content rather than session
+state: adr, analysis, answers, backlog, bench, codeindex, config, docs,
+glossary, gitcmd, lessons, lint, plan, principles, review, security,
+spec, templates, todo, wizard.
+
+Directory-backed owners get ListDir/LoadIn/SaveIn; single-file owners get
+LoadDoc/SaveDoc. Locking stays per file, not per directory — two people
+editing two different stories must not serialise against each other.
+
+Done means no package outside internal/store reads or writes under
+.procoder/ directly, and nothing about any file's format or location has
+moved.
+
+## Acceptance criteria
+
+- [ ] `TestSaveInLocksItsOwnFile` — a held lock on `s1.md` blocks a save to `s1.md` but not to `s2.md` in the same directory.
+- [ ] `TestMultiFileSaveTakesSortedLocks` — a story-and-sprint save driven from two goroutines in opposite argument order, 50 times each, does not deadlock within 30s.
+- [ ] `ListDir` returns names sorted, and an absent directory returns an empty slice with a nil error.
+- [ ] All twenty packages listed in the plan's Files make no direct filesystem call under `.procoder/`, and their exported signatures are unchanged.
+- [ ] `go test ./...` passes with no change to any existing test.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-store-typed-pairs-state-owners.md
+++ b/.procoder/todo/20260828-store-typed-pairs-state-owners.md
@@ -1,0 +1,34 @@
+# store: typed pairs for the five state owners, and migrate them
+
+Status: open
+Created: 2026-08-28
+
+## Description
+
+Plan task 5 of .procoder/plans/service-state-seam.md.
+
+The five gitignored state owners are where the race actually bites:
+dispatch.json, claims.json, env.json, learn.jsonl and the handoff files
+in internal/hook/stop.go. Each gets a typed load/save pair on top of the
+lock and the atomic write, and each owning package loses its direct
+filesystem calls without changing an exported signature.
+
+Reads take no lock — the atomic rename means a reader always sees a whole
+file, which is the property that matters, and read locking is out of
+scope in the spec.
+
+Done means two concurrent appends to learn.jsonl both survive, which they
+do not today.
+
+## Acceptance criteria
+
+- [ ] `TestSaveDispatchLocksAndWritesAtomically` — while a lock on `.procoder/state/dispatch.json` is held, `SaveDispatch` errors naming that path rather than writing.
+- [ ] `TestConcurrentAppendsBothSurvive` — 20 concurrent `AppendLearn` calls all appear in the file; removing the `Lock` call makes it fail.
+- [ ] All twelve pairs exist: dispatch, claims, env state, learn append/load, handoff, and `LoadMarker`/`SaveMarker` for `last-decisions-digest` and `last-unasked-decision`.
+- [ ] `internal/dispatch`, `internal/claims`, `internal/envsync`, `internal/learn` and `internal/hook/stop.go` make no direct filesystem call under `.procoder/`, and their exported signatures are unchanged.
+- [ ] A broken stale lock is reported through the command's existing output, not swallowed and not given a new channel.
+- [ ] `go test ./...` passes with no change to any existing test.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260828-store-typed-pairs-state-owners.md
+++ b/.procoder/todo/20260828-store-typed-pairs-state-owners.md
@@ -1,6 +1,6 @@
 # store: typed pairs for the five state owners, and migrate them
 
-Status: open
+Status: closed 2026-08-28
 Created: 2026-08-28
 
 ## Description
@@ -22,13 +22,40 @@ do not today.
 
 ## Acceptance criteria
 
-- [ ] `TestSaveDispatchLocksAndWritesAtomically` — while a lock on `.procoder/state/dispatch.json` is held, `SaveDispatch` errors naming that path rather than writing.
-- [ ] `TestConcurrentAppendsBothSurvive` — 20 concurrent `AppendLearn` calls all appear in the file; removing the `Lock` call makes it fail.
-- [ ] All twelve pairs exist: dispatch, claims, env state, learn append/load, handoff, and `LoadMarker`/`SaveMarker` for `last-decisions-digest` and `last-unasked-decision`.
-- [ ] `internal/dispatch`, `internal/claims`, `internal/envsync`, `internal/learn` and `internal/hook/stop.go` make no direct filesystem call under `.procoder/`, and their exported signatures are unchanged.
-- [ ] A broken stale lock is reported through the command's existing output, not swallowed and not given a new channel.
-- [ ] `go test ./...` passes with no change to any existing test.
-- [ ] `procoder check` is clean.
+- [x] `TestSaveDispatchLocksAndWritesAtomically` — while a lock on `.procoder/state/dispatch.json` is held, `SaveDispatch` errors naming that path rather than writing.
+- [x] `TestConcurrentAppendsBothSurvive` — 20 concurrent `AppendLearn` calls all appear in the file; removing the `Lock` call makes it fail.
+- [x] All twelve pairs exist: dispatch, claims, env state, learn append/load, handoff, and `LoadMarker`/`SaveMarker` for `last-decisions-digest` and `last-unasked-decision`.
+- [x] `internal/dispatch`, `internal/claims`, `internal/envsync`, `internal/learn` and `internal/hook/stop.go` make no direct filesystem call under `.procoder/`, and their exported signatures are unchanged.
+- [x] A broken stale lock is reported through the command's existing output, not swallowed and not given a new channel.
+- [x] `go test ./...` passes with no change to any existing test.
+- [x] `procoder check` is clean.
 
 ## Evidence
+
+- `internal/store/state.go` and `internal/store/state_test.go`, plus the
+  migration of internal/dispatch, internal/claims, internal/envsync,
+  internal/learn and internal/hook. Committed as 3ff036d. `go test ./...`
+  green; `procoder check` clean.
+- Tests: TestSaveDispatchLocksAndWritesAtomically,
+  TestConcurrentAppendsBothSurvive, TestLoadsDoNotLock,
+  TestAbsentStateReadsAsAbsent, TestMarkerNameIsNotAPath.
+- Mutation-checked: removing the Lock from AppendLearn leaves 1 line of 20;
+  treating a newborn empty lock as stale leaves 11 of 20 AND fails
+  TestNewbornLockIsNotStolen.
+- TestConcurrentAppendsBothSurvive found a second, deeper bug — the
+  newborn-lock steal in task 1's lockfile. See the correction appended to
+  that task's record. The lock alone was not enough; six appends were
+  still lost until staleness was decided by mtime.
+- The payload is bytes, not each owner's type: a store returning
+  []dispatch.Wave would import dispatch, which imports the store. The spec's
+  Interfaces section was corrected to show the byte form and say why.
+- Two things the plan's enumeration missed, both now done: learn's
+  applied-proposal marker (`.procoder/state/learn-applied.json`) was not
+  listed, and `blockedPath` in internal/hook fell out as dead code and is
+  deleted.
+- envsync had hand-rolled its own temp-and-rename; that is now the store's,
+  which also takes the file lock it never had.
+- KNOWN, deliberate: `LoadMarker`/`SaveMarker` refuse a name containing a
+  separator. Nothing passes a hostile name today, but joining an unchecked
+  name would let ".." walk out of .procoder/state.
 

--- a/.procoder/todo/20260829-index-refs-json-differs-on-every-build.md
+++ b/.procoder/todo/20260829-index-refs-json-differs-on-every-build.md
@@ -1,0 +1,46 @@
+# index: refs.json differs on every build
+
+Status: open
+Created: 2026-08-29
+
+## Description
+
+`procoder index build` writes a byte-different `.procoder/index/refs.json`
+every time it runs, on an unchanged tree. Two consecutive builds of the
+same fixture produce files that are not equal; the CONTENT is equivalent —
+canonicalising the JSON (sorting each document's `symbols` and
+`occurrences`) makes them compare equal — so what varies is the ORDER of
+elements within each document, which comes from map iteration somewhere
+between the SCIP output and the merged file.
+
+Found while proving the state seam (#117 phase 0) changed no behaviour: it
+was the one file out of thirty-seven whose bytes differed between the old
+and new binaries. Checking whether the OLD binary agreed with itself is
+what showed it was not a regression — it never has agreed with itself.
+
+This matters for the same reason #236 and #245 did. A file that changes
+without the tree changing is one that shows up in `git status` for no
+reason, produces noise in a diff, and defeats any cache or comparison
+keyed on its contents. It also means the file cannot be used as evidence
+that an index is current.
+
+The index is gitignored, so nobody has been bitten by it yet. That is why
+it is a task and not a fix in flight.
+
+Done means two consecutive `index build` runs over an unchanged tree
+produce byte-identical `refs.json`.
+
+## Acceptance criteria
+
+- [ ] A test builds the index twice over one fixture and asserts the two
+      `refs.json` files are byte-identical. Fails today.
+- [ ] The ordering is fixed at the point the file is assembled — documents
+      by path, occurrences and symbols by a stable key — rather than by
+      sorting on read, so every reader gets the same file.
+- [ ] `procoder index stats`, `find`, `search`, `refs`, `entrypoints`,
+      `unused`, `outline` and `impact` report what they report today; the
+      ordering change is in the file, not in the answers.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/.procoder/todo/20260829-learn-records-are-not-actually-bounded.md
+++ b/.procoder/todo/20260829-learn-records-are-not-actually-bounded.md
@@ -1,0 +1,43 @@
+# learn: the record file is not actually bounded
+
+Status: open
+Created: 2026-08-29
+
+## Description
+
+`internal/learn` shipped a `maxRecords = 5000` constant in 3baaac6 with a
+comment saying it "bounds the file so an old repository does not carry an
+unbounded one. Oldest dropped." Nothing ever referenced it. Rotation was
+specified and never wired, so `.procoder/state/learn.jsonl` grows without
+limit on any repository that turns `[learn] record = true` on.
+
+The dead constant was deleted in the state-seam branch (#117 phase 0)
+rather than left contradicting the code around it — a comment that claims
+a bound the code does not enforce is worse than no comment. Deleting it
+does not fix the gap; it stops the tree lying about the gap.
+
+This predates the seam and is not the seam's to fix: that branch is about
+where reads and writes go, not about what `learn` retains. But the seam is
+now the natural place to fix it, because `store.AppendLearn` already holds
+the file's lock, which is exactly what a safe trim needs.
+
+Done means the file has a bound the code enforces, the bound is stated in
+`docs/configuration.md` beside the other `[learn]` keys, and appending
+stays O(1) in the common case — a trim on every append would put the
+length of a repository's history on the cost of every command.
+
+## Acceptance criteria
+
+- [ ] A test appends more records than the bound and asserts the file
+      holds at most the bound afterwards, oldest dropped.
+- [ ] A test asserts the common-case append does no full read of the
+      file — appending to a large file costs the same as appending to a
+      small one.
+- [ ] `procoder learn measure` reports the same ranking before and after a
+      trim that drops only records outside the window.
+- [ ] `docs/configuration.md` states the bound and what happens at it,
+      beside `[learn] record` and `[learn] min_samples`.
+- [ ] `procoder check` is clean.
+
+## Evidence
+

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -1460,7 +1460,7 @@ func todoCmd(args []string) int {
 			out(err.Error())
 			return 2
 		}
-		raw, err := os.ReadFile(path)
+		raw, err := todo.Read(root, path)
 		if err != nil {
 			out("no task " + args[1] + " — `procoder todo list` shows what exists")
 			return 2

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1141,6 +1141,19 @@ number, or Procoder's own default. A policy set weaker than the default
 is marked as relaxed, so a repository that quietly turned a gate down
 says so out loud rather than looking like a repository that never had one.
 
+It ends with the repository's identity and the rung that produced it:
+
+```
+repo identity  host/owner/repo  (origin remote)
+```
+
+The identity is a name for this repository that means the same thing on
+somebody else's machine, which a filesystem path does not. It is not a
+setting — it has no default to be relaxed from — which is why it sits
+below the table rather than in it. See
+[Configuration](configuration.md) for the ladder and for `[service] repo`,
+which overrides it.
+
 #### `procoder doctor`
 
 Which tools this repository needs (by its file inventory), which are

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,10 @@ policy = "report"
 # setting that upgraded without asking would remove the consent the
 # upgrade is built on.
 check = "warn"
+
+[service]
+# Overrides the repository identity procoder computes. Unset by default.
+repo = "acme/widgets"
 ```
 
 ## A setting procoder does not know
@@ -437,3 +441,41 @@ told.
 The records are gitignored state, not repository content, and hold a
 command name, a duration and an exit code — nothing about a file's
 contents and nothing identifying a person.
+
+### `[service]`
+
+| Key    | Default    | What it does                                                         |
+| ------ | ---------- | -------------------------------------------------------------------- |
+| `repo` | _computed_ | The repository's stable name, overriding the one procoder works out. |
+
+Procoder needs a name for this repository that means the same thing on
+somebody else's machine. A filesystem path does not: the same repository
+lives at a different path for every person who clones it.
+
+So it works one out, down a ladder, and `procoder config` prints both the
+answer and the rung that produced it:
+
+```
+repo identity  host/owner/repo   (origin remote)
+```
+
+| Rung             | When it answers                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `[service] repo` | You set it. Nothing below is consulted.                                            |
+| origin           | There is an `origin` remote.                                                       |
+| first remote     | There is no `origin`; the alphabetically first remote wins, and the line names it. |
+| root path        | There are no remotes at all. The resolved absolute path.                           |
+
+Remote URLs are normalised to `host/owner/repo`, so
+`git@host:o/r.git`, `https://host/o/r.git` and `ssh://git@host/o/r` are
+one identity rather than three.
+
+**`origin` beats an alphabetically earlier remote deliberately.** Pure
+alphabetical order is simpler and wrong: a colleague who adds a personal
+remote named `fork` would key the same repository differently from
+everybody else, which defeats the one thing an identity is for.
+
+Set `repo` when the computed answer is wrong for you — a monorepo serving
+several products, a mirror whose remote is not the name anybody uses, or
+a checkout with no remote at all that you would rather not identify by
+path.

--- a/internal/adr/adr.go
+++ b/internal/adr/adr.go
@@ -7,7 +7,6 @@ package adr
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -15,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -75,15 +75,14 @@ func New(root, title string, out func(string)) int {
 		out("a decision record needs a title")
 		return 2
 	}
-	dir := filepath.Join(root, Dir)
-	entries, err := os.ReadDir(dir)
-	if err != nil && !os.IsNotExist(err) {
+	names, err := store.ListDir(root, Dir)
+	if err != nil {
 		out("adr directory unreadable: " + err.Error())
 		return 2
 	}
 	next := 1
-	for _, e := range entries {
-		if m := numberRe.FindStringSubmatch(e.Name()); m != nil {
+	for _, name := range names {
+		if m := numberRe.FindStringSubmatch(name); m != nil {
 			if n, err := strconv.Atoi(m[1]); err == nil && n >= next {
 				next = n + 1
 			}
@@ -221,24 +220,20 @@ type parsed struct {
 // unreadable directory is an error; an unreadable file is a record with
 // Err set — never silently skipped.
 func load(root string) ([]parsed, error) {
-	dir := filepath.Join(root, Dir)
-	entries, err := os.ReadDir(dir)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
+	names, err := store.ListDir(root, Dir)
 	if err != nil {
 		return nil, err
 	}
 	var records []parsed
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+	for _, name := range names {
+		if !strings.HasSuffix(name, ".md") {
 			continue
 		}
-		r := parsed{Record: Record{File: filepath.ToSlash(filepath.Join(Dir, e.Name()))}}
-		if m := numberRe.FindStringSubmatch(e.Name()); m != nil {
+		r := parsed{Record: Record{File: filepath.ToSlash(filepath.Join(Dir, name))}}
+		if m := numberRe.FindStringSubmatch(name); m != nil {
 			r.Number = m[1]
 		}
-		raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		raw, err := store.LoadIn(root, Dir, name)
 		if err != nil {
 			r.Err = err
 			records = append(records, r)

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -71,14 +72,14 @@ Created: %s
 
 // Files lists the analysis documents in root, sorted.
 func Files(root string) []string {
-	entries, err := os.ReadDir(filepath.Join(root, Dir))
+	names, err := store.ListDir(root, Dir)
 	if err != nil {
 		return nil
 	}
 	var out []string
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
-			out = append(out, filepath.Join(root, Dir, e.Name()))
+	for _, name := range names {
+		if strings.HasSuffix(name, ".md") {
+			out = append(out, filepath.Join(root, Dir, name))
 		}
 	}
 	sort.Strings(out)
@@ -132,7 +133,7 @@ func Check(root, name string, out func(string)) int {
 
 	worst := 0
 	for _, path := range files {
-		raw, err := os.ReadFile(path)
+		raw, err := readUnder(root, path)
 		if err != nil {
 			out(filepath.Base(path) + ": unreadable — " + err.Error())
 			worst = 2
@@ -169,4 +170,15 @@ func SpecSource(root, specName string) string {
 		return ""
 	}
 	return filepath.ToSlash(filepath.Join(Dir, specName+".md"))
+}
+
+// readUnder reads a .procoder/ file the caller was handed as an absolute
+// path. Files returns absolute paths, so its readers would otherwise have
+// to go around the store to open what they were given.
+func readUnder(root, abs string) ([]byte, error) {
+	rel, err := store.Rel(root, abs)
+	if err != nil {
+		return nil, err
+	}
+	return store.LoadDoc(root, rel)
 }

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -133,7 +133,7 @@ func Check(root, name string, out func(string)) int {
 
 	worst := 0
 	for _, path := range files {
-		raw, err := readUnder(root, path)
+		raw, err := store.LoadUnder(root, path)
 		if err != nil {
 			out(filepath.Base(path) + ": unreadable — " + err.Error())
 			worst = 2
@@ -170,15 +170,4 @@ func SpecSource(root, specName string) string {
 		return ""
 	}
 	return filepath.ToSlash(filepath.Join(Dir, specName+".md"))
-}
-
-// readUnder reads a .procoder/ file the caller was handed as an absolute
-// path. Files returns absolute paths, so its readers would otherwise have
-// to go around the store to open what they were given.
-func readUnder(root, abs string) ([]byte, error) {
-	rel, err := store.Rel(root, abs)
-	if err != nil {
-		return nil, err
-	}
-	return store.LoadDoc(root, rel)
 }

--- a/internal/analysis/entry.go
+++ b/internal/analysis/entry.go
@@ -2,8 +2,9 @@ package analysis
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
+
+	"procoder/internal/store"
 )
 
 // Entry is a point in the quality chain a change can start from.
@@ -97,12 +98,12 @@ func furthest(root string) string {
 		{".procoder/specs", "spec"},
 		{Dir, "analysis"},
 	} {
-		entries, err := os.ReadDir(filepath.Join(root, probe.dir))
+		names, err := store.ListDir(root, probe.dir)
 		if err != nil {
 			continue
 		}
-		for _, e := range entries {
-			if !e.IsDir() && filepath.Ext(e.Name()) == ".md" {
+		for _, name := range names {
+			if filepath.Ext(name) == ".md" {
 				return probe.name
 			}
 		}

--- a/internal/answers/answers.go
+++ b/internal/answers/answers.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"procoder/internal/store"
 )
 
 // Dir and File are where the record lives, beside the other state this
@@ -63,7 +65,7 @@ func Path(root string) string { return filepath.Join(root, filepath.FromSlash(Di
 // error: treating it as empty would re-ask everything and then write the new
 // answers over decisions already made.
 func Load(root string) (Store, error) {
-	raw, err := os.ReadFile(Path(root))
+	raw, err := store.LoadIn(root, Dir, File)
 	if os.IsNotExist(err) {
 		return Store{}, nil
 	}

--- a/internal/ask/ask.go
+++ b/internal/ask/ask.go
@@ -92,7 +92,7 @@ func specQuestions(root string) []Question {
 	var qs []Question
 	for _, path := range spec.Files(root) {
 		name := strings.TrimSuffix(filepath.Base(path), ".md")
-		for _, line := range spec.OpenQuestions(path) {
+		for _, line := range spec.OpenQuestions(root, path) {
 			qs = append(qs, Question{Source: "spec", Origin: name, Text: line})
 		}
 	}

--- a/internal/ask/decisions.go
+++ b/internal/ask/decisions.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"procoder/internal/answers"
+	"procoder/internal/store"
 	"strings"
 )
 
@@ -37,8 +38,7 @@ const DecisionsFile = "decisions.md"
 // nothing. It is not a finding, and treating it as one would put a note in
 // front of every user who never writes decisions.
 func decisionQuestions(root string) ([]Question, []string) {
-	path := Path(root, DecisionsFile)
-	raw, err := os.ReadFile(path)
+	raw, err := store.LoadIn(root, Dir, DecisionsFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/internal/ask/file.go
+++ b/internal/ask/file.go
@@ -2,10 +2,10 @@ package ask
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 	"procoder/internal/answers"
+	"procoder/internal/store"
 	"sort"
 	"strings"
 	"time"
@@ -59,12 +59,12 @@ func WriteQuestions(root string, qs []Question, now time.Time) error {
 		// parser trims each line, so the space is not load-bearing.
 		b.WriteString(strings.TrimRight(answers.AnswerPrefix, " ") + "\n")
 	}
-	return write(Path(root, QuestionsFile), b.String())
+	return write(root, Path(root, QuestionsFile), b.String())
 }
 
 // WriteAnswers records the decisions. Questions are carried alongside their
 // answers so the file reads as a record rather than a list of hashes.
-func WriteAnswers(root string, qs []Question, store Answers, now time.Time) error {
+func WriteAnswers(root string, qs []Question, decided Answers, now time.Time) error {
 	known := map[string]Question{}
 	for _, q := range qs {
 		known[q.Key()] = q
@@ -74,15 +74,15 @@ func WriteAnswers(root string, qs []Question, store Answers, now time.Time) erro
 	b.WriteString("Written " + now.UTC().Format("2006-01-02 15:04") + " UTC. procoder reads this\n")
 	b.WriteString("file to avoid asking a question twice; edit an answer here to change what\n")
 	b.WriteString("it believes. Reword the question and it will be asked again.\n")
-	keys := make([]string, 0, len(store))
-	for k := range store {
+	keys := make([]string, 0, len(decided))
+	for k := range decided {
 		keys = append(keys, k)
 	}
 	// Stable output: a file that reorders itself on every write is a diff
 	// nobody can read.
 	sort.Strings(keys)
 	for _, key := range keys {
-		entry := store[key]
+		entry := decided[key]
 		heading, question := "(no longer asked)", entry.Question
 		if q, ok := known[key]; ok {
 			heading, question = q.Label(), q.Text
@@ -98,50 +98,33 @@ func WriteAnswers(root string, qs []Question, store Answers, now time.Time) erro
 		}
 		b.WriteString("\n" + answers.AnswerPrefix + entry.Answer + "\n")
 	}
-	return write(Path(root, answers.File), b.String())
+	return write(root, Path(root, answers.File), b.String())
 }
 
 // write replaces a file only once the new content is safely on disk. The
-// answers file is the durable record of decisions nobody can reconstruct, and
-// os.WriteFile truncates before it writes: a failure halfway leaves an empty
+// answers file is the durable record of decisions nobody can reconstruct,
+// and a plain write truncates first: a failure halfway leaves an empty
 // record where the decisions were.
-func write(dest, body string) error {
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(dest), ".procoder-ask-*")
+//
+// The temp-and-rename this used to do by hand is now the store's, which
+// does the same thing and also takes the file's lock — the guarantee this
+// code never had.
+func write(root, dest, body string) error {
+	rel, err := store.Rel(root, dest)
 	if err != nil {
 		return err
 	}
-	name := tmp.Name()
-	defer func() { _ = os.Remove(name) }()
-	if _, err := tmp.WriteString(body); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	// The checked close: a write that fails on close is a failed write, and
-	// renaming it over the record would install the failure.
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Chmod(name, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(name, dest)
+	return store.SaveDoc(root, rel, []byte(body))
 }
 
 // Same reports whether the store already on disk matches this one, so a run
 // with nothing new to say leaves the file — and its timestamp — alone.
-func Same(root string, store Answers) bool {
+func Same(root string, a Answers) bool {
 	existing, err := answers.Load(root)
-	if err != nil || len(existing) != len(store) {
+	if err != nil || len(existing) != len(a) {
 		return false
 	}
-	for k, v := range store {
+	for k, v := range a {
 		if existing[k] != v {
 			return false
 		}

--- a/internal/backlog/board.go
+++ b/internal/backlog/board.go
@@ -15,6 +15,7 @@ import (
 
 	"procoder/internal/gitx"
 	"procoder/internal/spec"
+	"procoder/internal/store"
 )
 
 // emptyHint is the one line an empty backlog prints — an instruction to
@@ -275,7 +276,7 @@ func driftFlag(root string, e Item) string {
 	if e.SpecName == "" {
 		return ""
 	}
-	raw, err := os.ReadFile(filepath.Join(root, spec.Dir, e.SpecName+".md"))
+	raw, err := store.LoadIn(root, spec.Dir, e.SpecName+".md")
 	if err != nil {
 		return "  ⚠ spec missing"
 	}

--- a/internal/backlog/close.go
+++ b/internal/backlog/close.go
@@ -8,13 +8,12 @@ package backlog
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"procoder/internal/evidence"
 	"procoder/internal/spec"
 	"strings"
 	"time"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -75,7 +74,7 @@ func CloseStoryWith(root, id string, gateClean func() bool, suite func() (bool, 
 		out(err.Error())
 		return 2
 	}
-	raw, err := os.ReadFile(path)
+	raw, err := readUnder(root, path)
 	if err != nil {
 		out("no story " + id + " — `procoder backlog list` shows what exists")
 		return 2
@@ -165,7 +164,7 @@ func CloseStoryWith(root, id string, gateClean func() bool, suite func() (bool, 
 		}
 		return 1
 	}
-	if !markDone(path, text, out) {
+	if !markDone(root, path, text, out) {
 		return 2
 	}
 	out("story " + id + " closed — criteria checked, evidence recorded, gate clean")
@@ -215,12 +214,12 @@ func CloseEpic(root, id string, out func(string)) int {
 		emit(out, warns)
 		return 1
 	}
-	raw, err := os.ReadFile(epic.Path)
+	raw, err := readUnder(root, epic.Path)
 	if err != nil {
 		out("cannot read the epic file: " + err.Error())
 		return 2
 	}
-	if !markDone(epic.Path, string(raw), out) {
+	if !markDone(root, epic.Path, string(raw), out) {
 		return 2
 	}
 	out("epic " + id + " closed — every story done")
@@ -265,12 +264,12 @@ func CloseMilestone(root, id string, out func(string)) int {
 		}
 		return 1
 	}
-	raw, err := os.ReadFile(ms.Path)
+	raw, err := readUnder(root, ms.Path)
 	if err != nil {
 		out("cannot read the milestone file: " + err.Error())
 		return 2
 	}
-	if !markDone(ms.Path, string(raw), out) {
+	if !markDone(root, ms.Path, string(raw), out) {
 		return 2
 	}
 	out("milestone " + id + " closed — every epic done")
@@ -294,7 +293,7 @@ func driftWarnings(root string, epic Item) []string {
 	if epic.SpecName == "" {
 		return nil
 	}
-	b, err := os.ReadFile(filepath.Join(root, ".procoder", "specs", epic.SpecName+".md"))
+	b, err := store.LoadIn(root, ".procoder/specs", epic.SpecName+".md")
 	if err != nil {
 		return []string{"⚠ spec " + epic.SpecName + " is missing — traceability lost, not blocking"}
 	}
@@ -316,9 +315,9 @@ func emit(out func(string), lines []string) {
 
 // markDone rewrites the Status line to done <date> in a whole-file write —
 // no partial rewrite, same as todo. A write failure is printed verbatim.
-func markDone(path, text string, out func(string)) bool {
+func markDone(root, path, text string, out func(string)) bool {
 	done := statusRe.ReplaceAllString(text, "Status: done "+time.Now().UTC().Format("2006-01-02"))
-	if err := os.WriteFile(path, []byte(done), 0o644); err != nil {
+	if err := writeUnder(root, path, []byte(done)); err != nil {
 		out("cannot update the file: " + err.Error())
 		return false
 	}

--- a/internal/backlog/close.go
+++ b/internal/backlog/close.go
@@ -74,7 +74,7 @@ func CloseStoryWith(root, id string, gateClean func() bool, suite func() (bool, 
 		out(err.Error())
 		return 2
 	}
-	raw, err := readUnder(root, path)
+	raw, err := store.LoadUnder(root, path)
 	if err != nil {
 		out("no story " + id + " — `procoder backlog list` shows what exists")
 		return 2
@@ -214,7 +214,7 @@ func CloseEpic(root, id string, out func(string)) int {
 		emit(out, warns)
 		return 1
 	}
-	raw, err := readUnder(root, epic.Path)
+	raw, err := store.LoadUnder(root, epic.Path)
 	if err != nil {
 		out("cannot read the epic file: " + err.Error())
 		return 2
@@ -264,7 +264,7 @@ func CloseMilestone(root, id string, out func(string)) int {
 		}
 		return 1
 	}
-	raw, err := readUnder(root, ms.Path)
+	raw, err := store.LoadUnder(root, ms.Path)
 	if err != nil {
 		out("cannot read the milestone file: " + err.Error())
 		return 2
@@ -317,7 +317,7 @@ func emit(out func(string), lines []string) {
 // no partial rewrite, same as todo. A write failure is printed verbatim.
 func markDone(root, path, text string, out func(string)) bool {
 	done := statusRe.ReplaceAllString(text, "Status: done "+time.Now().UTC().Format("2006-01-02"))
-	if err := writeUnder(root, path, []byte(done)); err != nil {
+	if err := store.SaveUnder(root, path, []byte(done)); err != nil {
 		out("cannot update the file: " + err.Error())
 		return false
 	}

--- a/internal/backlog/items.go
+++ b/internal/backlog/items.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"procoder/internal/store"
 	"procoder/internal/templates"
 	"procoder/internal/textutil"
 )
@@ -129,20 +130,17 @@ func LoadAll(root string) ([]Item, error) {
 	var items []Item
 	for _, kind := range []string{KindMilestone, KindEpic, KindStory, KindSprint} {
 		dir := filepath.Join(root, Dir, kind)
-		entries, err := os.ReadDir(dir)
-		if os.IsNotExist(err) {
-			continue
-		}
+		names, err := store.ListDir(root, Dir+"/"+kind)
 		if err != nil {
 			return nil, fmt.Errorf("backlog directory unreadable: %v", err)
 		}
-		for _, e := range entries {
-			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+		for _, name := range names {
+			if !strings.HasSuffix(name, ".md") {
 				continue
 			}
-			path := filepath.Join(dir, e.Name())
-			it := Item{ID: strings.TrimSuffix(e.Name(), ".md"), Kind: kind, Path: path, Status: "open"}
-			raw, err := os.ReadFile(path)
+			path := filepath.Join(dir, name)
+			it := Item{ID: strings.TrimSuffix(name, ".md"), Kind: kind, Path: path, Status: "open"}
+			raw, err := store.LoadIn(root, Dir+"/"+kind, name)
 			if err != nil {
 				it.Status = "unreadable"
 				it.Title = err.Error()
@@ -312,17 +310,35 @@ func printItem(root, kind, slug, title string, fill func(now string) string, out
 func ItemFiles(root string) []string {
 	var out []string
 	for _, kind := range []string{KindMilestone, KindEpic, KindStory, KindSprint} {
-		dir := filepath.Join(root, filepath.FromSlash(Dir), kind)
-		entries, err := os.ReadDir(dir)
+		names, err := store.ListDir(root, Dir+"/"+kind)
 		if err != nil {
 			continue // a repository need not have every kind
 		}
-		for _, e := range entries {
-			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+		for _, name := range names {
+			if !strings.HasSuffix(name, ".md") {
 				continue
 			}
-			out = append(out, path.Join(Dir, kind, e.Name()))
+			out = append(out, path.Join(Dir, kind, name))
 		}
 	}
 	return out
+}
+
+// readUnder and writeUnder reach a .procoder/ file the caller was handed as
+// an absolute path. Item.Path is absolute, and its holders would otherwise
+// have to go around the store to open what they were given.
+func readUnder(root, abs string) ([]byte, error) {
+	rel, err := store.Rel(root, abs)
+	if err != nil {
+		return nil, err
+	}
+	return store.LoadDoc(root, rel)
+}
+
+func writeUnder(root, abs string, data []byte) error {
+	rel, err := store.Rel(root, abs)
+	if err != nil {
+		return err
+	}
+	return store.SaveDoc(root, rel, data)
 }

--- a/internal/backlog/items.go
+++ b/internal/backlog/items.go
@@ -323,22 +323,3 @@ func ItemFiles(root string) []string {
 	}
 	return out
 }
-
-// readUnder and writeUnder reach a .procoder/ file the caller was handed as
-// an absolute path. Item.Path is absolute, and its holders would otherwise
-// have to go around the store to open what they were given.
-func readUnder(root, abs string) ([]byte, error) {
-	rel, err := store.Rel(root, abs)
-	if err != nil {
-		return nil, err
-	}
-	return store.LoadDoc(root, rel)
-}
-
-func writeUnder(root, abs string, data []byte) error {
-	rel, err := store.Rel(root, abs)
-	if err != nil {
-		return err
-	}
-	return store.SaveDoc(root, rel, data)
-}

--- a/internal/backlog/seed.go
+++ b/internal/backlog/seed.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"procoder/internal/spec"
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -69,7 +70,7 @@ func Seed(root, specName, milestone string, out func(string)) int {
 		// spec with gaps, 2 for a spec that does not exist.
 		return code
 	}
-	raw, err := os.ReadFile(filepath.Join(root, spec.Dir, specName+".md"))
+	raw, err := store.LoadIn(root, spec.Dir, specName+".md")
 	if err != nil {
 		out("spec " + specName + " unreadable: " + err.Error())
 		return 2

--- a/internal/backlog/sprint.go
+++ b/internal/backlog/sprint.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"procoder/internal/config"
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -125,7 +126,7 @@ func sprintSeq(id string) int {
 // done. `[sprint] retro = "off"` in config.toml opts a repo out.
 func retroGate(root string, last Item, out func(string)) int {
 	rel := filepath.ToSlash(filepath.Join(Dir, KindSprint, last.ID+".md"))
-	raw, err := readUnder(root, last.Path)
+	raw, err := store.LoadUnder(root, last.Path)
 	if err != nil {
 		out("cannot read " + rel + " — an unreadable retro is unknown, and unknown is never done; fix the file before opening a sprint")
 		return 1
@@ -158,7 +159,7 @@ func SprintPull(root string, ids []string, out func(string)) int {
 			refused = true
 			continue
 		}
-		raw, err := readUnder(root, path)
+		raw, err := store.LoadUnder(root, path)
 		if err != nil {
 			out("refused " + id + ": no such story — `procoder backlog list` shows what exists")
 			refused = true
@@ -189,7 +190,7 @@ func SprintPull(root string, ids []string, out func(string)) int {
 			continue
 		}
 		updated := sprintLineRe.ReplaceAllString(text, "Sprint: "+active.ID)
-		if err := writeUnder(root, path, []byte(updated)); err != nil {
+		if err := store.SaveUnder(root, path, []byte(updated)); err != nil {
 			out("cannot update the story file: " + err.Error())
 			return 2
 		}
@@ -223,7 +224,7 @@ func SprintCarry(root, id, reason string, out func(string)) int {
 		out(err.Error())
 		return 2
 	}
-	raw, err := readUnder(root, path)
+	raw, err := store.LoadUnder(root, path)
 	if err != nil {
 		out("no story " + id + " — `procoder backlog list` shows what exists")
 		return 1
@@ -238,7 +239,7 @@ func SprintCarry(root, id, reason string, out func(string)) int {
 		return 1
 	}
 	updated := sprintLineRe.ReplaceAllString(text, "Sprint: -\nCarried: "+active.ID+" — "+reason)
-	if err := writeUnder(root, path, []byte(updated)); err != nil {
+	if err := store.SaveUnder(root, path, []byte(updated)); err != nil {
 		out("cannot update the story file: " + err.Error())
 		return 2
 	}
@@ -313,7 +314,7 @@ func SprintClose(root string, out func(string)) int {
 		}
 		return 1
 	}
-	raw, err := readUnder(root, active.Path)
+	raw, err := store.LoadUnder(root, active.Path)
 	if err != nil {
 		out("cannot read the sprint file: " + err.Error())
 		return 2
@@ -337,7 +338,7 @@ func SprintClose(root string, out func(string)) int {
 			"<!-- What we change next sprint because of it. -->\n\n" +
 			"<!-- One adaptation from this sprint worth keeping. -->\n"
 	}
-	if err := writeUnder(root, active.Path, []byte(text)); err != nil {
+	if err := store.SaveUnder(root, active.Path, []byte(text)); err != nil {
 		out("cannot update the sprint file: " + err.Error())
 		return 2
 	}
@@ -362,7 +363,7 @@ func sprintStories(root, sprintID string) (committed []Item, carried []string) {
 			committed = append(committed, it)
 			continue
 		}
-		raw, err := readUnder(root, it.Path)
+		raw, err := store.LoadUnder(root, it.Path)
 		if err == nil && carriedRe.Match(raw) {
 			carried = append(carried, it.ID)
 		}

--- a/internal/backlog/sprint.go
+++ b/internal/backlog/sprint.go
@@ -2,7 +2,6 @@ package backlog
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -93,7 +92,7 @@ func SprintOpen(root, goal string, out func(string)) int {
 		}
 	}
 	if lastSeq >= 0 && !config.Load(root).SprintRetroOff {
-		if code := retroGate(last, out); code != 0 {
+		if code := retroGate(root, last, out); code != 0 {
 			return code
 		}
 	}
@@ -124,9 +123,9 @@ func sprintSeq(id string) int {
 // all (one that predates the scaffold) counts as empty, and an unreadable
 // one refuses too: an unreadable retro is unknown, and unknown is never
 // done. `[sprint] retro = "off"` in config.toml opts a repo out.
-func retroGate(last Item, out func(string)) int {
+func retroGate(root string, last Item, out func(string)) int {
 	rel := filepath.ToSlash(filepath.Join(Dir, KindSprint, last.ID+".md"))
-	raw, err := os.ReadFile(last.Path)
+	raw, err := readUnder(root, last.Path)
 	if err != nil {
 		out("cannot read " + rel + " — an unreadable retro is unknown, and unknown is never done; fix the file before opening a sprint")
 		return 1
@@ -159,7 +158,7 @@ func SprintPull(root string, ids []string, out func(string)) int {
 			refused = true
 			continue
 		}
-		raw, err := os.ReadFile(path)
+		raw, err := readUnder(root, path)
 		if err != nil {
 			out("refused " + id + ": no such story — `procoder backlog list` shows what exists")
 			refused = true
@@ -190,7 +189,7 @@ func SprintPull(root string, ids []string, out func(string)) int {
 			continue
 		}
 		updated := sprintLineRe.ReplaceAllString(text, "Sprint: "+active.ID)
-		if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		if err := writeUnder(root, path, []byte(updated)); err != nil {
 			out("cannot update the story file: " + err.Error())
 			return 2
 		}
@@ -224,7 +223,7 @@ func SprintCarry(root, id, reason string, out func(string)) int {
 		out(err.Error())
 		return 2
 	}
-	raw, err := os.ReadFile(path)
+	raw, err := readUnder(root, path)
 	if err != nil {
 		out("no story " + id + " — `procoder backlog list` shows what exists")
 		return 1
@@ -239,7 +238,7 @@ func SprintCarry(root, id, reason string, out func(string)) int {
 		return 1
 	}
 	updated := sprintLineRe.ReplaceAllString(text, "Sprint: -\nCarried: "+active.ID+" — "+reason)
-	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+	if err := writeUnder(root, path, []byte(updated)); err != nil {
 		out("cannot update the story file: " + err.Error())
 		return 2
 	}
@@ -314,7 +313,7 @@ func SprintClose(root string, out func(string)) int {
 		}
 		return 1
 	}
-	raw, err := os.ReadFile(active.Path)
+	raw, err := readUnder(root, active.Path)
 	if err != nil {
 		out("cannot read the sprint file: " + err.Error())
 		return 2
@@ -338,7 +337,7 @@ func SprintClose(root string, out func(string)) int {
 			"<!-- What we change next sprint because of it. -->\n\n" +
 			"<!-- One adaptation from this sprint worth keeping. -->\n"
 	}
-	if err := os.WriteFile(active.Path, []byte(text), 0o644); err != nil {
+	if err := writeUnder(root, active.Path, []byte(text)); err != nil {
 		out("cannot update the sprint file: " + err.Error())
 		return 2
 	}
@@ -363,7 +362,7 @@ func sprintStories(root, sprintID string) (committed []Item, carried []string) {
 			committed = append(committed, it)
 			continue
 		}
-		raw, err := os.ReadFile(it.Path)
+		raw, err := readUnder(root, it.Path)
 		if err == nil && carriedRe.Match(raw) {
 			carried = append(carried, it.ID)
 		}

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -122,8 +123,7 @@ func Run(root string, save bool, threshold int, out func(string)) int {
 // corrupt or unreadable one skips comparison with the reason and offers
 // --save as the fix.
 func compareBaseline(root string, current []row, threshold int, out func(string)) bool {
-	path := filepath.Join(root, filepath.FromSlash(Dir), "baseline.txt")
-	raw, err := os.ReadFile(path)
+	raw, err := store.LoadIn(root, Dir, "baseline.txt")
 	if os.IsNotExist(err) {
 		out("no baseline at " + Dir + "/baseline.txt — run with --save to record one")
 		return false
@@ -175,14 +175,10 @@ func compareBaseline(root string, current []row, threshold int, out func(string)
 // saveBaseline writes Dir/baseline.txt: the header line, then the raw
 // benchmark lines. This is the only write the package ever performs.
 func saveBaseline(root string, lines []string) error {
-	dir := filepath.Join(root, filepath.FromSlash(Dir))
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
 	header := fmt.Sprintf("# procoder bench baseline %s %s %s/%s",
 		time.Now().Format("2006-01-02"), commit(root), runtime.GOOS, runtime.GOARCH)
 	body := header + "\n" + strings.Join(lines, "\n") + "\n"
-	return os.WriteFile(filepath.Join(dir, "baseline.txt"), []byte(body), 0o644)
+	return store.SaveIn(root, Dir, "baseline.txt", []byte(body))
 }
 
 // parseBaseline parses a stored baseline: rows plus the GOOS/GOARCH the

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -31,7 +31,7 @@ import (
 // File is where claims live: procoder-owned session state, beside the
 // handoff note. Ephemeral by nature — a claim outlives nothing but the
 // work it describes.
-const File = ".procoder/state/claims.json"
+const File = store.ClaimsPath
 
 // Claim is one agent's declared working set.
 type Claim struct {

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"procoder/internal/store"
 )
 
 // File is where claims live: procoder-owned session state, beside the
@@ -50,7 +51,7 @@ type ledger struct {
 // none would say "nobody else is working here" on the strength of not
 // having looked, which is the failure this package exists to prevent.
 func Load(root string) ([]Claim, error) {
-	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(File)))
+	raw, err := store.LoadClaims(root)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -68,15 +69,11 @@ func Load(root string) ([]Claim, error) {
 // repository content — the same footing as the handoff note, and outside
 // P-CONTROL for the same reason.
 func Save(root string, cs []Claim) error {
-	p := filepath.Join(root, filepath.FromSlash(File))
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return err
-	}
 	raw, err := json.MarshalIndent(ledger{Claims: cs}, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(p, append(raw, '\n'), 0o644)
+	return store.SaveClaims(root, append(raw, '\n'))
 }
 
 // Overlap reports whether two globs could match the same path.

--- a/internal/codeindex/codeindex.go
+++ b/internal/codeindex/codeindex.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 	"procoder/internal/tools"
 )
@@ -223,7 +224,7 @@ func Build(root string, stdout func(string)) error {
 		return fmt.Errorf("ctags failed: %v", err)
 	}
 	tags, count := normalizeTags(raw)
-	if err := os.WriteFile(filepath.Join(dir, tagsFile), tags, 0o644); err != nil {
+	if err := store.SaveIn(root, Dir, tagsFile, tags); err != nil {
 		return err
 	}
 	stdout(fmt.Sprintf("broad tier: %d symbols from %d files (universal-ctags)", count, len(files)))
@@ -233,7 +234,7 @@ func Build(root string, stdout func(string)) error {
 	meta := Meta{Commit: head(root), BuiltAt: time.Now().UTC().Format(time.RFC3339),
 		Files: len(files), Tags: count, Precise: precise}
 	enc, _ := json.Marshal(meta)
-	return os.WriteFile(filepath.Join(dir, metaFile), enc, 0o644)
+	return store.SaveIn(root, Dir, metaFile, enc)
 }
 
 // normalizeTags keeps only real tag lines and re-emits them in our stable
@@ -322,7 +323,7 @@ func buildPrecise(root, dir string, stdout func(string)) bool {
 	if err != nil {
 		return false
 	}
-	if err := os.WriteFile(filepath.Join(dir, refsFile), merged, 0o644); err != nil {
+	if err := store.SaveIn(root, Dir, refsFile, merged); err != nil {
 		return false
 	}
 	if len(built) < len(indexers) {

--- a/internal/codeindex/graph.go
+++ b/internal/codeindex/graph.go
@@ -3,11 +3,12 @@ package codeindex
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
+
+	"procoder/internal/store"
 )
 
 // The call graph is assembled from SCIP occurrences — the indexer's own
@@ -39,7 +40,7 @@ type scipGraphDoc struct {
 }
 
 func loadScip(root string) (*scipIndex, error) {
-	raw, err := os.ReadFile(filepath.Join(root, Dir, refsFile))
+	raw, err := store.LoadIn(root, Dir, refsFile)
 	if err != nil {
 		return nil, fmt.Errorf("the precise tier is not built — run `procoder index build` with the SCIP tools installed (`procoder init`)")
 	}

--- a/internal/codeindex/impls.go
+++ b/internal/codeindex/impls.go
@@ -3,10 +3,10 @@ package codeindex
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
+
+	"procoder/internal/store"
 )
 
 // implsDoc mirrors the SCIP fields Impls reads: the per-document symbol
@@ -33,7 +33,7 @@ type implsDoc struct {
 // nowhere else, so without SCIP the honest response is "not built", never
 // a textual guess.
 func Impls(root, symbol string, out func(string)) int {
-	raw, err := os.ReadFile(filepath.Join(root, Dir, refsFile))
+	raw, err := store.LoadIn(root, Dir, refsFile)
 	if err != nil {
 		out("the precise tier is not built — implementations need SCIP; install the SCIP tools and run `procoder index build`")
 		return 1

--- a/internal/codeindex/query.go
+++ b/internal/codeindex/query.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 	"procoder/internal/tools"
 )
@@ -21,7 +22,7 @@ import (
 // loadTags reads the broad tier. A missing index is an instruction, not an
 // empty answer — the caller prints the error verbatim.
 func loadTags(root string) ([]Tag, error) {
-	f, err := os.Open(filepath.Join(root, Dir, tagsFile))
+	f, err := store.OpenIn(root, Dir, tagsFile)
 	if err != nil {
 		return nil, fmt.Errorf("no index — run `procoder index build` first")
 	}
@@ -45,7 +46,7 @@ func loadTags(root string) ([]Tag, error) {
 
 func loadMeta(root string) Meta {
 	var m Meta
-	raw, err := os.ReadFile(filepath.Join(root, Dir, metaFile))
+	raw, err := store.LoadIn(root, Dir, metaFile)
 	if err == nil {
 		json.Unmarshal(raw, &m)
 	}
@@ -205,7 +206,7 @@ func Refs(root, symbol string, out func(string)) int {
 
 // preciseRefs answers from the SCIP JSON when it exists and knows the symbol.
 func preciseRefs(root, symbol string, out func(string)) (int, bool) {
-	raw, err := os.ReadFile(filepath.Join(root, Dir, refsFile))
+	raw, err := store.LoadIn(root, Dir, refsFile)
 	if err != nil {
 		return 0, false
 	}
@@ -442,7 +443,7 @@ func Refresh(root, file string) {
 	}
 	fresh, _ := normalizeTags(raw)
 
-	old, err := os.ReadFile(filepath.Join(root, Dir, tagsFile))
+	old, err := store.LoadIn(root, Dir, tagsFile)
 	if err != nil {
 		return
 	}
@@ -460,21 +461,12 @@ func Refresh(root, file string) {
 		return // leave the index untouched rather than write a truncated one
 	}
 	buf.Write(fresh)
-	// atomic swap: a crash mid-write must never leave a half index behind
-	tmp := filepath.Join(root, Dir, tagsFile+".tmp")
-	if os.WriteFile(tmp, []byte(buf.String()), 0o644) != nil {
-		return
-	}
-	if err := os.Rename(tmp, filepath.Join(root, Dir, tagsFile)); err != nil {
-		// The index is now stale and nobody can be told — Refresh is
-		// fire-and-forget from the write hook. What must not also happen is
-		// a .tmp accumulating beside it on every failed write; the next
-		// `index build` is the recovery, and staleNote already says so.
-		//
-		// debt: this cleanup is unprotected by tests, revisit if Refresh
-		// grows a second failure mode — a rename cannot be made to fail
-		// while the write beside it succeeds without injecting a seam, and
-		// one seam would then pay for itself twice.
-		os.Remove(tmp)
-	}
+	// The atomic swap this used to do by hand is now the store's, which
+	// also cleans up its own temp file on failure and takes the index's
+	// lock — so a Refresh firing from the write hook can no longer race an
+	// `index build` running in another session.
+	//
+	// The failure stays silent: Refresh is fire-and-forget from the write
+	// hook, the index is then stale, and staleNote is what says so.
+	_ = store.SaveIn(root, Dir, tagsFile, []byte(buf.String()))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,12 +7,11 @@ package config
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 
+	"procoder/internal/store"
 	"procoder/internal/tools"
 )
 
@@ -175,7 +174,7 @@ func Load(root string) Config {
 		"learn.record":            "false",
 		"learn.min_samples":       strconv.Itoa(defaultLearnMinSamples),
 	}
-	raw, err := os.ReadFile(filepath.Join(root, ".procoder", "config.toml"))
+	raw, err := store.LoadDoc(root, ".procoder/config.toml")
 	if err != nil {
 		cfg.Settings = defaultSettings(defaults)
 		return cfg

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,6 +126,16 @@ type Config struct {
 	// A name procoder does not ship is reported and dropped, so the default
 	// still runs — a mistyped tool name must not leave code unchecked.
 	Tools map[string]string
+	// ServiceRepo overrides the computed repository identity
+	// (`[service] repo`). Empty means compute it — see store.IdentityFor.
+	//
+	// It exists because the computed answer can be wrong: a monorepo
+	// serving several products, a mirror whose remote is not the name
+	// anybody uses, a checkout with no remote at all. A repository that
+	// knows its own name must be able to say so rather than live with a
+	// path.
+	ServiceRepo string
+
 	// Problems are settings the file names that could not be used. They
 	// block: a config that silently falls back lets a team believe a
 	// setting is in force when it never was.
@@ -261,6 +271,8 @@ func Load(root string) Config {
 			if value == "block" || value == "report" || value == "off" {
 				cfg.CommitGate = value
 			}
+		case "service.repo":
+			cfg.ServiceRepo = value
 		case "ask.policy":
 			cfg.AskBlock = value == "block"
 		case "version.check":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -447,3 +447,23 @@ func TestTheUnknownKeyFindingNamesTheRunningBuild(t *testing.T) {
 		t.Errorf("the finding does not say which build does not know the key: %q", cfg.Problems[0].Reason)
 	}
 }
+
+// proved by: dropping the service.repo case leaves ServiceRepo empty, and an
+// empty identity is one every repository shares.
+func TestServiceRepoKey(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".procoder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "[service]\nrepo = \"acme/widgets\"\n"
+	if err := os.WriteFile(filepath.Join(root, ".procoder", "config.toml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Load(root)
+	if cfg.ServiceRepo != "acme/widgets" {
+		t.Fatalf("ServiceRepo = %q, want acme/widgets", cfg.ServiceRepo)
+	}
+	if len(cfg.Problems) != 0 {
+		t.Fatalf("[service] repo was reported as a problem: %v", cfg.Problems)
+	}
+}

--- a/internal/config/report.go
+++ b/internal/config/report.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"procoder/internal/gitx"
+	"procoder/internal/store"
 )
 
 // Report is `procoder config`: every effective setting, its value, and
@@ -25,6 +26,14 @@ func Report(root string, stdout io.Writer) int {
 		}
 		fmt.Fprintf(stdout, "%-27s %-12s %s%s\n", s.Key, s.Value, s.Source, mark)
 	}
+	// Not a row in the table above, deliberately. The table is settings:
+	// each has a default and can be relaxed from it. The identity has
+	// neither — it is computed, or stated, and listing it there would
+	// invite somebody to read it as a knob that had been loosened.
+	id := store.IdentityFor(root, cfg.ServiceRepo)
+	fmt.Fprintln(stdout)
+	fmt.Fprintf(stdout, "repo identity  %s  (%s)\n", id.Key, id.Source())
+
 	if len(cfg.Problems) == 0 {
 		return 0
 	}

--- a/internal/config/report_test.go
+++ b/internal/config/report_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func reportRepo(t *testing.T, cfgBody string, remotes map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".procoder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if cfgBody != "" {
+		if err := os.WriteFile(filepath.Join(dir, ".procoder", "config.toml"), []byte(cfgBody), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	args := [][]string{{"init", "-q", "-b", "main"}}
+	for name, url := range remotes {
+		args = append(args, []string{"remote", "add", name, url})
+	}
+	for _, a := range args {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, a...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", a, err, out)
+		}
+	}
+	return dir
+}
+
+// proved by: printing the identity without its rung leaves an unexpected key
+// with nothing to explain it, which is the whole reason the rung is carried.
+func TestConfigPrintsIdentityRung(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cfg     string
+		remotes map[string]string
+		wantKey string
+		wantSrc string
+	}{
+		{"config", "[service]\nrepo = \"acme/widgets\"\n",
+			map[string]string{"origin": "https://host/o/r.git"},
+			"acme/widgets", "[service] repo in .procoder/config.toml"},
+		{"origin", "",
+			map[string]string{"origin": "https://host/o/r.git", "fork": "https://host/me/r.git"},
+			"host/o/r", "origin remote"},
+		{"remote", "",
+			map[string]string{"upstream": "https://host/o/r.git", "fork": "https://host/me/r.git"},
+			"host/me/r", "first remote alphabetically: fork"},
+		{"path", "", nil, "", "no remote — repository root path"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := reportRepo(t, tc.cfg, tc.remotes)
+			var buf bytes.Buffer
+			Report(root, &buf)
+
+			var line string
+			for _, l := range strings.Split(buf.String(), "\n") {
+				if strings.HasPrefix(l, "repo identity") {
+					line = l
+					break
+				}
+			}
+			if line == "" {
+				t.Fatalf("output has no \"repo identity\" line:\n%s", buf.String())
+			}
+			if tc.wantKey != "" && !strings.Contains(line, tc.wantKey) {
+				t.Errorf("line %q does not carry the key %q", line, tc.wantKey)
+			}
+			if !strings.Contains(line, tc.wantSrc) {
+				t.Errorf("line %q does not name the rung %q", line, tc.wantSrc)
+			}
+		})
+	}
+}
+
+// proved by: adding the identity to cfg.Settings instead would make it a
+// setting with a default that can be relaxed, which it is not.
+func TestIdentityIsNotASetting(t *testing.T) {
+	root := reportRepo(t, "", map[string]string{"origin": "https://host/o/r.git"})
+	for _, s := range Load(root).Settings {
+		if strings.Contains(s.Key, "identity") || s.Key == "service.repo" {
+			t.Fatalf("identity leaked into the settings table as %q", s.Key)
+		}
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -23,10 +23,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"procoder/internal/store"
 )
 
 // File is where waves live: procoder's own session state, beside the
@@ -57,7 +58,7 @@ type ledger struct {
 // reporting it as none would be claiming every wave was clean on the
 // strength of not having looked.
 func Load(root string) ([]Wave, error) {
-	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(File)))
+	raw, err := store.LoadDispatch(root)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -73,15 +74,11 @@ func Load(root string) ([]Wave, error) {
 
 // Save writes the ledger — session state, not repository content.
 func Save(root string, ws []Wave) error {
-	p := filepath.Join(root, filepath.FromSlash(File))
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return err
-	}
 	raw, err := json.MarshalIndent(ledger{Waves: ws}, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(p, append(raw, '\n'), 0o644)
+	return store.SaveDispatch(root, append(raw, '\n'))
 }
 
 func find(ws []Wave, id string) int {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -32,7 +32,7 @@ import (
 
 // File is where waves live: procoder's own session state, beside the
 // handoff note and the claims ledger.
-const File = ".procoder/state/dispatch.json"
+const File = store.DispatchPath
 
 // Wave is one fan-out.
 type Wave struct {

--- a/internal/docs/coverage.go
+++ b/internal/docs/coverage.go
@@ -11,6 +11,7 @@ import (
 
 	"procoder/internal/codeindex"
 	"procoder/internal/gitx"
+	"procoder/internal/store"
 )
 
 // Commands is the canonical list of procoder commands. cmd/procoder pins its
@@ -132,7 +133,7 @@ func documentedWords(root string) map[string]bool {
 const indexTagsFile = "tags.jsonl"
 
 func loadIndexTags(root string) ([]codeindex.Tag, error) {
-	f, err := os.Open(filepath.Join(root, codeindex.Dir, indexTagsFile))
+	f, err := store.OpenIn(root, codeindex.Dir, indexTagsFile)
 	if err != nil {
 		return nil, fmt.Errorf("the index has not been built")
 	}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -20,6 +20,7 @@ import (
 
 	"procoder/internal/actions"
 	"procoder/internal/gitx"
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 	"procoder/internal/tools"
 )
@@ -111,7 +112,7 @@ func defaultRules() Rules {
 // default for that section, absent sections keep their defaults.
 func LoadRules(root string) Rules {
 	r := defaultRules()
-	data, err := os.ReadFile(filepath.Join(root, RulesPath))
+	data, err := store.LoadDoc(root, RulesPath)
 	if err != nil {
 		return r
 	}

--- a/internal/envsync/envsync.go
+++ b/internal/envsync/envsync.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"procoder/internal/store"
 )
 
 // Dir is the procoder-owned state directory; StateFile is the only file this
@@ -435,8 +437,7 @@ func isEnvKey(k string) bool {
 // baseline is not an error. A corrupt file or an unknown version is an error
 // naming the file, never an empty baseline read as "nothing changed".
 func readState(root string) (*state, error) {
-	path := filepath.Join(root, filepath.FromSlash(StateFile))
-	raw, err := os.ReadFile(path)
+	raw, err := store.LoadEnvState(root)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -479,30 +480,10 @@ func writeState(root string, cur scan) error {
 		return err
 	}
 	body = append(body, '\n')
-	dir := filepath.Join(root, filepath.FromSlash(Dir))
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return reasonedPath(Dir, err)
-	}
-	tmp, err := os.CreateTemp(dir, "env-*.json.tmp")
-	if err != nil {
-		return reasonedPath(Dir, err)
-	}
-	name := tmp.Name()
-	if _, err := tmp.Write(body); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(name)
-		return reasonedPath(StateFile, err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(name)
-		return reasonedPath(StateFile, err)
-	}
-	if err := os.Chmod(name, 0o644); err != nil {
-		_ = os.Remove(name)
-		return reasonedPath(StateFile, err)
-	}
-	if err := os.Rename(name, filepath.Join(dir, "env.json")); err != nil {
-		_ = os.Remove(name)
+	// The temp-and-rename this used to do by hand now lives in the store,
+	// which also takes the file's lock — the same guarantee, plus the one
+	// this never had.
+	if err := store.SaveEnvState(root, body); err != nil {
 		return reasonedPath(StateFile, err)
 	}
 	return nil

--- a/internal/envsync/envsync.go
+++ b/internal/envsync/envsync.go
@@ -31,8 +31,8 @@ import (
 // Dir is the procoder-owned state directory; StateFile is the only file this
 // package ever writes, and only under --sync.
 const (
-	Dir       = ".procoder/state"
-	StateFile = ".procoder/state/env.json"
+	Dir       = store.StateDir
+	StateFile = store.EnvPath
 )
 
 // stateVersion is the shape version of the state file. A file carrying any

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -24,6 +24,7 @@ import (
 	"procoder/internal/planning"
 	"procoder/internal/portability"
 	"procoder/internal/security"
+	"procoder/internal/store"
 )
 
 // Paths under D-HOME.
@@ -194,7 +195,7 @@ func templateFindings(root string) []gitx.Finding {
 const githubPRTemplatePath = ".github/PULL_REQUEST_TEMPLATE.md"
 
 func mirrorSync(root string) []gitx.Finding {
-	master, err := os.ReadFile(filepath.Join(root, prTemplatePath))
+	master, err := store.LoadDoc(root, prTemplatePath)
 	if err != nil {
 		return nil // absence of the master is already its own finding
 	}

--- a/internal/gitx/remotes.go
+++ b/internal/gitx/remotes.go
@@ -1,0 +1,37 @@
+package gitx
+
+import "strings"
+
+// Remotes maps remote name to URL, as git reports them.
+//
+// One git call rather than `git remote` followed by a get-url each: this
+// runs on the identity path, which the daemon will ask for on every repo
+// it serves.
+//
+// A directory that is not a repository, or one with no remotes, returns an
+// empty map and never an error. Absence is the answer at that rung of the
+// identity ladder, not a fault — treating it as one would make a fresh
+// `git init` look broken.
+func Remotes(root string) map[string]string {
+	out, err := git(root, "config", "--get-regexp", `^remote\..*\.url$`)
+	if err != nil || out == "" {
+		return map[string]string{}
+	}
+
+	remotes := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		key, url, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok || url == "" {
+			continue
+		}
+		// remote.<name>.url, and <name> may itself contain dots — so the
+		// name is everything between the FIRST and the LAST dot, never the
+		// second field of a split.
+		name := strings.TrimSuffix(strings.TrimPrefix(key, "remote."), ".url")
+		if name == "" || name == key {
+			continue
+		}
+		remotes[name] = url
+	}
+	return remotes
+}

--- a/internal/gitx/remotes_test.go
+++ b/internal/gitx/remotes_test.go
@@ -1,0 +1,38 @@
+package gitx
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// proved by: parsing the remote name from the wrong dot in the config key —
+// remote.origin.url has three parts — returns "origin.url" and this fails.
+func TestRemotes(t *testing.T) {
+	dir := repo(t)
+	for _, args := range [][]string{
+		{"remote", "add", "origin", "git@example.com:o/r.git"},
+		{"remote", "add", "up.stream", "https://example.com/o/r2.git"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	got := Remotes(dir)
+	if got["origin"] != "git@example.com:o/r.git" {
+		t.Errorf("origin = %q, want git@example.com:o/r.git", got["origin"])
+	}
+	// A remote whose own name contains a dot is why the name is taken from
+	// between the FIRST and LAST dot, not by splitting on dots.
+	if got["up.stream"] != "https://example.com/o/r2.git" {
+		t.Errorf("up.stream = %q, want https://example.com/o/r2.git", got["up.stream"])
+	}
+}
+
+// proved by: returning an error instead of an empty map makes the identity
+// ladder treat "no remotes" as a fault rather than as the answer it is.
+func TestRemotesWithoutRepository(t *testing.T) {
+	if got := Remotes(t.TempDir()); len(got) != 0 {
+		t.Fatalf("Remotes on a non-repository returned %v", got)
+	}
+}

--- a/internal/glossary/glossary.go
+++ b/internal/glossary/glossary.go
@@ -15,9 +15,10 @@ package glossary
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
+
+	"procoder/internal/store"
 )
 
 // Path is where the glossary lives, beside the other things a repository
@@ -40,7 +41,7 @@ type Term struct {
 // there, and the one place this feature is meant to help is where it goes
 // quiet. Raised in review on #217.
 func Load(root string) ([]Term, error) {
-	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(Path)))
+	raw, err := store.LoadDoc(root, Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil // no glossary yet, which is not a problem

--- a/internal/hook/stop.go
+++ b/internal/hook/stop.go
@@ -17,7 +17,7 @@ import (
 // StateDir is procoder-owned, per-clone derived state — the same precedent as
 // the index. HandoffFile is the note a session leaves behind for the next one.
 const (
-	StateDir    = ".procoder/state"
+	StateDir    = store.StateDir
 	HandoffFile = "handoff.md"
 )
 

--- a/internal/hook/stop.go
+++ b/internal/hook/stop.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"procoder/internal/status"
 	"procoder/internal/tools"
+
+	"procoder/internal/store"
 )
 
 // StateDir is procoder-owned, per-clone derived state — the same precedent as
@@ -57,14 +58,9 @@ func Stop(stdin io.Reader, root string) int {
 		root = rootFromPayload(raw)
 	}
 
-	dir := filepath.Join(root, filepath.FromSlash(StateDir))
-	if os.MkdirAll(dir, 0o755) != nil {
-		return 0 // no state directory, no note — and no noise about it
-	}
-	path := filepath.Join(dir, HandoffFile)
-	old, _ := os.ReadFile(path) // absent is the first handoff, not an error
+	old, _ := store.LoadHandoff(root) // absent is the first handoff, not an error
 	// a note that could not be written is a lost note, never a broken session
-	_ = os.WriteFile(path, []byte(handoff(root, string(old))), 0o644)
+	_ = store.SaveHandoff(root, []byte(handoff(root, string(old))))
 
 	// The note is written first, on every path including this one: a
 	// blocked turn must not also lose its handoff.

--- a/internal/hook/unasked.go
+++ b/internal/hook/unasked.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"procoder/internal/ask"
+
+	"procoder/internal/store"
 )
 
 // blockedFile remembers the message this hook last refused to end the turn
@@ -159,11 +161,8 @@ func decisionsChanged(root string) bool {
 	sum := sha256.Sum256(raw)
 	now := hex.EncodeToString(sum[:])[:16]
 
-	digestPath := filepath.Join(root, filepath.FromSlash(StateDir), decisionsFile)
-	before, readErr := os.ReadFile(digestPath)
-	if os.MkdirAll(filepath.Dir(digestPath), 0o755) == nil {
-		_ = os.WriteFile(digestPath, []byte(now), 0o644)
-	}
+	before, readErr := store.LoadMarker(root, decisionsFile)
+	_ = store.SaveMarker(root, decisionsFile, []byte(now))
 	if readErr != nil {
 		// First stop in this tree: nothing to compare against, so the
 		// question "was this recorded just now" has no answer yet.
@@ -172,17 +171,13 @@ func decisionsChanged(root string) bool {
 	return strings.TrimSpace(string(before)) != now
 }
 
-func blockedPath(root string) string {
-	return filepath.Join(root, filepath.FromSlash(StateDir), blockedFile)
-}
-
 func fingerprint(message string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(message)))
 	return hex.EncodeToString(sum[:])[:16]
 }
 
 func alreadyBlocked(root, message string) bool {
-	raw, err := os.ReadFile(blockedPath(root))
+	raw, err := store.LoadMarker(root, blockedFile)
 	if err != nil {
 		return false
 	}
@@ -192,9 +187,5 @@ func alreadyBlocked(root, message string) bool {
 // rememberBlocked records the fingerprint and reports whether it stuck.
 // The caller blocks only when it did — see unaskedDecision.
 func rememberBlocked(root, message string) bool {
-	dir := filepath.Dir(blockedPath(root))
-	if os.MkdirAll(dir, 0o755) != nil {
-		return false
-	}
-	return os.WriteFile(blockedPath(root), []byte(fingerprint(message)), 0o644) == nil
+	return store.SaveMarker(root, blockedFile, []byte(fingerprint(message))) == nil
 }

--- a/internal/hook/unasked.go
+++ b/internal/hook/unasked.go
@@ -3,8 +3,6 @@ package hook
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -153,8 +151,7 @@ const decisionsFile = "last-decisions-digest"
 // direction there is to let the turn end. A hook that blocks on its own
 // broken bookkeeping is one people disable.
 func decisionsChanged(root string) bool {
-	path := filepath.Join(root, filepath.FromSlash(ask.Dir), ask.DecisionsFile)
-	raw, err := os.ReadFile(path)
+	raw, err := store.LoadIn(root, ask.Dir, ask.DecisionsFile)
 	if err != nil {
 		return true // no file, or unreadable: not evidence of a backlog
 	}

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -24,7 +24,7 @@ import (
 
 // Dir is where the records live, under the gitignored state directory:
 // timing data is not repository content and is never committed.
-const Dir = ".procoder/state"
+const Dir = store.StateDir
 
 // File is the append-only record, one JSON object per line.
 const File = "learn.jsonl"

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -16,10 +16,10 @@ package learn
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
+
+	"procoder/internal/store"
 )
 
 // Dir is where the records live, under the gitignored state directory:
@@ -65,20 +65,13 @@ func Append(root string, r Record, on bool) {
 	if !on {
 		return
 	}
-	dir := filepath.Join(root, filepath.FromSlash(Dir))
-	if os.MkdirAll(dir, 0o755) != nil {
-		return
-	}
 	line, err := json.Marshal(r)
 	if err != nil {
 		return
 	}
-	f, err := os.OpenFile(filepath.Join(dir, File), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return
-	}
-	defer f.Close() //nolint:errcheck // see the doc comment: silence is the contract
-	_, _ = f.Write(append(line, '\n'))
+	// Silence is the contract, per the doc comment above: a measurement
+	// able to fail the run it measures is a governance cost of its own.
+	_ = store.AppendLearn(root, append(line, '\n'))
 }
 
 // Reading is what a report knows about the records: the ones it could
@@ -93,7 +86,7 @@ type Reading struct {
 // dropped in silence: a report that quietly discarded half its input would
 // be a measurement nobody could check.
 func Read(root string) (Reading, error) {
-	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(Dir), File))
+	raw, err := store.LoadLearn(root)
 	if err != nil {
 		return Reading{}, err
 	}

--- a/internal/learn/learn.go
+++ b/internal/learn/learn.go
@@ -36,15 +36,6 @@ const File = "learn.jsonl"
 // corresponds to, nor whether an edit was a proposal at all.
 const AppliedFile = "learn-applied.json"
 
-// maxRecords bounds the file so an old repository does not carry an
-// unbounded one. Oldest dropped.
-//
-// debt: a flat line count, not a size or an age. It is the cheapest thing
-// that bounds the file, and a repository whose commands vary wildly in
-// number per day gets an uneven window. Revisit when somebody reports a
-// window that is too short to be useful.
-const maxRecords = 5000
-
 // Record is one command run.
 type Record struct {
 	Cmd      string `json:"cmd"`

--- a/internal/learn/report.go
+++ b/internal/learn/report.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"procoder/internal/evidence"
+
+	"procoder/internal/store"
 )
 
 // class labels a number with where it came from, reusing the evidence
@@ -149,8 +151,7 @@ type Applied struct {
 // Verify reports whether an applied proposal actually reduced what it
 // targeted, and prints the revert when it did not (S-5).
 func Verify(root string, out func(string)) int {
-	path := filepath.Join(root, filepath.FromSlash(Dir), AppliedFile)
-	raw, err := os.ReadFile(path)
+	raw, err := store.LoadMarker(root, AppliedFile)
 	if err != nil {
 		// No anchor is not "it worked". Without a marker there is nothing
 		// to measure against, and guessing from the git history of

--- a/internal/lessons/copilot.go
+++ b/internal/lessons/copilot.go
@@ -15,11 +15,11 @@ package lessons
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"procoder/internal/gitx"
+	"procoder/internal/store"
 )
 
 // CopilotLeaksPath is the scratch ledger of Copilot auto-review findings,
@@ -39,7 +39,7 @@ a failure, never the source that failed. An entry becomes a real lesson in
 // RunCopilotLeaks prints the leak ledger's state and flags entries nobody has
 // turned into an adaptation yet.
 func RunCopilotLeaks(root string, out func(string)) int {
-	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(CopilotLeaksPath)))
+	raw, err := store.LoadDoc(root, CopilotLeaksPath)
 	if os.IsNotExist(err) {
 		// nothing has been captured, which is the ordinary state — the ledger
 		// is written by `procoder copilot-leak`, not by a template, so there
@@ -77,21 +77,13 @@ func RunCopilotLeaks(root string, out func(string)) int {
 // human replaces it. title, url and finding must already be sanitised; this
 // package never sees the raw Copilot body.
 func RecordCopilotEntry(root, title, url, finding string, at time.Time) error {
-	path := filepath.Join(root, filepath.FromSlash(CopilotLeaksPath))
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }() // the checked close is below; this one only covers the error paths
-	st, err := f.Stat()
-	if err != nil {
+	existing, err := store.LoadDoc(root, CopilotLeaksPath)
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	var b strings.Builder
-	if st.Size() == 0 {
+	b.Write(existing)
+	if len(existing) == 0 {
 		b.WriteString(copilotHeader)
 	}
 	b.WriteString("\n## " + at.UTC().Format("2006-01-02 15:04") + " " + oneLine(url) +
@@ -100,10 +92,7 @@ func RecordCopilotEntry(root, title, url, finding string, at time.Time) error {
 	b.WriteString("- Original: " + oneLine(url) + "\n")
 	b.WriteString("- Finding: " + oneLine(finding) + "\n")
 	b.WriteString("- Adaptation: <the concrete change that catches this class from now on>\n")
-	if _, err := f.WriteString(b.String()); err != nil {
-		return err
-	}
-	return f.Close()
+	return store.SaveDoc(root, CopilotLeaksPath, []byte(b.String()))
 }
 
 // oneLine flattens a value onto a single ledger line. A finding body carries
@@ -128,13 +117,12 @@ func oneLine(s string) string {
 // The reminder never blocks: an unwritten adaptation is work to do, not a
 // broken tree.
 func LeakReminder(root string) []gitx.Finding {
-	path := filepath.Join(root, filepath.FromSlash(CopilotLeaksPath))
-	raw, err := os.ReadFile(path)
+	raw, err := store.LoadDoc(root, CopilotLeaksPath)
 	if os.IsNotExist(err) {
 		return nil // no ledger is the ordinary case, not a finding
 	}
 	if err != nil {
-		return []gitx.Finding{{File: path,
+		return []gitx.Finding{{File: CopilotLeaksPath,
 			Message: CopilotLeaksPath + " NOT checked (" + err.Error() + ") — captured Copilot findings cannot be counted"}}
 	}
 	unlearned := 0
@@ -146,7 +134,7 @@ func LeakReminder(root string) []gitx.Finding {
 	if unlearned == 0 {
 		return nil
 	}
-	return []gitx.Finding{{File: path,
+	return []gitx.Finding{{File: CopilotLeaksPath,
 		Message: fmt.Sprintf("%d captured Copilot finding(s) in %s carry no adaptation — the class stays open until one is written",
 			unlearned, CopilotLeaksPath)}}
 }

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -9,8 +9,9 @@ package lessons
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
+
+	"procoder/internal/store"
 )
 
 // Path is the ledger, under D-HOME with the other github rules files.
@@ -113,7 +114,7 @@ func Parse(text string) []Entry {
 
 // Run prints the ledger state and flags unlearned lessons.
 func Run(root string, out func(string)) int {
-	raw, err := os.ReadFile(filepath.Join(root, Path))
+	raw, err := store.LoadDoc(root, Path)
 	if os.IsNotExist(err) {
 		out("no lessons ledger — `procoder templates` prints the shape for " + Path)
 		return 0

--- a/internal/lint/rules.go
+++ b/internal/lint/rules.go
@@ -1,9 +1,9 @@
 package lint
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
+
+	"procoder/internal/store"
 )
 
 // RulesPath is the lint domain's repo-overridable rules file, following
@@ -25,7 +25,7 @@ type Rules struct {
 // LoadRules reads the repository's lint rules.
 func LoadRules(root string) Rules {
 	var r Rules
-	data, err := os.ReadFile(filepath.Join(root, RulesPath))
+	data, err := store.LoadDoc(root, RulesPath)
 	if err != nil {
 		return r
 	}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -131,7 +131,7 @@ func Check(root, name string, out func(string)) int {
 }
 
 func checkOne(root, path string, out func(string)) int {
-	raw, err := readUnder(root, path)
+	raw, err := store.LoadUnder(root, path)
 	if err != nil {
 		out(filepath.Base(path) + ": unreadable — " + err.Error())
 		return 2
@@ -210,14 +210,3 @@ func planFiles(root string) []string {
 // surgical-scope check, which reads the `**Files:**` lines a plan already
 // has to carry.
 func Files(root string) []string { return planFiles(root) }
-
-// readUnder reads a .procoder/ file the caller was handed as an absolute
-// path. Files returns absolute paths, so its readers would otherwise have
-// to go around the store to open what they were given.
-func readUnder(root, abs string) ([]byte, error) {
-	rel, err := store.Rel(root, abs)
-	if err != nil {
-		return nil, err
-	}
-	return store.LoadDoc(root, rel)
-}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -122,15 +123,15 @@ func Check(root, name string, out func(string)) int {
 	}
 	worst := 0
 	for _, f := range files {
-		if code := checkOne(f, out); code > worst {
+		if code := checkOne(root, f, out); code > worst {
 			worst = code
 		}
 	}
 	return worst
 }
 
-func checkOne(path string, out func(string)) int {
-	raw, err := os.ReadFile(path)
+func checkOne(root, path string, out func(string)) int {
+	raw, err := readUnder(root, path)
 	if err != nil {
 		out(filepath.Base(path) + ": unreadable — " + err.Error())
 		return 2
@@ -191,14 +192,14 @@ func checkOne(path string, out func(string)) int {
 }
 
 func planFiles(root string) []string {
-	entries, err := os.ReadDir(filepath.Join(root, Dir))
+	entries, err := store.ListDir(root, Dir)
 	if err != nil {
 		return nil
 	}
 	var out []string
 	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
-			out = append(out, filepath.Join(root, Dir, e.Name()))
+		if strings.HasSuffix(e, ".md") {
+			out = append(out, filepath.Join(root, Dir, e))
 		}
 	}
 	sort.Strings(out)
@@ -209,3 +210,14 @@ func planFiles(root string) []string {
 // surgical-scope check, which reads the `**Files:**` lines a plan already
 // has to carry.
 func Files(root string) []string { return planFiles(root) }
+
+// readUnder reads a .procoder/ file the caller was handed as an absolute
+// path. Files returns absolute paths, so its readers would otherwise have
+// to go around the store to open what they were given.
+func readUnder(root, abs string) ([]byte, error) {
+	rel, err := store.Rel(root, abs)
+	if err != nil {
+		return nil, err
+	}
+	return store.LoadDoc(root, rel)
+}

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"procoder/internal/host"
 	"procoder/internal/releases"
 	"procoder/internal/status"
+	"procoder/internal/store"
 )
 
 // File is the repo override path, under D-HOME.
@@ -219,7 +219,7 @@ the ND formatting for that response and answer in plain prose.
 // Effective returns the principles text for this repo: the override file
 // if present, else the default; the bool says whether it was overridden.
 func Effective(root string) (string, bool) {
-	if raw, err := os.ReadFile(filepath.Join(root, File)); err == nil && strings.TrimSpace(string(raw)) != "" {
+	if raw, err := store.LoadDoc(root, File); err == nil && strings.TrimSpace(string(raw)) != "" {
 		return string(raw), true
 	}
 	return Default, false

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"procoder/internal/gitx"
+	"procoder/internal/store"
 )
 
 // Dir is where a repository puts its own lenses.
@@ -65,7 +66,7 @@ func resolveSet(root string, shippedSet []Lens, dir string) ([]Lens, []gitx.Find
 	for _, shipped := range shippedSet {
 		path := filepath.Join(root, dir, shipped.Name+".md")
 		rel := filepath.ToSlash(filepath.Join(dir, shipped.Name+".md"))
-		data, err := os.ReadFile(path)
+		data, err := store.LoadIn(root, dir, shipped.Name+".md")
 		switch {
 		case os.IsNotExist(err):
 			shipped.Source = "default"

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -174,8 +175,8 @@ func Check(root, name string, out func(string)) int {
 // lines read as the one question it is. It lives here because this package
 // decides what a spec is; `ask` offers these to a human and `checkOne` judges
 // them, and one reading keeps the two from disagreeing.
-func OpenQuestions(path string) []string {
-	raw, err := os.ReadFile(path)
+func OpenQuestions(root, path string) []string {
+	raw, err := readUnder(root, path)
 	if err != nil {
 		return nil
 	}
@@ -234,7 +235,7 @@ func continuesPrevious(line string) bool {
 // package calls too, so the collector that offers a question and the checker
 // that judges it can never disagree about what is still being asked.
 func openQuestions(root, path string) (unanswered []string, answered int) {
-	questions := OpenQuestions(path)
+	questions := OpenQuestions(root, path)
 	if len(questions) == 0 {
 		return nil, 0
 	}
@@ -266,7 +267,7 @@ func statusOf(text string) string {
 }
 
 func checkOne(root, path string, out func(string)) int {
-	raw, err := os.ReadFile(path)
+	raw, err := readUnder(root, path)
 	if err != nil {
 		out(filepath.Base(path) + ": unreadable — " + err.Error())
 		return 2
@@ -415,14 +416,14 @@ func checkOne(root, path string, out func(string)) int {
 func Files(root string) []string { return specFiles(root) }
 
 func specFiles(root string) []string {
-	entries, err := os.ReadDir(filepath.Join(root, Dir))
+	entries, err := store.ListDir(root, Dir)
 	if err != nil {
 		return nil
 	}
 	var out []string
 	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
-			out = append(out, filepath.Join(root, Dir, e.Name()))
+		if strings.HasSuffix(e, ".md") {
+			out = append(out, filepath.Join(root, Dir, e))
 		}
 	}
 	sort.Strings(out)
@@ -434,4 +435,15 @@ func trim(s string) string {
 		return s[:57] + "..."
 	}
 	return s
+}
+
+// readUnder reads a .procoder/ file the caller was handed as an absolute
+// path. Files returns absolute paths, so its readers would otherwise have
+// to go around the store to open what they were given.
+func readUnder(root, abs string) ([]byte, error) {
+	rel, err := store.Rel(root, abs)
+	if err != nil {
+		return nil, err
+	}
+	return store.LoadDoc(root, rel)
 }

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -176,7 +176,7 @@ func Check(root, name string, out func(string)) int {
 // decides what a spec is; `ask` offers these to a human and `checkOne` judges
 // them, and one reading keeps the two from disagreeing.
 func OpenQuestions(root, path string) []string {
-	raw, err := readUnder(root, path)
+	raw, err := store.LoadUnder(root, path)
 	if err != nil {
 		return nil
 	}
@@ -267,7 +267,7 @@ func statusOf(text string) string {
 }
 
 func checkOne(root, path string, out func(string)) int {
-	raw, err := readUnder(root, path)
+	raw, err := store.LoadUnder(root, path)
 	if err != nil {
 		out(filepath.Base(path) + ": unreadable — " + err.Error())
 		return 2
@@ -435,15 +435,4 @@ func trim(s string) string {
 		return s[:57] + "..."
 	}
 	return s
-}
-
-// readUnder reads a .procoder/ file the caller was handed as an absolute
-// path. Files returns absolute paths, so its readers would otherwise have
-// to go around the store to open what they were given.
-func readUnder(root, abs string) ([]byte, error) {
-	rel, err := store.Rel(root, abs)
-	if err != nil {
-		return nil, err
-	}
-	return store.LoadDoc(root, rel)
 }

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -316,13 +316,16 @@ func TestARenumberedQuestionKeepsItsAnswer(t *testing.T) {
 	}
 }
 
-// writeQuestions puts one Open questions section on disk and returns its path.
-func writeQuestions(t *testing.T, body string) string {
+// writeQuestions puts one Open questions section on disk and returns the
+// root it lives under and its path — OpenQuestions reads through the store,
+// which refuses a path outside the root it was given.
+func writeQuestions(t *testing.T, body string) (string, string) {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "widget.md")
+	root := t.TempDir()
+	path := filepath.Join(root, "widget.md")
 	spec := strings.Replace(completeSpec(), "## Open questions\n\n", "## Open questions\n\n"+body+"\n\n", 1)
 	if err := os.WriteFile(path, []byte(spec), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	return path
+	return root, path
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -22,6 +22,7 @@ import (
 	"procoder/internal/config"
 	"procoder/internal/lessons"
 	"procoder/internal/planning"
+	"procoder/internal/store"
 	"procoder/internal/testrun"
 	"procoder/internal/todo"
 )
@@ -410,7 +411,7 @@ func lessonLine(root string) string {
 // HEAD. Freshness with no HEAD to compare against is unknown, and says so —
 // a stale index that reads as current is exactly the lie this domain bans.
 func indexLine(root, head string, timedOut bool) string {
-	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(codeindex.Dir), "meta.json"))
+	raw, err := store.LoadIn(root, codeindex.Dir, "meta.json")
 	if os.IsNotExist(err) {
 		return "index: none — `procoder index build` has not run here"
 	}

--- a/internal/store/atomic.go
+++ b/internal/store/atomic.go
@@ -1,11 +1,11 @@
 package store
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -14,15 +14,20 @@ import (
 // and so a person reading `git status` after a crash can tell what it is.
 const tempPrefix = ".procoder-tmp-"
 
-// tempMaxAge is how long a temp file may sit before the sweep removes it. It
-// is not the lock's staleAfter by accident: both answer the same question,
-// which is how long a live write could plausibly still be going.
-const tempMaxAge = 30 * time.Second
+// tempLitterAge is how long a temp file may sit before the sweep removes
+// it. An hour rather than the lock's thirty seconds, and deliberately much
+// longer than any write could take: the sweep runs in one process against
+// files another process may still be writing, and the only way to be sure
+// a temp file is litter rather than work in progress is for it to be far
+// older than any live write could be. Litter costs nothing to leave a
+// little longer; deleting somebody's in-flight write costs them the write.
+const tempLitterAge = time.Hour
 
-// forceRenameFailure makes the rename fail. It exists for one test and
-// nothing else: there is no portable way to make os.Rename fail on demand,
-// and the atomicity claim is not worth making if nothing can check it.
-var forceRenameFailure bool
+// swept remembers which directories this process has already tidied. The
+// sweep is a full ReadDir, and running one after every save into
+// .procoder/todo or .procoder/specs would put the size of the directory on
+// the cost of writing one file in it.
+var swept sync.Map
 
 // ReadFile reads the file at the repo-relative path. An absent file returns
 // an error satisfying os.IsNotExist, exactly as os.ReadFile does, because
@@ -79,35 +84,50 @@ func WriteFile(root, relPath string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("procoder: could not close %s (%v) — the write was NOT made", relPath, err)
 	}
 
-	if err := rename(tmp, target); err != nil {
+	if err := os.Rename(tmp, target); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("procoder: could not replace %s (%v) — the write was NOT made", relPath, err)
 	}
+	syncDir(dir)
 
 	sweep(dir)
 	return nil
 }
 
-// rename is os.Rename with the test seam in front of it.
-func rename(from, to string) error {
-	if forceRenameFailure {
-		return errors.New("rename failure forced by a test")
+// syncDir flushes the directory entry the rename created.
+//
+// Syncing the file's data is not enough on its own: the rename is a
+// directory operation, and a power failure between the two can leave the
+// target back under its old name or missing altogether — which is the
+// "rename that outlives its own data" this whole function exists to
+// prevent. Best effort, because a filesystem that will not sync a
+// directory handle is not a reason to fail a write that has already
+// landed.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
 	}
-	return os.Rename(from, to)
+	_ = d.Sync()
+	_ = d.Close()
 }
 
 // sweep removes temp files old enough that no live write could still own
-// them — the litter left by a process that died between staging and rename.
+// them — the litter left by a process that died between staging and
+// rename. Once per directory per process: see swept.
 //
 // Best effort by design: it runs after a write that has already succeeded,
 // and failing the caller because some unrelated stale file could not be
 // removed would turn tidying into an outage.
 func sweep(dir string) {
+	if _, done := swept.LoadOrStore(dir, true); done {
+		return
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}
-	cutoff := time.Now().Add(-tempMaxAge)
+	cutoff := time.Now().Add(-tempLitterAge)
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasPrefix(e.Name(), tempPrefix) {
 			continue

--- a/internal/store/atomic.go
+++ b/internal/store/atomic.go
@@ -1,0 +1,121 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// tempPrefix marks the half-written files. It is fixed rather than random so
+// a sweep can recognise one left behind by a process that died mid-write —
+// and so a person reading `git status` after a crash can tell what it is.
+const tempPrefix = ".procoder-tmp-"
+
+// tempMaxAge is how long a temp file may sit before the sweep removes it. It
+// is not the lock's staleAfter by accident: both answer the same question,
+// which is how long a live write could plausibly still be going.
+const tempMaxAge = 30 * time.Second
+
+// forceRenameFailure makes the rename fail. It exists for one test and
+// nothing else: there is no portable way to make os.Rename fail on demand,
+// and the atomicity claim is not worth making if nothing can check it.
+var forceRenameFailure bool
+
+// ReadFile reads the file at the repo-relative path. An absent file returns
+// an error satisfying os.IsNotExist, exactly as os.ReadFile does, because
+// every caller already treats that as "none" rather than as a fault.
+func ReadFile(root, relPath string) ([]byte, error) {
+	return os.ReadFile(filepath.Join(root, filepath.FromSlash(relPath)))
+}
+
+// WriteFile replaces the file at the repo-relative path with data, or leaves
+// it exactly as it was.
+//
+// Every write in procoder was an os.WriteFile until now, which truncates
+// first: a process killed mid-write leaves a truncated claims.json, and the
+// next reader reports a corrupt ledger for a crash that had nothing to do
+// with it. Here the bytes land in a temp file, are flushed to disk, and are
+// renamed over the target — so a reader sees the whole old file or the whole
+// new one, and a failure leaves the old one untouched.
+//
+// The temp file goes in the DESTINATION directory, not os.TempDir: rename is
+// only atomic within a filesystem, and /tmp is frequently a different one.
+func WriteFile(root, relPath string, data []byte, perm os.FileMode) error {
+	target := filepath.Join(root, filepath.FromSlash(relPath))
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("procoder: could not create %s for %s (%v) — the write was NOT made", dir, relPath, err)
+	}
+
+	f, err := os.CreateTemp(dir, tempPrefix+"*")
+	if err != nil {
+		return fmt.Errorf("procoder: could not stage a write to %s (%v) — the write was NOT made", relPath, err)
+	}
+	tmp := f.Name()
+	// From here every failure removes the temp file. The target is not open
+	// and cannot have been damaged, which is the property being bought.
+	fail := func(err error) error {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+
+	if _, err := f.Write(data); err != nil {
+		return fail(fmt.Errorf("procoder: could not write %s (%v) — the write was NOT made", relPath, err))
+	}
+	// Sync before the rename: a rename that outlives its own data is how a
+	// crash turns an atomic write into an empty file.
+	if err := f.Sync(); err != nil {
+		return fail(fmt.Errorf("procoder: could not flush %s (%v) — the write was NOT made", relPath, err))
+	}
+	if err := f.Chmod(perm); err != nil {
+		return fail(fmt.Errorf("procoder: could not set the mode on %s (%v) — the write was NOT made", relPath, err))
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("procoder: could not close %s (%v) — the write was NOT made", relPath, err)
+	}
+
+	if err := rename(tmp, target); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("procoder: could not replace %s (%v) — the write was NOT made", relPath, err)
+	}
+
+	sweep(dir)
+	return nil
+}
+
+// rename is os.Rename with the test seam in front of it.
+func rename(from, to string) error {
+	if forceRenameFailure {
+		return errors.New("rename failure forced by a test")
+	}
+	return os.Rename(from, to)
+}
+
+// sweep removes temp files old enough that no live write could still own
+// them — the litter left by a process that died between staging and rename.
+//
+// Best effort by design: it runs after a write that has already succeeded,
+// and failing the caller because some unrelated stale file could not be
+// removed would turn tidying into an outage.
+func sweep(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-tempMaxAge)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), tempPrefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, e.Name()))
+	}
+}

--- a/internal/store/atomic_test.go
+++ b/internal/store/atomic_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -145,6 +146,9 @@ func TestSweepRunsOncePerDirectory(t *testing.T) {
 // would let this succeed, which is the silent-green this package exists to
 // remove.
 func TestReadOnlyStateRefusesWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod on Windows toggles a file's read-only attribute and does not restrict a DIRECTORY, so there is no read-only directory to test against here")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("root ignores the directory mode, so there is nothing to test")
 	}

--- a/internal/store/atomic_test.go
+++ b/internal/store/atomic_test.go
@@ -1,0 +1,128 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// proved by: replacing the temp-and-rename with a direct os.WriteFile leaves
+// the target truncated instead of untouched, and this fails.
+func TestAtomicWriteLeavesOriginalOnRenameFailure(t *testing.T) {
+	root := t.TempDir()
+	rel := ".procoder/state/claims.json"
+	if err := WriteFile(root, rel, []byte("original"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	forceRenameFailure = true
+	t.Cleanup(func() { forceRenameFailure = false })
+
+	if err := WriteFile(root, rel, []byte("replacement"), 0o644); err == nil {
+		t.Fatal("WriteFile reported success though the rename failed")
+	}
+	got, err := ReadFile(root, rel)
+	if err != nil {
+		t.Fatalf("target unreadable after a failed write: %v", err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("target was modified: %q", got)
+	}
+}
+
+// proved by: a direct os.WriteFile truncates first, so a reader catches a
+// zero-length or half-written file and this fails.
+func TestReaderNeverSeesPartialFile(t *testing.T) {
+	root := t.TempDir()
+	rel := ".procoder/state/claims.json"
+	oldData, newData := strings.Repeat("a", 1<<16), strings.Repeat("b", 1<<16)
+	if err := WriteFile(root, rel, []byte(oldData), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = WriteFile(root, rel, []byte(newData), 0o644)
+				_ = WriteFile(root, rel, []byte(oldData), 0o644)
+			}
+		}
+	}()
+	defer func() { close(stop); <-done }()
+
+	for i := 0; i < 2000; i++ {
+		got, err := ReadFile(root, rel)
+		if err != nil {
+			continue // the file is momentarily absent between rename attempts
+		}
+		if s := string(got); s != oldData && s != newData {
+			t.Fatalf("partial read of %d bytes", len(s))
+		}
+	}
+}
+
+// proved by: dropping the sweep leaves the stale temp file in place and this
+// fails. Without it a crashed write litters .procoder/ forever.
+func TestTempFilesAreSwept(t *testing.T) {
+	root := t.TempDir()
+	rel := ".procoder/state/claims.json"
+	if err := WriteFile(root, rel, []byte("seed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := filepath.Join(root, ".procoder", "state", tempPrefix+"stale")
+	if err := os.WriteFile(stale, []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-31 * time.Second)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteFile(root, rel, []byte("second"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); err == nil {
+		t.Fatal("stale temp file survived a successful write")
+	}
+}
+
+// proved by: falling back to a direct write when the temp file cannot be made
+// would let this succeed, which is the silent-green this package exists to
+// remove.
+func TestReadOnlyStateRefusesWrite(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the directory mode, so there is nothing to test")
+	}
+	root := t.TempDir()
+	rel := ".procoder/state/claims.json"
+	if err := WriteFile(root, rel, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(root, ".procoder", "state")
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := WriteFile(root, rel, []byte("replacement"), 0o644)
+	if err == nil {
+		t.Fatal("write succeeded into a read-only directory")
+	}
+	if !strings.Contains(err.Error(), rel) {
+		t.Fatalf("error does not name the path: %v", err)
+	}
+	got, _ := ReadFile(root, rel)
+	if string(got) != "original" {
+		t.Fatalf("file changed under a read-only directory: %q", got)
+	}
+}

--- a/internal/store/atomic_test.go
+++ b/internal/store/atomic_test.go
@@ -8,27 +8,44 @@ import (
 	"time"
 )
 
-// proved by: replacing the temp-and-rename with a direct os.WriteFile leaves
-// the target truncated instead of untouched, and this fails.
+// proved by: replacing the temp-and-rename with a direct os.WriteFile makes
+// the write destroy what was at the target instead of leaving it, and this
+// fails.
+//
+// The rename is made to fail by pointing it at a NON-EMPTY DIRECTORY, which
+// no platform will let a file be renamed over. That is why this test needs
+// no seam in the production code: an atomicity claim nothing can check is
+// not worth making, but a claim that needs a flag in the shipping binary to
+// check is worse.
 func TestAtomicWriteLeavesOriginalOnRenameFailure(t *testing.T) {
 	root := t.TempDir()
-	rel := ".procoder/state/claims.json"
-	if err := WriteFile(root, rel, []byte("original"), 0o644); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+	const rel = ".procoder/state/claims.json"
 
-	forceRenameFailure = true
-	t.Cleanup(func() { forceRenameFailure = false })
+	target := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(target, "keep.txt")
+	if err := os.WriteFile(child, []byte("untouched"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := WriteFile(root, rel, []byte("replacement"), 0o644); err == nil {
-		t.Fatal("WriteFile reported success though the rename failed")
+		t.Fatal("WriteFile reported success though the rename could not have worked")
 	}
-	got, err := ReadFile(root, rel)
+	got, err := os.ReadFile(child)
+	if err != nil || string(got) != "untouched" {
+		t.Fatalf("a failed write damaged the target: %q %v", got, err)
+	}
+	// and it left no litter behind
+	entries, err := os.ReadDir(filepath.Dir(target))
 	if err != nil {
-		t.Fatalf("target unreadable after a failed write: %v", err)
+		t.Fatal(err)
 	}
-	if string(got) != "original" {
-		t.Fatalf("target was modified: %q", got)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), tempPrefix) {
+			t.Fatalf("a failed write left %s behind", e.Name())
+		}
 	}
 }
 
@@ -73,25 +90,54 @@ func TestReaderNeverSeesPartialFile(t *testing.T) {
 // fails. Without it a crashed write litters .procoder/ forever.
 func TestTempFilesAreSwept(t *testing.T) {
 	root := t.TempDir()
-	rel := ".procoder/state/claims.json"
+	const rel = ".procoder/state/claims.json"
+
+	// The litter is planted BEFORE the first write into this directory,
+	// because the sweep runs once per directory per process — a second
+	// write does not pay for a second ReadDir.
+	dir := filepath.Join(root, ".procoder", "state")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	litter := filepath.Join(dir, tempPrefix+"stale")
+	if err := os.WriteFile(litter, []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(litter, old, old); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := WriteFile(root, rel, []byte("seed"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
-	stale := filepath.Join(root, ".procoder", "state", tempPrefix+"stale")
-	if err := os.WriteFile(stale, []byte("junk"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	old := time.Now().Add(-31 * time.Second)
-	if err := os.Chtimes(stale, old, old); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := WriteFile(root, rel, []byte("second"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(stale); err == nil {
+	if _, err := os.Stat(litter); err == nil {
 		t.Fatal("stale temp file survived a successful write")
+	}
+}
+
+// proved by: sweeping on every write puts the size of the directory on the
+// cost of writing one file in it.
+func TestSweepRunsOncePerDirectory(t *testing.T) {
+	root := t.TempDir()
+	const rel = ".procoder/specs/a.md"
+	if err := WriteFile(root, rel, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, ".procoder", "specs")
+	litter := filepath.Join(dir, tempPrefix+"later")
+	if err := os.WriteFile(litter, []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(litter, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(root, ".procoder/specs/b.md", []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(litter); err != nil {
+		t.Fatal("the second write into the same directory swept again")
 	}
 }
 

--- a/internal/store/content.go
+++ b/internal/store/content.go
@@ -55,14 +55,14 @@ func SaveIn(root, relDir, name string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	return saveContent(root, p, data)
+	return save(root, p, data)
 }
 
 // LoadDoc reads a single-file owner.
 func LoadDoc(root, relPath string) ([]byte, error) { return ReadFile(root, relPath) }
 
 // SaveDoc replaces a single-file owner.
-func SaveDoc(root, relPath string, data []byte) error { return saveContent(root, relPath, data) }
+func SaveDoc(root, relPath string, data []byte) error { return save(root, relPath, data) }
 
 // inDir refuses a name that is a path, for the reason markerPath does:
 // joining an unchecked name lets ".." walk out of the directory the caller
@@ -72,18 +72,6 @@ func inDir(relDir, name string) (string, error) {
 		return "", errors.New("procoder: a file in " + relDir + " is named by a file name, not a path: " + name)
 	}
 	return strings.TrimRight(relDir, "/") + "/" + name, nil
-}
-
-// saveContent is one file's write: take its lock, replace it atomically,
-// release. Per file, not per directory — two people editing two different
-// stories have no reason to wait for each other.
-func saveContent(root, relPath string, data []byte) error {
-	release, err := Lock(root, relPath)
-	if err != nil {
-		return err
-	}
-	defer release()
-	return WriteFile(root, relPath, data, 0o644)
 }
 
 // Rel turns an absolute path inside root into the repo-relative slash form
@@ -135,7 +123,15 @@ func resolve(p string) (string, error) {
 		return r, nil
 	}
 	dir, base := filepath.Split(abs)
-	parent, err := resolve(filepath.Clean(dir))
+	// The fixed point, or this recurses forever: Clean("/") is "/", so a
+	// filesystem root that EvalSymlinks cannot resolve — a Windows drive
+	// that is not ready — would call this with the same argument until the
+	// stack ran out.
+	clean := filepath.Clean(dir)
+	if clean == abs || base == "" {
+		return abs, nil
+	}
+	parent, err := resolve(clean)
 	if err != nil {
 		return abs, nil
 	}

--- a/internal/store/content.go
+++ b/internal/store/content.go
@@ -1,0 +1,131 @@
+package store
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// The content owners are the other half of .procoder/: the files a
+// repository commits and reviews, as opposed to the gitignored session
+// state in state.go. They get the same lock and the same atomic write —
+// two sessions editing two stories must not lose one of them either.
+//
+// Two shapes cover all of them. A directory owner holds many files under
+// one directory (specs, plans, stories, todos, ADRs); a document owner is
+// a single known file (config.toml, PRINCIPLES.md, the github templates).
+
+// ListDir names the files directly under relDir, sorted.
+//
+// An absent directory is an empty list and a nil error, not a fault: every
+// caller already treats "no specs yet" as an ordinary state, and making
+// them each unwrap an IsNotExist would be twenty chances to get it wrong.
+func ListDir(root, relDir string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(root, filepath.FromSlash(relDir)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// LoadIn reads one file from a directory owner.
+func LoadIn(root, relDir, name string) ([]byte, error) {
+	p, err := inDir(relDir, name)
+	if err != nil {
+		return nil, err
+	}
+	return ReadFile(root, p)
+}
+
+// SaveIn replaces one file in a directory owner.
+func SaveIn(root, relDir, name string, data []byte) error {
+	p, err := inDir(relDir, name)
+	if err != nil {
+		return err
+	}
+	return saveContent(root, p, data)
+}
+
+// LoadDoc reads a single-file owner.
+func LoadDoc(root, relPath string) ([]byte, error) { return ReadFile(root, relPath) }
+
+// SaveDoc replaces a single-file owner.
+func SaveDoc(root, relPath string, data []byte) error { return saveContent(root, relPath, data) }
+
+// inDir refuses a name that is a path, for the reason markerPath does:
+// joining an unchecked name lets ".." walk out of the directory the caller
+// named and overwrite whatever it finds there.
+func inDir(relDir, name string) (string, error) {
+	if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return "", errors.New("procoder: a file in " + relDir + " is named by a file name, not a path: " + name)
+	}
+	return strings.TrimRight(relDir, "/") + "/" + name, nil
+}
+
+// saveContent is one file's write: take its lock, replace it atomically,
+// release. Per file, not per directory — two people editing two different
+// stories have no reason to wait for each other.
+func saveContent(root, relPath string, data []byte) error {
+	release, _, err := Lock(root, relPath)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return WriteFile(root, relPath, data, 0o644)
+}
+
+// Rel turns an absolute path inside root into the repo-relative slash form
+// every other function here speaks.
+//
+// It exists because several packages list .procoder/ files as absolute
+// paths and hand them around — spec.Files, plan.Files, analysis.Files —
+// and their readers would otherwise have to go around the store to open
+// what they were given. It refuses a path outside root, so "read what I
+// was handed" cannot become "read anything".
+func Rel(root, abs string) (string, error) {
+	r, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	a, err := filepath.Abs(abs)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(r, a)
+	if err != nil {
+		return "", err
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", errors.New("procoder: " + abs + " is outside " + root)
+	}
+	return rel, nil
+}
+
+// OpenIn opens a file in a directory owner for streaming.
+//
+// The index's tag file runs to megabytes and two readers scan it line by
+// line rather than loading it whole; handing them the bytes would undo
+// that. Reads take no lock in any case, so a handle is no weaker than a
+// ReadFile — and routing them here keeps the rule "nothing outside this
+// package opens a .procoder/ file" true, which is what makes the rule
+// checkable.
+func OpenIn(root, relDir, name string) (*os.File, error) {
+	p, err := inDir(relDir, name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(filepath.Join(root, filepath.FromSlash(p)))
+}

--- a/internal/store/content.go
+++ b/internal/store/content.go
@@ -78,7 +78,7 @@ func inDir(relDir, name string) (string, error) {
 // release. Per file, not per directory — two people editing two different
 // stories have no reason to wait for each other.
 func saveContent(root, relPath string, data []byte) error {
-	release, _, err := Lock(root, relPath)
+	release, err := Lock(root, relPath)
 	if err != nil {
 		return err
 	}
@@ -95,11 +95,11 @@ func saveContent(root, relPath string, data []byte) error {
 // what they were given. It refuses a path outside root, so "read what I
 // was handed" cannot become "read anything".
 func Rel(root, abs string) (string, error) {
-	r, err := filepath.Abs(root)
+	r, err := resolve(root)
 	if err != nil {
 		return "", err
 	}
-	a, err := filepath.Abs(abs)
+	a, err := resolve(abs)
 	if err != nil {
 		return "", err
 	}
@@ -108,10 +108,62 @@ func Rel(root, abs string) (string, error) {
 		return "", err
 	}
 	rel = filepath.ToSlash(rel)
-	if rel == ".." || strings.HasPrefix(rel, "../") {
-		return "", errors.New("procoder: " + abs + " is outside " + root)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", errors.New("procoder: " + filepath.ToSlash(abs) + " is not a file inside " + filepath.ToSlash(root))
 	}
 	return rel, nil
+}
+
+// resolve makes a path absolute AND follows symlinks, which matters in both
+// directions.
+//
+// Without it a legitimate path is refused: on macOS a temp root is
+// /var/... while anything that has called EvalSymlinks holds
+// /private/var/..., and comparing the two says "outside". And an escape is
+// permitted: a symlink inside the root pointing out of it would otherwise
+// produce a clean-looking relative path that reads and writes elsewhere.
+//
+// A path that does not exist yet cannot be resolved; its nearest existing
+// ancestor is resolved instead, so a first write is not refused for not
+// having happened yet.
+func resolve(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	if r, err := filepath.EvalSymlinks(abs); err == nil {
+		return r, nil
+	}
+	dir, base := filepath.Split(abs)
+	parent, err := resolve(filepath.Clean(dir))
+	if err != nil {
+		return abs, nil
+	}
+	return filepath.Join(parent, base), nil
+}
+
+// LoadUnder and SaveUnder reach a .procoder/ file the caller was handed as
+// an ABSOLUTE path.
+//
+// Several packages list .procoder/ files as absolute paths and hand them
+// around — spec.Files, plan.Files, analysis.Files, Item.Path, Task.Path —
+// and their readers would otherwise have to go around the store to open
+// what they were given. Rel refuses a path outside the root, so "read what
+// I was handed" cannot become "read anything".
+func LoadUnder(root, abs string) ([]byte, error) {
+	rel, err := Rel(root, abs)
+	if err != nil {
+		return nil, err
+	}
+	return LoadDoc(root, rel)
+}
+
+func SaveUnder(root, abs string, data []byte) error {
+	rel, err := Rel(root, abs)
+	if err != nil {
+		return err
+	}
+	return SaveDoc(root, rel, data)
 }
 
 // OpenIn opens a file in a directory owner for streaming.

--- a/internal/store/content_test.go
+++ b/internal/store/content_test.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// proved by: locking the directory rather than the file makes the second
+// save fail too, and two people editing two stories would wait on each
+// other for no reason.
+func TestSaveInLocksItsOwnFile(t *testing.T) {
+	root := t.TempDir()
+	const dir = ".procoder/backlog/stories"
+	plant(t, root, dir+"/s1.md", os.Getpid(), time.Now().Unix())
+
+	if err := SaveIn(root, dir, "s1.md", []byte("x")); err == nil {
+		t.Fatal("SaveIn wrote while that file was locked")
+	}
+	if err := SaveIn(root, dir, "s2.md", []byte("y")); err != nil {
+		t.Fatalf("a lock on s1.md blocked s2.md: %v", err)
+	}
+}
+
+// proved by: taking the caller's argument order rather than sorted order
+// deadlocks two operations spanning the same two files.
+func TestMultiFileSaveTakesSortedLocks(t *testing.T) {
+	root := t.TempDir()
+	a := ".procoder/backlog/stories/s1.md"
+	b := ".procoder/backlog/sprints/001.md"
+	done := make(chan error, 2)
+	for _, pair := range [][2]string{{a, b}, {b, a}} {
+		go func(p [2]string) {
+			for i := 0; i < 50; i++ {
+				release, _, err := Lock(root, p[0], p[1])
+				if err != nil {
+					done <- err
+					return
+				}
+				release()
+			}
+			done <- nil
+		}(pair)
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("lock failed: %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("deadlock: locks were not taken in sorted order")
+		}
+	}
+}
+
+// proved by: returning the IsNotExist error makes every caller unwrap it,
+// and "no specs yet" is an ordinary state, not a fault.
+func TestListDirAbsentIsEmpty(t *testing.T) {
+	names, err := ListDir(t.TempDir(), ".procoder/specs")
+	if err != nil {
+		t.Fatalf("absent directory reported as an error: %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("got %v, want none", names)
+	}
+}
+
+// proved by: returning entries in readdir order makes every listing depend
+// on the filesystem, and two machines disagree about what `procoder spec
+// list` prints.
+func TestListDirIsSortedAndFilesOnly(t *testing.T) {
+	root := t.TempDir()
+	for _, n := range []string{"c.md", "a.md", "b.md"} {
+		if err := SaveIn(root, ".procoder/specs", n, []byte("x")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(root+"/.procoder/specs/sub", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	names, err := ListDir(root, ".procoder/specs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(names, ",") != "a.md,b.md,c.md" {
+		t.Fatalf("got %v, want a.md,b.md,c.md with the directory excluded", names)
+	}
+}
+
+// proved by: joining an unchecked name lets ".." walk out of the directory
+// the caller named.
+func TestInDirNameIsNotAPath(t *testing.T) {
+	root := t.TempDir()
+	if err := SaveIn(root, ".procoder/specs", "../escape.md", []byte("x")); err == nil {
+		t.Fatal("SaveIn accepted a name containing a path")
+	}
+	if _, err := LoadIn(root, ".procoder/specs", "sub/thing.md"); err == nil {
+		t.Fatal("LoadIn accepted a name containing a separator")
+	}
+}
+
+// proved by: a doc write that skipped the lock would lose one of two
+// concurrent edits to the same rules file.
+func TestSaveDocLocks(t *testing.T) {
+	root := t.TempDir()
+	const doc = ".procoder/security/RULES.md"
+	plant(t, root, doc, os.Getpid(), time.Now().Unix())
+	if err := SaveDoc(root, doc, []byte("x")); err == nil {
+		t.Fatal("SaveDoc wrote while the file was locked")
+	}
+}
+
+// proved by: returning the path unchecked lets "read what I was handed"
+// become "read anything on this machine".
+func TestRelRefusesOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Rel(root, "/etc/passwd"); err == nil {
+		t.Fatal("Rel accepted a path outside root")
+	}
+	got, err := Rel(root, root+"/.procoder/specs/a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ".procoder/specs/a.md" {
+		t.Fatalf("Rel = %q, want .procoder/specs/a.md", got)
+	}
+}

--- a/internal/store/content_test.go
+++ b/internal/store/content_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -214,6 +215,9 @@ func TestResolveTerminatesAtTheRoot(t *testing.T) {
 // proved by: falling back to an unlocked write here makes this pass while
 // reintroducing the race the package exists to remove.
 func TestReadOnlyStateBlocksContentWrites(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod on Windows toggles a file's read-only attribute and does not restrict a DIRECTORY, so there is no read-only directory to test against here")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("root ignores the directory mode, so there is nothing to test here")
 	}

--- a/internal/store/content_test.go
+++ b/internal/store/content_test.go
@@ -177,3 +177,16 @@ func TestRelRefusesTheRootItself(t *testing.T) {
 		t.Fatal("Rel accepted the root directory as a file")
 	}
 }
+
+// proved by: without the fixed-point guard, a path whose root cannot be
+// resolved recurses until the stack runs out.
+func TestResolveTerminatesAtTheRoot(t *testing.T) {
+	root := filepath.VolumeName(os.TempDir()) + string(filepath.Separator)
+	got, err := resolve(root)
+	if err != nil {
+		t.Fatalf("resolving the filesystem root errored: %v", err)
+	}
+	if got == "" {
+		t.Fatal("resolving the filesystem root returned nothing")
+	}
+}

--- a/internal/store/content_test.go
+++ b/internal/store/content_test.go
@@ -190,3 +190,63 @@ func TestResolveTerminatesAtTheRoot(t *testing.T) {
 		t.Fatal("resolving the filesystem root returned nothing")
 	}
 }
+
+// TestReadOnlyStateBlocksContentWrites pins a real behaviour change, so it
+// is a decision rather than a surprise.
+//
+// The lock for every file lives under .procoder/state/locks, so a
+// read-only .procoder/state stops writes to content that has nothing to do
+// with state: `procoder ask` used to write .procoder/ask/QA.md in that
+// situation and now refuses.
+//
+// The condition is narrow, and worth being precise about rather than
+// alarming: it bites only while .procoder/state/locks does not yet exist.
+// Once it has been created — which the first successful write in a
+// repository does — a read-only state directory blocks nothing, because
+// no new entry has to be made inside it.
+//
+// Accepted deliberately. Locks beside their files show up in git status
+// and in review; locks in the OS temp directory stop being mutually
+// exclusive the moment two processes have different TMPDIR values, which
+// on macOS is the ordinary case across sessions — and a lock that silently
+// stops locking is the one failure this package cannot have.
+//
+// proved by: falling back to an unlocked write here makes this pass while
+// reintroducing the race the package exists to remove.
+func TestReadOnlyStateBlocksContentWrites(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the directory mode, so there is nothing to test here")
+	}
+	root := t.TempDir()
+	// Seed the content file WITHOUT the store, so the lock directory has
+	// never been created. That is the whole condition: once
+	// .procoder/state/locks exists, a read-only state directory no longer
+	// blocks anything, because nothing new has to be created inside it.
+	ask := filepath.Join(root, ".procoder", "ask")
+	if err := os.MkdirAll(ask, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ask, "QA.md"), []byte("before"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state := filepath.Join(root, ".procoder", "state")
+	if err := os.MkdirAll(state, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(state, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(state, 0o755) })
+
+	err := SaveDoc(root, ".procoder/ask/QA.md", []byte("after"))
+	if err == nil {
+		t.Fatal("wrote a content file unlocked while the lock directory was unwritable")
+	}
+	if !strings.Contains(err.Error(), "lock directory") {
+		t.Fatalf("the error does not name the lock directory, so the coupling is not diagnosable: %v", err)
+	}
+	got, _ := ReadFile(root, ".procoder/ask/QA.md")
+	if string(got) != "before" {
+		t.Fatalf("the refused write changed the file anyway: %q", got)
+	}
+}

--- a/internal/store/content_test.go
+++ b/internal/store/content_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 // save fail too, and two people editing two stories would wait on each
 // other for no reason.
 func TestSaveInLocksItsOwnFile(t *testing.T) {
+	impatient(t)
 	root := t.TempDir()
 	const dir = ".procoder/backlog/stories"
 	plant(t, root, dir+"/s1.md", os.Getpid(), time.Now().Unix())
@@ -33,7 +35,7 @@ func TestMultiFileSaveTakesSortedLocks(t *testing.T) {
 	for _, pair := range [][2]string{{a, b}, {b, a}} {
 		go func(p [2]string) {
 			for i := 0; i < 50; i++ {
-				release, _, err := Lock(root, p[0], p[1])
+				release, err := Lock(root, p[0], p[1])
 				if err != nil {
 					done <- err
 					return
@@ -104,6 +106,7 @@ func TestInDirNameIsNotAPath(t *testing.T) {
 // proved by: a doc write that skipped the lock would lose one of two
 // concurrent edits to the same rules file.
 func TestSaveDocLocks(t *testing.T) {
+	impatient(t)
 	root := t.TempDir()
 	const doc = ".procoder/security/RULES.md"
 	plant(t, root, doc, os.Getpid(), time.Now().Unix())
@@ -125,5 +128,52 @@ func TestRelRefusesOutsideRoot(t *testing.T) {
 	}
 	if got != ".procoder/specs/a.md" {
 		t.Fatalf("Rel = %q, want .procoder/specs/a.md", got)
+	}
+}
+
+// proved by: comparing unresolved paths refuses a legitimate file — on
+// macOS a temp root is /var/... while anything that has called
+// EvalSymlinks holds /private/var/..., and every readUnder caller then
+// reports a perfectly readable file as unreadable.
+func TestRelResolvesSymlinksOnBothSides(t *testing.T) {
+	root := t.TempDir()
+	if err := SaveIn(root, ".procoder/specs", "a.md", []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved == root {
+		t.Skip("this temp root is not behind a symlink, so there is nothing to test here")
+	}
+	if _, err := Rel(root, filepath.Join(resolved, ".procoder", "specs", "a.md")); err != nil {
+		t.Fatalf("a resolved path under an unresolved root was refused: %v", err)
+	}
+	if _, err := Rel(resolved, filepath.Join(root, ".procoder", "specs", "a.md")); err != nil {
+		t.Fatalf("an unresolved path under a resolved root was refused: %v", err)
+	}
+}
+
+// proved by: not resolving symlinks lets a link inside the root read and
+// WRITE anywhere on the machine while producing a clean relative path.
+func TestRelRefusesEscapeThroughASymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "esc")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("this platform will not make a symlink: %v", err)
+	}
+	if _, err := Rel(root, filepath.Join(link, "secret.txt")); err == nil {
+		t.Fatal("Rel accepted a path that leaves the root through a symlink")
+	}
+}
+
+// proved by: returning "." lets LoadDoc read, and SaveDoc write over, the
+// repository root itself.
+func TestRelRefusesTheRootItself(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Rel(root, root); err == nil {
+		t.Fatal("Rel accepted the root directory as a file")
 	}
 }

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -6,7 +6,9 @@ import (
 	"go/printer"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -116,36 +118,51 @@ func TestStoreCoversEveryPathConstant(t *testing.T) {
 	}
 }
 
-// procoderPathIdents are the identifiers that hold a .procoder/ path. An
-// os.* call naming one of these is reaching past the store.
-//
-// Written out rather than inferred: inferring it means guessing which `Dir`
-// a call meant, and a guard that guesses is a guard that fails open.
+// procoderPathIdents are identifiers from OTHER packages that hold a
+// .procoder/ path. Within a package the constants are discovered; across
+// one they are named here, because guessing which `Dir` a qualified
+// selector meant is how a guard starts failing open.
 var procoderPathIdents = []string{
-	"RulesPath", "CopilotLeaksPath", "MermaidConfigPath", "PerspectiveDir",
-	"StateDir", "DecisionsFile", "codeindex.Dir", "spec.Dir",
+	"codeindex.Dir", "spec.Dir", "ask.Dir", "answers.Dir",
 }
 
-// ioFuncs are the calls that read or write a file's contents. os.Stat and
-// os.Getwd are absent deliberately: asking whether something exists is not
-// reaching past the store, and gate adoption legitimately stats .procoder/.
+// ioFuncs are the calls that read, write, replace or remove a file.
+//
+// os.Stat and os.Lstat are absent deliberately: asking whether something
+// exists is not reaching past the store, and gate adoption legitimately
+// stats .procoder/ to decide whether a repository opted in. Removal and
+// mode changes ARE here — a delete past the store is as much a write as a
+// write is.
 var ioFuncs = map[string]bool{
 	"ReadFile": true, "WriteFile": true, "Create": true, "CreateTemp": true,
 	"OpenFile": true, "Open": true, "ReadDir": true, "Rename": true,
+	"Remove": true, "RemoveAll": true, "Truncate": true, "Chmod": true,
+	"Symlink": true, "Link": true,
 }
 
-// proved by: reintroducing a direct os.ReadFile on a .procoder/ path
-// anywhere outside this package fails this, which is what stops the seam
-// eroding one convenient call at a time.
-func TestNoDirectProcoderFileIO(t *testing.T) {
+// packageProcoderConsts collects the .procoder/ path constants declared
+// anywhere in a package.
+//
+// Per PACKAGE, not per file: Go constants are package-scoped, and a guard
+// that only looked in the violating file missed a call in todo.go using a
+// Dir declared three lines up in the same file's package but a different
+// file. That bypass was found by review, not by the guard.
+func packageProcoderConsts(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
 	fset := token.NewFileSet()
-	for _, p := range goFiles(t) {
-		f, err := parser.ParseFile(fset, p, nil, 0)
-		if err != nil {
-			t.Fatalf("%s: %v", p, err)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
 		}
-		// The package's own .procoder path constants, by name.
-		local := map[string]bool{}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, 0)
+		if err != nil {
+			continue
+		}
 		ast.Inspect(f, func(n ast.Node) bool {
 			vs, ok := n.(*ast.ValueSpec)
 			if !ok {
@@ -159,14 +176,118 @@ func TestNoDirectProcoderFileIO(t *testing.T) {
 				if !ok || bl.Kind != token.STRING {
 					continue
 				}
-				if v, err := strconv.Unquote(bl.Value); err == nil && strings.HasPrefix(v, ".procoder") {
-					local[name.Name] = true
+				if v, err := strconv.Unquote(bl.Value); err == nil && isProcoderPath(v) {
+					out[name.Name] = true
+				}
+			}
+			return true
+		})
+	}
+	return out
+}
+
+// isProcoderPath matches `.procoder` and `.procoder/...` and NOT
+// `.procoder-...`, which is how the self-upgrade names a temp directory
+// and has nothing to do with the store.
+func isProcoderPath(v string) bool {
+	return v == ".procoder" || strings.HasPrefix(v, ".procoder/")
+}
+
+// proved by: reintroducing a direct os.ReadFile on a .procoder/ path
+// anywhere outside this package fails this, which is what stops the seam
+// eroding one convenient call at a time.
+func TestNoDirectProcoderFileIO(t *testing.T) {
+	fset := token.NewFileSet()
+	byDir := map[string][]string{}
+	for _, p := range goFiles(t) {
+		d := filepath.Dir(p)
+		byDir[d] = append(byDir[d], p)
+	}
+	dirs := make([]string, 0, len(byDir))
+	for d := range byDir {
+		dirs = append(dirs, d)
+	}
+	sort.Strings(dirs)
+
+	for _, dir := range dirs {
+		consts := packageProcoderConsts(t, dir)
+		for _, p := range byDir[dir] {
+			f, err := parser.ParseFile(fset, p, nil, 0)
+			if err != nil {
+				t.Fatalf("%s: %v", p, err)
+			}
+			checkFile(t, fset, p, f, consts)
+		}
+	}
+}
+
+// checkFile flags every IO call in one file that names a .procoder/ path,
+// directly or through a variable that was assigned one.
+func checkFile(t *testing.T, fset *token.FileSet, path string, f *ast.File, consts map[string]bool) {
+	t.Helper()
+	render := func(n ast.Node) string {
+		var b strings.Builder
+		if printer.Fprint(&b, fset, n) != nil {
+			return ""
+		}
+		return b.String()
+	}
+	// names a .procoder path, either as a literal or through a constant
+	// this package or another one declares as one.
+	names := func(text string) bool {
+		if procoderLiteral.MatchString(text) {
+			return true
+		}
+		for c := range consts {
+			if identRe(c).MatchString(text) {
+				return true
+			}
+		}
+		for _, c := range procoderPathIdents {
+			if identRe(c).MatchString(text) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		// Variables holding a .procoder path. Without this the guard is
+		// bypassed by one line — `p := filepath.Join(root, Dir, name)`
+		// followed by `os.ReadFile(p)` — which review demonstrated.
+		tainted := map[string]bool{}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			var lhs []ast.Expr
+			var rhs []ast.Expr
+			switch a := n.(type) {
+			case *ast.AssignStmt:
+				lhs, rhs = a.Lhs, a.Rhs
+			case *ast.ValueSpec:
+				for _, id := range a.Names {
+					lhs = append(lhs, id)
+				}
+				rhs = a.Values
+			default:
+				return true
+			}
+			for i, l := range lhs {
+				id, ok := l.(*ast.Ident)
+				if !ok || i >= len(rhs) {
+					continue
+				}
+				text := render(rhs[i])
+				if names(text) {
+					tainted[id.Name] = true
 				}
 			}
 			return true
 		})
 
-		ast.Inspect(f, func(n ast.Node) bool {
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
 			if !ok {
 				return true
@@ -175,63 +296,39 @@ func TestNoDirectProcoderFileIO(t *testing.T) {
 			if !ok {
 				return true
 			}
-			id, ok := sel.X.(*ast.Ident)
-			if !ok || id.Name != "os" || !ioFuncs[sel.Sel.Name] {
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "os" || !ioFuncs[sel.Sel.Name] {
 				return true
 			}
-			var b strings.Builder
-			if err := printer.Fprint(&b, fset, call); err != nil {
-				return true
-			}
-			text := b.String()
-
-			// `".procoder/` or exactly `".procoder"` — NOT `.procoder-`,
-			// which is how the self-upgrade names a temp directory and has
-			// nothing to do with the store.
-			hit := strings.Contains(text, `".procoder/`) || strings.Contains(text, `".procoder"`)
-			for name := range local {
-				if !hit && containsIdent(text, name) {
-					hit = true
-				}
-			}
-			for _, name := range procoderPathIdents {
-				if !hit && containsIdent(text, name) {
+			text := render(call)
+			hit := names(text)
+			for v := range tainted {
+				if !hit && identRe(v).MatchString(text) {
 					hit = true
 				}
 			}
 			if hit {
 				t.Errorf("%s:%d reaches past the store: %s",
-					p, fset.Position(call.Pos()).Line, strings.Join(strings.Fields(text), " "))
+					path, fset.Position(call.Pos()).Line, strings.Join(strings.Fields(text), " "))
 			}
 			return true
 		})
 	}
 }
 
-// containsIdent reports whether text uses name as a whole identifier, so
-// "Dir" does not match "SkipDir".
-func containsIdent(text, name string) bool {
-	for i := 0; ; {
-		j := strings.Index(text[i:], name)
-		if j < 0 {
-			return false
-		}
-		j += i
-		before := byte(' ')
-		if j > 0 {
-			before = text[j-1]
-		}
-		after := byte(' ')
-		if j+len(name) < len(text) {
-			after = text[j+len(name)]
-		}
-		if !isIdentByte(before) && !isIdentByte(after) {
-			return true
-		}
-		i = j + len(name)
+// procoderLiteral matches a `".procoder"` or `".procoder/..."` string in
+// rendered source, and not `".procoder-..."`.
+var procoderLiteral = regexp.MustCompile(`"\.procoder(/[^"]*)?"`)
+
+// identRe matches name as a whole identifier, so "Dir" does not match
+// "SkipDir" and "spec.Dir" does not match "myspec.Dir".
+func identRe(name string) *regexp.Regexp {
+	if re, ok := identCache[name]; ok {
+		return re
 	}
+	re := regexp.MustCompile(`(^|[^\w.])` + regexp.QuoteMeta(name) + `($|[^\w.])`)
+	identCache[name] = re
+	return re
 }
 
-func isIdentByte(b byte) bool {
-	return b == '_' || b == '.' || (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
-}
+var identCache = map[string]*regexp.Regexp{}

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -256,36 +256,79 @@ func checkFile(t *testing.T, fset *token.FileSet, path string, f *ast.File, cons
 		if !ok || fn.Body == nil {
 			continue
 		}
-		// Variables holding a .procoder path. Without this the guard is
+		// Names holding a .procoder path. Without this the guard is
 		// bypassed by one line — `p := filepath.Join(root, Dir, name)`
 		// followed by `os.ReadFile(p)` — which review demonstrated.
+		//
+		// Selector targets are tainted by their rendered text, because
+		// `t.Path` and `it.Path` really do hold .procoder absolute paths
+		// today, and `os.ReadFile(t.Path)` is the likeliest future
+		// regression. Taint propagates and the loop runs to a fixed point,
+		// so an alias chain does not launder it.
+		//
+		// KNOWN GAP, documented rather than left to be discovered: a
+		// helper that RETURNS a .procoder path — `os.ReadFile(mk(root))` —
+		// is not caught. Following return values wants a second pass over
+		// the package's call graph, which is more than this guard is
+		// worth; the coverage test above is what catches a new path being
+		// introduced at all.
 		tainted := map[string]bool{}
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			var lhs []ast.Expr
-			var rhs []ast.Expr
-			switch a := n.(type) {
-			case *ast.AssignStmt:
-				lhs, rhs = a.Lhs, a.Rhs
-			case *ast.ValueSpec:
-				for _, id := range a.Names {
-					lhs = append(lhs, id)
+		taintedText := func(text string) bool {
+			for v := range tainted {
+				if identRe(v).MatchString(text) {
+					return true
 				}
-				rhs = a.Values
-			default:
+			}
+			return false
+		}
+		for pass := 0; pass < 8; pass++ {
+			before := len(tainted)
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				var lhs, rhs []ast.Expr
+				switch a := n.(type) {
+				case *ast.AssignStmt:
+					lhs, rhs = a.Lhs, a.Rhs
+				case *ast.ValueSpec:
+					for _, id := range a.Names {
+						lhs = append(lhs, id)
+					}
+					rhs = a.Values
+				case *ast.RangeStmt:
+					// for _, p := range paths — the value carries the
+					// taint of what is ranged over.
+					x := render(a.X)
+					if a.Value != nil && (names(x) || taintedText(x)) {
+						if id, ok := a.Value.(*ast.Ident); ok {
+							tainted[id.Name] = true
+						}
+					}
+					return true
+				default:
+					return true
+				}
+				for i, l := range lhs {
+					if i >= len(rhs) {
+						continue
+					}
+					text := render(rhs[i])
+					if !names(text) && !taintedText(text) {
+						continue
+					}
+					switch target := l.(type) {
+					case *ast.Ident:
+						tainted[target.Name] = true
+					case *ast.SelectorExpr:
+						if t := render(target); t != "" {
+							tainted[t] = true
+						}
+					}
+				}
 				return true
+			})
+			if len(tainted) == before {
+				break
 			}
-			for i, l := range lhs {
-				id, ok := l.(*ast.Ident)
-				if !ok || i >= len(rhs) {
-					continue
-				}
-				text := render(rhs[i])
-				if names(text) {
-					tainted[id.Name] = true
-				}
-			}
-			return true
-		})
+		}
 
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
@@ -301,12 +344,7 @@ func checkFile(t *testing.T, fset *token.FileSet, path string, f *ast.File, cons
 				return true
 			}
 			text := render(call)
-			hit := names(text)
-			for v := range tainted {
-				if !hit && identRe(v).MatchString(text) {
-					hit = true
-				}
-			}
+			hit := names(text) || taintedText(text)
 			if hit {
 				t.Errorf("%s:%d reaches past the store: %s",
 					path, fset.Position(call.Pos()).Line, strings.Join(strings.Fields(text), " "))

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -1,0 +1,237 @@
+package store
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// treeRoot is this package's directory two levels up: the repository.
+const treeRoot = "../.."
+
+// knownPaths is every .procoder/ path literal the tree is allowed to carry,
+// each one served by this package.
+//
+// It is a list somebody has to edit, on purpose. A new .procoder/ path is a
+// new thing procoder owns, and it should not be possible to add one without
+// deciding which store operation serves it — which is a decision, not a
+// detail. The test below fails when a literal appears that is not here.
+var knownPaths = map[string]string{
+	".procoder":                                 "the root marker (gate adoption; stat only)",
+	".procoder/":                                "the root prefix (docs obligation; prefix test only)",
+	".procoder-upgrade-*":                       "a temp directory name, not a path under .procoder/",
+	".procoder/ is here":                        "prose, not a path",
+	".procoder/PRINCIPLES.md":                   "LoadDoc",
+	".procoder/adr":                             "ListDir, LoadIn",
+	".procoder/analysis":                        "ListDir, LoadDoc via Rel",
+	".procoder/ask":                             "LoadIn, SaveDoc via Rel",
+	".procoder/backlog":                         "ListDir, LoadIn",
+	".procoder/backlog/epics":                   "ListDir",
+	".procoder/backlog/sprints":                 "ListDir",
+	".procoder/bench":                           "LoadIn, SaveIn",
+	".procoder/config.toml":                     "LoadDoc",
+	".procoder/config.toml:%d":                  "a message format, not a path",
+	".procoder/config.toml:%d — %s (%s)":        "a message format, not a path",
+	".procoder/context.md":                      "LoadDoc",
+	".procoder/docs/RULES.md":                   "LoadDoc",
+	".procoder/docs/mermaid.json":               "passed to mmdc as a path; stat only",
+	".procoder/github/COMMIT_TEMPLATE.md":       "LoadDoc",
+	".procoder/github/COPILOT-LEAKS.md":         "LoadDoc, SaveDoc",
+	".procoder/github/LESSONS.md":               "LoadDoc",
+	".procoder/github/PULL_REQUEST_TEMPLATE.md": "LoadDoc",
+	".procoder/github/REVIEW.md":                "LoadIn",
+	".procoder/github/WORKFLOW.md":              "LoadDoc",
+	".procoder/index":                           "ListDir, LoadIn, SaveIn, OpenIn",
+	".procoder/index/":                          "a gitignore prefix, not a path",
+	".procoder/lint/RULES.md":                   "LoadDoc",
+	".procoder/plans":                           "ListDir, LoadDoc via Rel",
+	".procoder/review/lenses":                   "LoadIn",
+	".procoder/review/perspectives":             "LoadIn",
+	".procoder/security/RULES.md":               "LoadDoc",
+	".procoder/specs":                           "ListDir, LoadIn, LoadDoc via Rel",
+	".procoder/state":                           "the state directory (markers)",
+	".procoder/state/":                          "a gitignore prefix, not a path",
+	".procoder/state/claims.json":               "LoadClaims, SaveClaims",
+	".procoder/state/dispatch.json":             "LoadDispatch, SaveDispatch",
+	".procoder/state/env.json":                  "LoadEnvState, SaveEnvState",
+	".procoder/templates":                       "LoadIn",
+	".procoder/todo":                            "ListDir, LoadIn, LoadDoc/SaveDoc via Rel",
+	".procoder/wizards":                         "ListDir, LoadIn",
+}
+
+func goFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, dir := range []string{"internal", "cmd"} {
+		err := filepath.WalkDir(filepath.Join(treeRoot, dir), func(p string, d fs.DirEntry, err error) error {
+			switch {
+			case err != nil, d.IsDir(), !strings.HasSuffix(p, ".go"), strings.HasSuffix(p, "_test.go"):
+				return nil
+			}
+			if strings.Contains(filepath.ToSlash(p), "/internal/store/") {
+				return nil
+			}
+			out = append(out, p)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// proved by: adding a new .procoder/ path anywhere in the tree without
+// deciding which store operation serves it fails this.
+func TestStoreCoversEveryPathConstant(t *testing.T) {
+	fset := token.NewFileSet()
+	for _, p := range goFiles(t) {
+		f, err := parser.ParseFile(fset, p, nil, 0)
+		if err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			bl, ok := n.(*ast.BasicLit)
+			if !ok || bl.Kind != token.STRING {
+				return true
+			}
+			v, err := strconv.Unquote(bl.Value)
+			if err != nil || !strings.HasPrefix(v, ".procoder") {
+				return true
+			}
+			if _, known := knownPaths[v]; !known {
+				t.Errorf("%s:%d path %q has no store pair — add it to knownPaths in this file and say which operation serves it",
+					p, fset.Position(bl.Pos()).Line, v)
+			}
+			return true
+		})
+	}
+}
+
+// procoderPathIdents are the identifiers that hold a .procoder/ path. An
+// os.* call naming one of these is reaching past the store.
+//
+// Written out rather than inferred: inferring it means guessing which `Dir`
+// a call meant, and a guard that guesses is a guard that fails open.
+var procoderPathIdents = []string{
+	"RulesPath", "CopilotLeaksPath", "MermaidConfigPath", "PerspectiveDir",
+	"StateDir", "DecisionsFile", "codeindex.Dir", "spec.Dir",
+}
+
+// ioFuncs are the calls that read or write a file's contents. os.Stat and
+// os.Getwd are absent deliberately: asking whether something exists is not
+// reaching past the store, and gate adoption legitimately stats .procoder/.
+var ioFuncs = map[string]bool{
+	"ReadFile": true, "WriteFile": true, "Create": true, "CreateTemp": true,
+	"OpenFile": true, "Open": true, "ReadDir": true, "Rename": true,
+}
+
+// proved by: reintroducing a direct os.ReadFile on a .procoder/ path
+// anywhere outside this package fails this, which is what stops the seam
+// eroding one convenient call at a time.
+func TestNoDirectProcoderFileIO(t *testing.T) {
+	fset := token.NewFileSet()
+	for _, p := range goFiles(t) {
+		f, err := parser.ParseFile(fset, p, nil, 0)
+		if err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		// The package's own .procoder path constants, by name.
+		local := map[string]bool{}
+		ast.Inspect(f, func(n ast.Node) bool {
+			vs, ok := n.(*ast.ValueSpec)
+			if !ok {
+				return true
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				bl, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || bl.Kind != token.STRING {
+					continue
+				}
+				if v, err := strconv.Unquote(bl.Value); err == nil && strings.HasPrefix(v, ".procoder") {
+					local[name.Name] = true
+				}
+			}
+			return true
+		})
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			id, ok := sel.X.(*ast.Ident)
+			if !ok || id.Name != "os" || !ioFuncs[sel.Sel.Name] {
+				return true
+			}
+			var b strings.Builder
+			if err := printer.Fprint(&b, fset, call); err != nil {
+				return true
+			}
+			text := b.String()
+
+			// `".procoder/` or exactly `".procoder"` — NOT `.procoder-`,
+			// which is how the self-upgrade names a temp directory and has
+			// nothing to do with the store.
+			hit := strings.Contains(text, `".procoder/`) || strings.Contains(text, `".procoder"`)
+			for name := range local {
+				if !hit && containsIdent(text, name) {
+					hit = true
+				}
+			}
+			for _, name := range procoderPathIdents {
+				if !hit && containsIdent(text, name) {
+					hit = true
+				}
+			}
+			if hit {
+				t.Errorf("%s:%d reaches past the store: %s",
+					p, fset.Position(call.Pos()).Line, strings.Join(strings.Fields(text), " "))
+			}
+			return true
+		})
+	}
+}
+
+// containsIdent reports whether text uses name as a whole identifier, so
+// "Dir" does not match "SkipDir".
+func containsIdent(text, name string) bool {
+	for i := 0; ; {
+		j := strings.Index(text[i:], name)
+		if j < 0 {
+			return false
+		}
+		j += i
+		before := byte(' ')
+		if j > 0 {
+			before = text[j-1]
+		}
+		after := byte(' ')
+		if j+len(name) < len(text) {
+			after = text[j+len(name)]
+		}
+		if !isIdentByte(before) && !isIdentByte(after) {
+			return true
+		}
+		i = j + len(name)
+	}
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || b == '.' || (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}

--- a/internal/store/deps_test.go
+++ b/internal/store/deps_test.go
@@ -1,0 +1,23 @@
+package store
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// proved by: adding any module dependency fails this.
+//
+// The lockfile in this package is an O_EXCL file rather than flock because
+// a portable flock/LockFileEx pair costs golang.org/x/sys. That reasoning
+// is only worth anything while the module really has no dependencies, so
+// the claim gets a test rather than a comment.
+func TestNoModuleDependencies(t *testing.T) {
+	raw, err := os.ReadFile("../../go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "require") {
+		t.Fatal("go.mod has grown a require block — procoder's zero-dependency claim, and the reason the lock is a lockfile, no longer hold")
+	}
+}

--- a/internal/store/golden_test.go
+++ b/internal/store/golden_test.go
@@ -1,0 +1,192 @@
+// Package store_test holds the parity harness.
+//
+// It is an EXTERNAL test package on purpose. The harness drives the real
+// entrypoints — status, principles, the stop hook, the config report — and
+// those packages import internal/store. An in-package test importing them
+// back would be an import cycle.
+package store_test
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"procoder/internal/config"
+	"procoder/internal/hook"
+	"procoder/internal/principles"
+	"procoder/internal/status"
+)
+
+var update = flag.Bool("update", false, "rewrite the golden files from the binary named by PROCODER_GOLDEN_BIN")
+
+// fixture builds a small repository with a fixed git history.
+//
+// The dates are pinned because a golden that moves with the calendar is a
+// golden that fails tomorrow for a reason nobody changed.
+func fixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	for _, d := range []string{
+		".procoder/specs", ".procoder/backlog/stories", ".procoder/backlog/sprints",
+		".procoder/todo", ".procoder/adr",
+	} {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(d)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		".procoder/specs/thing.md": "# thing\n\nStatus: complete\n\n## Problem\n\nA problem.\n",
+		".procoder/config.toml":    "[ask]\npolicy = \"report\"\n",
+		"main.go":                  "package main\n\nfunc main() {}\n",
+		"README.md":                "# readme\n\nText.\n",
+	}
+	for rel, body := range files {
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(rel)), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	run := func(env []string, args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		cmd.Env = append(os.Environ(), env...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run(nil, "init", "-q", "-b", "main")
+	run(nil, "add", "-A")
+	run([]string{
+		"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z",
+		"GIT_COMMITTER_DATE=2026-01-01T00:00:00Z",
+	}, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "seed")
+	return root
+}
+
+// replaceLinePrefix rewrites the whole of any line starting with prefix,
+// so a nondeterministic value can be held out of a golden without losing
+// the fact that the line is printed at all.
+func replaceLinePrefix(text, prefix, with string) string {
+	lines := strings.Split(text, "\n")
+	for i, l := range lines {
+		if strings.HasPrefix(l, prefix) {
+			lines[i] = with
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// captures are the outputs the harness compares. Each runs in process.
+//
+// What is NOT here is as deliberate as what is. `procoder check`, the
+// pre-tool-use hook and the post-tool-use hook all exec gitleaks, semgrep,
+// golangci-lint or the test runner, whose presence and version vary by
+// machine. A golden of those would pin THIS laptop rather than procoder's
+// behaviour, and would fail in CI for reasons no change caused.
+var captures = map[string]func(root string) string{
+	"status": func(root string) string {
+		var b strings.Builder
+		status.Run(root, func(s string) { b.WriteString(s + "\n") })
+		return b.String()
+	},
+	"principles-hook": func(root string) string {
+		var b strings.Builder
+		principles.RunHook(root, strings.NewReader("{}"), func(s string) { b.WriteString(s + "\n") })
+		return b.String()
+	},
+	"handoff": func(root string) string {
+		hook.Stop(strings.NewReader("{}"), root)
+		raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(".procoder/state/handoff.md")))
+		if err != nil {
+			return "NO HANDOFF: " + err.Error()
+		}
+		// The note stamps the wall clock. That the line is THERE is the
+		// behaviour; its value is not, and leaving it in would make this
+		// golden fail one second after it was written. Caught by
+		// TestCapturesAreDeterministic, which is why that test exists.
+		return replaceLinePrefix(string(raw), "generated: ", "generated: <time>")
+	},
+	"config": func(root string) string {
+		var b bytes.Buffer
+		config.Report(root, &b)
+		// The identity falls to the path rung in a fixture with no remote,
+		// and a temp path is different on every run and every machine. The
+		// rung is the behaviour under test; the path is not.
+		var out strings.Builder
+		for _, line := range strings.Split(b.String(), "\n") {
+			if strings.HasPrefix(line, "repo identity") {
+				out.WriteString("repo identity  <root>  (" + line[strings.Index(line, "(")+1:])
+			} else {
+				out.WriteString(line)
+			}
+			out.WriteString("\n")
+		}
+		return out.String()
+	},
+}
+
+// proved by: any change to what these commands print, anywhere in the
+// twenty-five packages the seam touches, fails this with a diff.
+//
+// The goldens for status, principles-hook and handoff were captured from
+// c4bb353 — the commit before internal/store existed — so they assert that
+// moving every read and write behind the store changed nothing. The config
+// golden is captured from the new code, because task 4 changed that output
+// on purpose; it guards against drift from here, not against the seam.
+func TestMigrationOutputUnchanged(t *testing.T) {
+	if *update {
+		t.Skip("-update writes goldens; run TestUpdateGoldens instead")
+	}
+	for name, capture := range captures {
+		t.Run(name, func(t *testing.T) {
+			want, err := os.ReadFile(filepath.Join("testdata", "golden", name+".txt"))
+			if err != nil {
+				t.Fatalf("no golden for %s: %v", name, err)
+			}
+			got := capture(fixture(t))
+			if got != string(want) {
+				t.Errorf("output drifted.\n--- want ---\n%s\n--- got ---\n%s", want, got)
+			}
+		})
+	}
+}
+
+// proved by: a command whose output moves between two runs would make every
+// golden a record of one roll of the dice, and would fail for everybody
+// afterwards for no reason anybody changed.
+func TestCapturesAreDeterministic(t *testing.T) {
+	for name, capture := range captures {
+		t.Run(name, func(t *testing.T) {
+			first := capture(fixture(t))
+			second := capture(fixture(t))
+			if first != second {
+				t.Errorf("two runs differ, so a golden cannot mean anything.\n--- first ---\n%s\n--- second ---\n%s", first, second)
+			}
+		})
+	}
+}
+
+// TestUpdateGoldens rewrites the golden files from the CURRENT code. It runs
+// only under -update and is how the config golden was made; the other three
+// were captured from the pre-store binary and must not be regenerated
+// casually, because regenerating them is exactly how a parity assertion
+// stops asserting anything.
+func TestUpdateGoldens(t *testing.T) {
+	if !*update {
+		t.Skip("run with -update to rewrite goldens")
+	}
+	dir := filepath.Join("testdata", "golden")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, capture := range captures {
+		if err := os.WriteFile(filepath.Join(dir, name+".txt"), []byte(capture(fixture(t))), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote %s", name)
+	}
+}

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -46,62 +46,108 @@ func (i Identity) Source() string {
 // personal remote named "fork" would key the same repository differently
 // from everybody else, which defeats the one thing an identity is for.
 //
+// A rung that produces an EMPTY key does not answer. A remote URL that
+// normalises to nothing — a malformed one, or a bare host with no path —
+// would otherwise hand every such repository the same empty identity,
+// which is the collision this exists to prevent.
+//
 // The path rung is last and is always available, so this never fails and
-// never returns an empty key — an empty identity is one every repository
-// would share.
+// never returns an empty key.
 func IdentityFor(root, cfgRepo string) Identity {
 	if s := strings.TrimSpace(cfgRepo); s != "" {
 		return Identity{Key: s, Rung: "config"}
 	}
 
 	remotes := gitx.Remotes(root)
-	if url, ok := remotes["origin"]; ok {
-		return Identity{Key: normalise(url), Rung: "origin"}
+	if key := normalise(remotes["origin"]); key != "" {
+		return Identity{Key: key, Rung: "origin"}
 	}
-	if len(remotes) > 0 {
-		names := make([]string, 0, len(remotes))
-		for name := range remotes {
-			names = append(names, name)
+	names := make([]string, 0, len(remotes))
+	for name := range remotes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if key := normalise(remotes[name]); key != "" {
+			return Identity{Key: key, Rung: "remote", Detail: name}
 		}
-		sort.Strings(names)
-		return Identity{Key: normalise(remotes[names[0]]), Rung: "remote", Detail: names[0]}
 	}
 
 	// Resolved, not raw: two paths reaching one checkout through a symlink
-	// are one repository and must not be two keys.
+	// are one repository and must not be two keys. Slash-separated, so the
+	// key for a checkout is the same string on Windows as anywhere else.
 	resolved, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		resolved = root
 	}
-	return Identity{Key: resolved, Rung: "path"}
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		abs = resolved
+	}
+	return Identity{Key: filepath.ToSlash(abs), Rung: "path"}
 }
 
 // normalise reduces a remote URL to host/path, so the same repository keys
-// the same however each person happens to have cloned it.
+// the same however each person happens to have cloned it. It returns ""
+// for anything it cannot reduce to both a host and a path, and the ladder
+// treats that as "this rung did not answer".
 //
-// A string matching none of the known shapes comes back trimmed and
-// otherwise untouched: a surprising key that can be traced to its remote is
-// better than a confident wrong one.
+// The host is lower-cased and the PATH IS NOT. Two repositories differing
+// only in the case of their path are rare; two hosts differing only in
+// case are the same host, always. Merging two repositories onto one key is
+// the worse failure of the two, so the path keeps its case.
 func normalise(url string) string {
 	s := strings.TrimSpace(url)
+	scheme := false
 	if i := strings.Index(s, "://"); i >= 0 {
-		s = s[i+3:]
-	}
-	if i := strings.Index(s, "@"); i >= 0 {
-		s = s[i+1:]
+		s, scheme = s[i+3:], true
 	}
 
-	// The scp-like form, git@host:owner/repo — the colon is the separator
-	// the URL forms spell as a slash.
-	host, rest := s, ""
-	if i := strings.IndexAny(s, ":/"); i >= 0 {
-		host, rest = s[:i], s[i+1:]
+	// Split the authority from the path. The scp-like form git@host:o/r
+	// separates them with a colon and has no scheme; every other form uses
+	// the first slash.
+	var authority, rest string
+	slash := strings.Index(s, "/")
+	colon := strings.Index(s, ":")
+	switch {
+	case !scheme && colon >= 0 && (slash < 0 || colon < slash):
+		authority, rest = s[:colon], s[colon+1:]
+	case slash >= 0:
+		authority, rest = s[:slash], s[slash+1:]
+	default:
+		authority = s
 	}
 
-	rest = strings.TrimSuffix(strings.TrimSuffix(strings.TrimRight(rest, "/"), ".git"), "/")
-	host = strings.ToLower(host)
-	if rest == "" {
-		return host
+	// A port is not part of the identity, and leaving it in makes
+	// https://host:8443/o/r collide with https://host/8443/o/r — two
+	// different repositories on one key.
+	if i := strings.LastIndex(authority, ":"); i >= 0 && allDigits(authority[i+1:]) {
+		authority = authority[:i]
+	}
+	// The user, and only within the authority. Searching the whole URL
+	// throws the host away for any path containing an "@".
+	if i := strings.LastIndex(authority, "@"); i >= 0 {
+		authority = authority[i+1:]
+	}
+
+	host := strings.ToLower(authority)
+	rest = strings.Trim(rest, "/")
+	rest = strings.TrimSuffix(rest, ".git")
+	rest = strings.Trim(rest, "/")
+	if host == "" || rest == "" {
+		return ""
 	}
 	return host + "/" + rest
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -98,17 +98,46 @@ func IdentityFor(root, cfgRepo string) Identity {
 // the worse failure of the two, so the path keeps its case.
 func normalise(url string) string {
 	s := strings.TrimSpace(url)
+	if s == "" {
+		return ""
+	}
+	// A remote can be a path on this machine rather than a URL. Returning
+	// "" for those made two clones of one /srv/git/repo.git key by their
+	// own checkout paths — two identities for one repository, which is the
+	// divergence identity exists to prevent.
+	if p, ok := localRemote(s); ok {
+		return p
+	}
+	// A RELATIVE path remote means something different from each clone's
+	// own directory, so it cannot key two clones together. It does not
+	// answer, rather than answering with a key built out of "..".
+	if strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") {
+		return ""
+	}
+
 	scheme := false
 	if i := strings.Index(s, "://"); i >= 0 {
 		s, scheme = s[i+3:], true
 	}
+	// A query or a fragment is not part of the repository's name.
+	if i := strings.IndexAny(s, "?#"); i >= 0 {
+		s = s[:i]
+	}
 
 	// Split the authority from the path. The scp-like form git@host:o/r
 	// separates them with a colon and has no scheme; every other form uses
-	// the first slash.
+	// the first slash. A bracketed IPv6 literal is skipped before the scan,
+	// or the colon inside it is read as the separator.
+	scan := s
+	offset := 0
+	if strings.HasPrefix(s, "[") {
+		if end := strings.Index(s, "]"); end >= 0 {
+			scan, offset = s[end+1:], end+1
+		}
+	}
 	var authority, rest string
-	slash := strings.Index(s, "/")
-	colon := strings.Index(s, ":")
+	slash := indexAt(scan, "/", offset)
+	colon := indexAt(scan, ":", offset)
 	switch {
 	case !scheme && colon >= 0 && (slash < 0 || colon < slash):
 		authority, rest = s[:colon], s[colon+1:]
@@ -131,13 +160,76 @@ func normalise(url string) string {
 	}
 
 	host := strings.ToLower(authority)
-	rest = strings.Trim(rest, "/")
-	rest = strings.TrimSuffix(rest, ".git")
-	rest = strings.Trim(rest, "/")
+	rest = trimPath(rest)
 	if host == "" || rest == "" {
 		return ""
 	}
 	return host + "/" + rest
+}
+
+// indexAt finds sep in s, returning an index into the ORIGINAL string that
+// s was sliced from at offset.
+func indexAt(s, sep string, offset int) int {
+	if i := strings.Index(s, sep); i >= 0 {
+		return i + offset
+	}
+	return -1
+}
+
+// trimPath reduces a repository path to its bare form: no leading or
+// trailing slashes, no doubled ones, and no .git suffix in any case — the
+// hosts that serve these are not case-sensitive about that suffix, and two
+// keys for one repository is the failure being avoided.
+func trimPath(p string) string {
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	p = strings.Trim(p, "/")
+	if len(p) >= 4 && strings.EqualFold(p[len(p)-4:], ".git") {
+		p = p[:len(p)-4]
+	}
+	return strings.Trim(p, "/")
+}
+
+// localRemote recognises a remote that names a path on this machine rather
+// than a host: file:///srv/git/repo.git, /srv/git/repo.git, C:\\git\\repo.
+//
+// These are ordinary — a bare shared remote, a submodule, a mirror — and
+// two clones of one of them are one repository. The key is the path of the
+// REMOTE, which both clones agree on, not of either checkout.
+//
+// A RELATIVE path remote is deliberately not matched: it means something
+// different from each clone's own directory, so it cannot key them
+// together and pretending otherwise would be worse than falling through.
+func localRemote(s string) (string, bool) {
+	p := s
+	switch {
+	case strings.HasPrefix(s, "file://"):
+		p = strings.TrimPrefix(s, "file://")
+	case strings.HasPrefix(s, "/"):
+	case windowsDrive(s):
+	default:
+		return "", false
+	}
+	p = trimPath(filepath.ToSlash(p))
+	if p == "" {
+		return "", false
+	}
+	return "/" + p, true
+}
+
+// windowsDrive reports whether s begins with a drive letter, as C:\\git\\repo
+// does. A single-letter host is not a shape any real remote uses, so the
+// ambiguity with the scp form costs nothing.
+func windowsDrive(s string) bool {
+	if len(s) < 3 || s[1] != ':' {
+		return false
+	}
+	c := s[0]
+	if (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+		return false
+	}
+	return s[2] == '/' || s[2] == '\\'
 }
 
 func allDigits(s string) bool {

--- a/internal/store/identity.go
+++ b/internal/store/identity.go
@@ -1,0 +1,107 @@
+package store
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"procoder/internal/gitx"
+)
+
+// Identity is the repository key and the rung of the ladder that produced
+// it.
+//
+// The rung is not decoration. A key that surprises somebody has to be
+// traceable to the thing that decided it, or the only way to explain an
+// unexpected identity is to guess.
+type Identity struct {
+	// Key is the repository's stable name.
+	Key string
+	// Rung is which answer won: "config", "origin", "remote" or "path".
+	Rung string
+	// Detail names the remote, for the "remote" rung. Empty otherwise.
+	Detail string
+}
+
+// Source renders the rung for a person reading `procoder config`.
+func (i Identity) Source() string {
+	switch i.Rung {
+	case "config":
+		return "[service] repo in .procoder/config.toml"
+	case "origin":
+		return "origin remote"
+	case "remote":
+		return "first remote alphabetically: " + i.Detail
+	default:
+		return "no remote — repository root path"
+	}
+}
+
+// IdentityFor resolves the repository key down a fixed ladder: the
+// configured value, then the origin remote, then the first remote in
+// alphabetical order, then the resolved absolute path of the root.
+//
+// origin beats an alphabetically earlier remote deliberately. Pure
+// alphabetical order looks simpler and is wrong: a colleague who adds a
+// personal remote named "fork" would key the same repository differently
+// from everybody else, which defeats the one thing an identity is for.
+//
+// The path rung is last and is always available, so this never fails and
+// never returns an empty key — an empty identity is one every repository
+// would share.
+func IdentityFor(root, cfgRepo string) Identity {
+	if s := strings.TrimSpace(cfgRepo); s != "" {
+		return Identity{Key: s, Rung: "config"}
+	}
+
+	remotes := gitx.Remotes(root)
+	if url, ok := remotes["origin"]; ok {
+		return Identity{Key: normalise(url), Rung: "origin"}
+	}
+	if len(remotes) > 0 {
+		names := make([]string, 0, len(remotes))
+		for name := range remotes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return Identity{Key: normalise(remotes[names[0]]), Rung: "remote", Detail: names[0]}
+	}
+
+	// Resolved, not raw: two paths reaching one checkout through a symlink
+	// are one repository and must not be two keys.
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		resolved = root
+	}
+	return Identity{Key: resolved, Rung: "path"}
+}
+
+// normalise reduces a remote URL to host/path, so the same repository keys
+// the same however each person happens to have cloned it.
+//
+// A string matching none of the known shapes comes back trimmed and
+// otherwise untouched: a surprising key that can be traced to its remote is
+// better than a confident wrong one.
+func normalise(url string) string {
+	s := strings.TrimSpace(url)
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if i := strings.Index(s, "@"); i >= 0 {
+		s = s[i+1:]
+	}
+
+	// The scp-like form, git@host:owner/repo — the colon is the separator
+	// the URL forms spell as a slash.
+	host, rest := s, ""
+	if i := strings.IndexAny(s, ":/"); i >= 0 {
+		host, rest = s[:i], s[i+1:]
+	}
+
+	rest = strings.TrimSuffix(strings.TrimSuffix(strings.TrimRight(rest, "/"), ".git"), "/")
+	host = strings.ToLower(host)
+	if rest == "" {
+		return host
+	}
+	return host + "/" + rest
+}

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -75,6 +75,10 @@ func TestIdentityLadder(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		// Slash-separated: the key for one checkout must be the same
+		// string on Windows as anywhere else, which is why IdentityFor
+		// puts it through ToSlash.
+		want = filepath.ToSlash(want)
 		got := IdentityFor(root, "")
 		if got.Key != want || got.Rung != "path" {
 			t.Fatalf("got %+v, want key %s rung path", got, want)
@@ -100,6 +104,7 @@ func TestIdentityWithoutGit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	want = filepath.ToSlash(want)
 	got := IdentityFor(root, "")
 	if got.Key != want || got.Rung != "path" {
 		t.Fatalf("got %+v, want key %s rung path", got, want)

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -123,3 +123,36 @@ func TestIdentitySource(t *testing.T) {
 		}
 	}
 }
+
+// proved by: leaving a port in the authority makes https://host:8443/o/r
+// and https://host/8443/o/r one key — two repositories with one identity,
+// which is the collision an identity exists to prevent.
+func TestIdentityNormalisationIsAdversarial(t *testing.T) {
+	for _, tc := range []struct{ url, want string }{
+		{"https://host:8443/o/r", "host/o/r"},
+		{"https://host/8443/o/r", "host/8443/o/r"},
+		{"ssh://git@host:2222/o/r.git", "host/o/r"},
+		{"https://host/2222/o/r", "host/2222/o/r"},
+		// an "@" in the PATH must not throw the host away
+		{"https://host/o/r@2", "host/o/r@2"},
+		// nothing reducible to a host and a path is not an identity
+		{"", ""},
+		{"https://", ""},
+		{"git@host", ""},
+		{"   ", ""},
+	} {
+		if got := normalise(tc.url); got != tc.want {
+			t.Errorf("normalise(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+// proved by: taking a rung's answer without checking it is non-empty gives
+// every repository with a malformed remote the same empty identity.
+func TestIdentitySkipsARungThatCannotAnswer(t *testing.T) {
+	root := gitRepo(t, map[string]string{"origin": "git@host"})
+	got := IdentityFor(root, "")
+	if got.Rung != "path" || got.Key == "" {
+		t.Fatalf("got %+v, want the path rung with a non-empty key", got)
+	}
+}

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -1,0 +1,125 @@
+package store
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func gitRepo(t *testing.T, remotes map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	args := [][]string{{"init", "-q", "-b", "main"}}
+	for name, url := range remotes {
+		args = append(args, []string{"remote", "add", name, url})
+	}
+	for _, a := range args {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, a...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", a, err, out)
+		}
+	}
+	return dir
+}
+
+// proved by: skipping the host lower-casing, or keeping the .git suffix,
+// splits one repository into two keys and this fails.
+func TestIdentityNormalisation(t *testing.T) {
+	for _, url := range []string{
+		"git@host:o/r.git",
+		"https://host/o/r.git",
+		"ssh://git@host/o/r",
+		"https://HOST/o/r/",
+		"https://host/o/r",
+	} {
+		if got := normalise(url); got != "host/o/r" {
+			t.Errorf("normalise(%q) = %q, want host/o/r", url, got)
+		}
+	}
+}
+
+// proved by: letting the alphabetically first remote win outright makes the
+// origin-plus-fork case return the fork, which is the divergence this ladder
+// exists to prevent — two people with different extra remotes keying the same
+// repository differently.
+func TestIdentityLadder(t *testing.T) {
+	t.Run("config wins", func(t *testing.T) {
+		root := gitRepo(t, map[string]string{"origin": "https://host/o/r.git"})
+		got := IdentityFor(root, "acme/widgets")
+		if got.Key != "acme/widgets" || got.Rung != "config" {
+			t.Fatalf("got %+v, want key acme/widgets rung config", got)
+		}
+	})
+	t.Run("origin beats an earlier name", func(t *testing.T) {
+		root := gitRepo(t, map[string]string{
+			"origin": "https://host/o/r.git",
+			"fork":   "https://host/me/r.git",
+		})
+		got := IdentityFor(root, "")
+		if got.Key != "host/o/r" || got.Rung != "origin" {
+			t.Fatalf("got %+v, want key host/o/r rung origin", got)
+		}
+	})
+	t.Run("first alphabetically when there is no origin", func(t *testing.T) {
+		root := gitRepo(t, map[string]string{
+			"upstream": "https://host/o/r.git",
+			"fork":     "https://host/me/r.git",
+		})
+		got := IdentityFor(root, "")
+		if got.Key != "host/me/r" || got.Rung != "remote" || got.Detail != "fork" {
+			t.Fatalf("got %+v, want key host/me/r rung remote detail fork", got)
+		}
+	})
+	t.Run("path when there is no remote", func(t *testing.T) {
+		root := gitRepo(t, nil)
+		want, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := IdentityFor(root, "")
+		if got.Key != want || got.Rung != "path" {
+			t.Fatalf("got %+v, want key %s rung path", got, want)
+		}
+	})
+}
+
+// proved by: testing for the empty string rather than trimming leaves the key
+// empty, and an empty identity is one every repository shares.
+func TestIdentityBlankConfigKeyIgnored(t *testing.T) {
+	root := gitRepo(t, map[string]string{"origin": "https://host/o/r.git"})
+	got := IdentityFor(root, "   ")
+	if got.Rung != "origin" || got.Key != "host/o/r" {
+		t.Fatalf("got %+v, want the origin rung", got)
+	}
+}
+
+// proved by: falling back to the raw argument rather than the resolved path
+// gives two keys for one checkout reached through a symlink.
+func TestIdentityWithoutGit(t *testing.T) {
+	root := t.TempDir()
+	want, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := IdentityFor(root, "")
+	if got.Key != want || got.Rung != "path" {
+		t.Fatalf("got %+v, want key %s rung path", got, want)
+	}
+}
+
+// proved by: a Source that names the rung without the remote's name leaves a
+// surprising identity untraceable to the remote that produced it.
+func TestIdentitySource(t *testing.T) {
+	for _, tc := range []struct {
+		id   Identity
+		want string
+	}{
+		{Identity{Rung: "config"}, "[service] repo in .procoder/config.toml"},
+		{Identity{Rung: "origin"}, "origin remote"},
+		{Identity{Rung: "remote", Detail: "fork"}, "first remote alphabetically: fork"},
+		{Identity{Rung: "path"}, "no remote — repository root path"},
+	} {
+		if got := tc.id.Source(); got != tc.want {
+			t.Errorf("Source() for %+v = %q, want %q", tc.id, got, tc.want)
+		}
+	}
+}

--- a/internal/store/identity_test.go
+++ b/internal/store/identity_test.go
@@ -156,3 +156,54 @@ func TestIdentitySkipsARungThatCannotAnswer(t *testing.T) {
 		t.Fatalf("got %+v, want the path rung with a non-empty key", got)
 	}
 }
+
+// proved by: returning "" for a path-shaped remote makes two clones of one
+// /srv/git/repo.git key by their own checkout paths — two identities for
+// one repository, which is exactly the divergence identity prevents. That
+// was a regression this branch introduced and review caught.
+func TestIdentityHandlesLocalRemotes(t *testing.T) {
+	for _, tc := range []struct{ url, want string }{
+		{"/srv/git/repo.git", "/srv/git/repo"},
+		{"file:///srv/git/repo.git", "/srv/git/repo"},
+		{"file:///srv/git/repo", "/srv/git/repo"},
+		{"/srv/git/repo/", "/srv/git/repo"},
+		// relative remotes mean something different from each clone, so
+		// they deliberately do not answer
+		{"../sibling.git", ""},
+	} {
+		if got := normalise(tc.url); got != tc.want {
+			t.Errorf("normalise(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+// proved by: two clones of one bare remote must agree, which is the whole
+// point — and the rung must say the remote answered, not that there was none.
+func TestTwoClonesOfALocalRemoteAgree(t *testing.T) {
+	a := gitRepo(t, map[string]string{"origin": "/srv/git/repo.git"})
+	b := gitRepo(t, map[string]string{"origin": "/srv/git/repo.git"})
+	ida, idb := IdentityFor(a, ""), IdentityFor(b, "")
+	if ida.Key != idb.Key {
+		t.Fatalf("two clones of one remote disagree: %q vs %q", ida.Key, idb.Key)
+	}
+	if ida.Rung != "origin" {
+		t.Fatalf("rung = %q, want origin — there plainly is a remote", ida.Rung)
+	}
+}
+
+// proved by: scanning for the scp separator without skipping the brackets
+// lands inside an IPv6 literal and returns garbage.
+func TestIdentityNormalisationEdges(t *testing.T) {
+	for _, tc := range []struct{ url, want string }{
+		{"[::1]:o/r", "[::1]/o/r"},
+		{"https://[::1]:8443/o/r", "[::1]/o/r"},
+		{"https://host//o//r", "host/o/r"},
+		{"https://host/o/r.GIT", "host/o/r"},
+		{"https://host/o/r?x=1", "host/o/r"},
+		{"https://host/o/r#frag", "host/o/r"},
+	} {
+		if got := normalise(tc.url); got != tc.want {
+			t.Errorf("normalise(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -49,12 +50,6 @@ const (
 // A var rather than a const only so a test can shorten it; nothing in
 // procoder changes it at runtime.
 var staleAfter = 30 * time.Second
-
-// heartbeatEvery keeps a held lock looking alive. Without it a write that
-// legitimately takes longer than staleAfter — rewriting a multi-megabyte
-// tags.jsonl on a slow filesystem — would have its lock taken out from
-// under it while it was still writing.
-func heartbeatEvery() time.Duration { return staleAfter / 3 }
 
 // lockTimeout bounds the wait. A hook that blocked would take the session
 // with it, so waiting forever is never an option here.
@@ -102,18 +97,24 @@ func Lock(root string, relPaths ...string) (release func(), err error) {
 	sort.Strings(paths)
 
 	var hs []held
+	// Once, because the returned closure is a defer in most callers and a
+	// second close of h.stop would panic. A release function that can only
+	// be called safely once is a trap; this one can be called twice.
+	var once sync.Once
 	rel := func() {
-		for _, h := range hs {
-			close(h.stop)
-			p := lockPath(root, h.rel)
-			// Remove only what we actually hold. If this lock was broken
-			// as stale and somebody else's live lock now sits at the same
-			// path, removing it would hand a third caller a lock that is
-			// already held.
-			if cur, err := os.Stat(p); err == nil && os.SameFile(cur, h.info) {
-				_ = os.Remove(p)
+		once.Do(func() {
+			for _, h := range hs {
+				close(h.stop)
+				p := lockPath(root, h.rel)
+				// Remove only what we actually hold. If this lock was
+				// broken as stale and somebody else's live lock now sits
+				// at the same path, removing it would hand a third caller
+				// a lock that is already held.
+				if cur, err := os.Stat(p); err == nil && os.SameFile(cur, h.info) {
+					_ = os.Remove(p)
+				}
 			}
-		}
+		})
 	}
 	for _, p := range paths {
 		h, err := acquire(root, p)
@@ -148,7 +149,10 @@ func acquire(root, rel string) (held, error) {
 				return held{}, fmt.Errorf("procoder: could not write the lock for %s — the write was NOT made", rel)
 			}
 			h := held{rel: rel, info: info, stop: make(chan struct{})}
-			go keepAlive(p, h.stop)
+			// The tick is read HERE, on the caller's goroutine. Reading
+			// staleAfter inside keepAlive raced every test that restores
+			// it, and `go test -race` said so.
+			go keepAlive(p, info, staleAfter/3, h.stop)
 			return h, nil
 		}
 		if !os.IsExist(err) {
@@ -173,16 +177,27 @@ func breakStale(p, rel string) bool {
 	b, err := os.OpenFile(bp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
 		// Somebody else is breaking this one — unless they died doing it,
-		// which takes microseconds, so an old break file is litter. The
-		// recovery is bounded: the worst case is two callers breaking a
-		// lock that is dead either way, and O_EXCL still gives one winner.
+		// which takes microseconds, so an old break file is litter.
+		//
+		// The stat and the remove are bound by os.SameFile for the same
+		// reason the lock's own break is: without it, clearing what looks
+		// like an orphan can delete a break file somebody created in
+		// between, and then two callers are inside the section that exists
+		// to hold one.
 		if info, serr := os.Stat(bp); serr == nil && time.Since(info.ModTime()) > staleAfter {
-			_ = os.Remove(bp)
+			removeIfSame(bp, info)
 		}
 		return false
 	}
 	_ = b.Close()
-	defer func() { _ = os.Remove(bp) }()
+	// The identity of OUR break file, so the deferred remove cannot delete
+	// a later caller's.
+	mine, serr := os.Stat(bp)
+	if serr != nil {
+		_ = os.Remove(bp)
+		return false
+	}
+	defer removeIfSame(bp, mine)
 
 	if !stale(p) {
 		return false
@@ -194,16 +209,36 @@ func breakStale(p, rel string) bool {
 	return true
 }
 
+// removeIfSame deletes p only when it is still the file described by want.
+// Every unguarded stat-then-remove in this package has turned out to be a
+// way for one caller to delete another's file.
+func removeIfSame(p string, want os.FileInfo) {
+	if cur, err := os.Stat(p); err == nil && os.SameFile(cur, want) {
+		_ = os.Remove(p)
+	}
+}
+
 // keepAlive touches the lock while it is held, so a slow write is never
 // mistaken for a dead one.
-func keepAlive(p string, stop <-chan struct{}) {
-	t := time.NewTicker(heartbeatEvery())
+//
+// It stops the moment the file at p is no longer the file we created. If
+// our lock is ever broken — one failed os.Chtimes is enough — carrying on
+// would refresh a STRANGER'S lock for as long as this process lives, and
+// that lock would then never be judged stale even after its own owner
+// died. A heartbeat for a lock we no longer hold is worse than no
+// heartbeat at all.
+func keepAlive(p string, mine os.FileInfo, every time.Duration, stop <-chan struct{}) {
+	t := time.NewTicker(every)
 	defer t.Stop()
 	for {
 		select {
 		case <-stop:
 			return
 		case now := <-t.C:
+			cur, err := os.Stat(p)
+			if err != nil || !os.SameFile(cur, mine) {
+				return
+			}
 			_ = os.Chtimes(p, now, now)
 		}
 	}

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -1,7 +1,7 @@
 // Package store is the one place procoder reads and writes .procoder/.
 //
 // Until now every domain issued its own os.ReadFile and os.WriteFile
-// against its own path constant — twenty-five of them, none locking, none
+// against its own path constant — twenty-six of them, none locking, none
 // atomic. That was correct while procoder was a short-lived process: one
 // hook ran, touched a file, and exited before the next one started. The
 // daemon in #117 ends it. Two sessions writing the same ledger is ordinary
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,16 +31,53 @@ const (
 	// lockDir sits under .procoder/state/, which is already gitignored. A
 	// lock file beside the file it protects would show up in git status
 	// and in review, which is how a lock becomes a diff.
-	lockDir = ".procoder/state/locks"
-	// staleAfter is how long a lock may sit before it is presumed dead. No
-	// write through this package holds a lock for anything like this long;
-	// what takes this long is a process that was killed holding one.
-	staleAfter = 30 * time.Second
-	// lockTimeout bounds the wait. A hook that blocked would take the
-	// session with it, so waiting forever is never an option here.
-	lockTimeout = 5 * time.Second
-	lockRetry   = 10 * time.Millisecond
+	lockDir   = ".procoder/state/locks"
+	lockRetry = 10 * time.Millisecond
+	// breakSuffix names the file that serialises BREAKING a stale lock.
+	// Judging a lock stale and removing it are two operations, and two
+	// callers doing them at once is how both end up holding: the first
+	// removes and re-creates, the second removes what the first just
+	// created. Only the holder of this file may break, so that interleave
+	// cannot happen.
+	breakSuffix = ".break"
 )
+
+// staleAfter is how long a lock may go untouched before it is presumed
+// dead. A HELD lock is touched by its heartbeat every staleAfter/3, so
+// reaching this means the owner stopped running — not that it is slow.
+//
+// A var rather than a const only so a test can shorten it; nothing in
+// procoder changes it at runtime.
+var staleAfter = 30 * time.Second
+
+// heartbeatEvery keeps a held lock looking alive. Without it a write that
+// legitimately takes longer than staleAfter — rewriting a multi-megabyte
+// tags.jsonl on a slow filesystem — would have its lock taken out from
+// under it while it was still writing.
+func heartbeatEvery() time.Duration { return staleAfter / 3 }
+
+// lockTimeout bounds the wait. A hook that blocked would take the session
+// with it, so waiting forever is never an option here.
+//
+// A var rather than a const only so the contention tests can shorten it;
+// six tests waiting out five seconds each is thirty seconds of sleeping in
+// a suite that otherwise runs in two.
+var lockTimeout = 5 * time.Second
+
+// Notice is where the store says it had to break a stale lock. Breaking one
+// means a previous run died holding it, which is worth a human knowing;
+// returning the fact to callers that all discard it would be an honesty
+// channel nobody reads.
+var Notice io.Writer = os.Stderr
+
+// held is one acquired lock: which path, and WHICH FILE — os.SameFile
+// against this is what stops release removing a lock that has since been
+// broken and replaced by somebody else's live one.
+type held struct {
+	rel  string
+	info os.FileInfo
+	stop chan struct{}
+}
 
 // lockPath is where rel's lock lives. The name is a hash because the
 // repo-relative path contains separators, and because a name derived from
@@ -50,98 +88,140 @@ func lockPath(root, rel string) string {
 }
 
 // Lock takes an exclusive lock on each repo-relative path and returns the
-// func that releases them, plus any stale lock it had to break so the
-// caller can report it.
+// func that releases them.
 //
 // The paths are locked in sorted order, always, whatever order the caller
 // asked for. That is the whole deadlock story: two callers wanting the
 // same two files can no longer take them in opposite orders.
 //
-// broken is returned rather than read from a package-level accessor,
-// because concurrent callers would race on shared state — and this package
-// exists precisely because that concurrency is real.
-//
 // On failure nothing is held: locks already taken are released before the
 // error returns, so a caller that gives up does not leave a file locked
 // against everybody else for the next thirty seconds.
-func Lock(root string, relPaths ...string) (release func(), broken []string, err error) {
+func Lock(root string, relPaths ...string) (release func(), err error) {
 	paths := append([]string(nil), relPaths...)
 	sort.Strings(paths)
 
-	var held []string
+	var hs []held
 	rel := func() {
-		for _, p := range held {
-			_ = os.Remove(lockPath(root, p))
+		for _, h := range hs {
+			close(h.stop)
+			p := lockPath(root, h.rel)
+			// Remove only what we actually hold. If this lock was broken
+			// as stale and somebody else's live lock now sits at the same
+			// path, removing it would hand a third caller a lock that is
+			// already held.
+			if cur, err := os.Stat(p); err == nil && os.SameFile(cur, h.info) {
+				_ = os.Remove(p)
+			}
 		}
 	}
 	for _, p := range paths {
-		b, err := acquire(root, p)
-		broken = append(broken, b...)
+		h, err := acquire(root, p)
 		if err != nil {
 			rel()
-			return nil, nil, err
+			return nil, err
 		}
-		held = append(held, p)
+		hs = append(hs, h)
 	}
-	return rel, broken, nil
+	return rel, nil
 }
 
 // acquire takes one lock, breaking a dead one if that is what is in the
 // way, and gives up at the deadline rather than waiting on a live writer
 // forever.
-func acquire(root, rel string) ([]string, error) {
+func acquire(root, rel string) (held, error) {
 	p := lockPath(root, rel)
 	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return nil, fmt.Errorf("procoder: could not create the lock directory for %s (%v) — the write was NOT made", rel, err)
+		return held{}, fmt.Errorf("procoder: could not create the lock directory for %s (%v) — the write was NOT made", rel, err)
 	}
 
-	var broken []string
 	deadline := time.Now().Add(lockTimeout)
 	for {
 		f, err := os.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 		if err == nil {
 			_, werr := fmt.Fprintf(f, "%d\n%d\n", os.Getpid(), time.Now().Unix())
 			cerr := f.Close()
-			if werr != nil || cerr != nil {
+			info, serr := os.Stat(p)
+			if werr != nil || cerr != nil || serr != nil {
 				// A lock nobody can read is one everybody else will break.
 				_ = os.Remove(p)
-				return broken, fmt.Errorf("procoder: could not write the lock for %s — the write was NOT made", rel)
+				return held{}, fmt.Errorf("procoder: could not write the lock for %s — the write was NOT made", rel)
 			}
-			return broken, nil
+			h := held{rel: rel, info: info, stop: make(chan struct{})}
+			go keepAlive(p, h.stop)
+			return h, nil
 		}
 		if !os.IsExist(err) {
-			return broken, fmt.Errorf("procoder: could not lock %s (%v) — the write was NOT made", rel, err)
+			return held{}, fmt.Errorf("procoder: could not lock %s (%v) — the write was NOT made", rel, err)
 		}
 
-		if stale(p) {
-			_ = os.Remove(p)
-			if len(broken) == 0 {
-				broken = append(broken, rel)
-			}
-		} else {
+		if !breakStale(p, rel) {
 			time.Sleep(lockRetry)
 		}
 		if time.Now().After(deadline) {
-			return broken, fmt.Errorf("procoder: could not lock %s within %s — the write was NOT made", rel, lockTimeout)
+			return held{}, fmt.Errorf("procoder: could not lock %s within %s — the write was NOT made", rel, lockTimeout)
+		}
+	}
+}
+
+// breakStale removes the lock at p if it is dead, and reports whether it
+// did. Only one caller at a time may be inside the removal, because
+// judging and removing are two operations and interleaving two of them is
+// how both end up holding.
+func breakStale(p, rel string) bool {
+	bp := p + breakSuffix
+	b, err := os.OpenFile(bp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		// Somebody else is breaking this one — unless they died doing it,
+		// which takes microseconds, so an old break file is litter. The
+		// recovery is bounded: the worst case is two callers breaking a
+		// lock that is dead either way, and O_EXCL still gives one winner.
+		if info, serr := os.Stat(bp); serr == nil && time.Since(info.ModTime()) > staleAfter {
+			_ = os.Remove(bp)
+		}
+		return false
+	}
+	_ = b.Close()
+	defer func() { _ = os.Remove(bp) }()
+
+	if !stale(p) {
+		return false
+	}
+	if os.Remove(p) != nil {
+		return false
+	}
+	fmt.Fprintf(Notice, "procoder: broke a stale lock on %s — a previous run left it behind\n", rel)
+	return true
+}
+
+// keepAlive touches the lock while it is held, so a slow write is never
+// mistaken for a dead one.
+func keepAlive(p string, stop <-chan struct{}) {
+	t := time.NewTicker(heartbeatEvery())
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case now := <-t.C:
+			_ = os.Chtimes(p, now, now)
 		}
 	}
 }
 
 // stale says whether the lock at p can be presumed dead.
 //
-// The file's OWN age is the first test, and it is the one that makes this
-// safe. A lock file is created empty by O_EXCL and only then written, so
-// for a moment every live lock has contents that do not parse. Treating
-// unparsable contents as dead on its own let a second caller steal a
-// newborn lock and gave two holders — the exact defect this package
-// exists to prevent, found by TestConcurrentAppendsBothSurvive.
+// The file's OWN age is the test that matters, and the heartbeat above is
+// what makes it trustworthy: a lock whose owner is running is touched
+// every ten seconds, so one untouched for thirty belongs to a process that
+// is gone.
 //
-// So: old by mtime is dead, whatever it says. Otherwise the contents get
-// a say only when they parse — a recorded time long past, or one in the
-// future (clock skew, a restored backup), is a lock whose owner cannot be
-// believed. Contents that do not parse on a FRESH file are a lock being
-// written this instant, and waiting is correct; if it really is corrupt,
-// mtime condemns it thirty seconds later.
+// The contents get a say only when they parse. A lock file is created
+// empty by O_EXCL and written a moment later, so for that moment every
+// live lock is unparsable; treating that as dead let a second caller steal
+// a newborn lock and gave two holders — found by
+// TestConcurrentAppendsBothSurvive. A genuinely corrupt lock is condemned
+// by its mtime instead, thirty seconds later.
 //
 // A lock that has vanished is NOT stale — it is gone, and the next O_EXCL
 // settles who gets it.
@@ -169,6 +249,14 @@ func stale(p string) bool {
 	if err != nil {
 		return false
 	}
-	age := time.Since(time.Unix(sec, 0))
-	return age > staleAfter || age < 0
+	// The recorded time is when the lock was TAKEN, and nothing refreshes
+	// it — the heartbeat touches the file's mtime, which is the liveness
+	// signal. Ageing the contents as well would condemn every lock whose
+	// owner is still working after staleAfter, which is the case the
+	// heartbeat exists to protect.
+	//
+	// What the contents still answer is a timestamp in the FUTURE: a clock
+	// that moved, or a restored backup. A lock whose owner claims to have
+	// taken it after now cannot be believed about anything.
+	return time.Since(time.Unix(sec, 0)) < 0
 }

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -129,29 +129,45 @@ func acquire(root, rel string) ([]string, error) {
 
 // stale says whether the lock at p can be presumed dead.
 //
-// Three ways, and two of them are about not being able to tell: contents
-// that do not parse, and a timestamp in the future, are both locks whose
-// liveness cannot be established. A lock nobody can interpret cannot be
-// proven live, and treating it as live would wedge the file until somebody
-// deleted it by hand.
+// The file's OWN age is the first test, and it is the one that makes this
+// safe. A lock file is created empty by O_EXCL and only then written, so
+// for a moment every live lock has contents that do not parse. Treating
+// unparsable contents as dead on its own let a second caller steal a
+// newborn lock and gave two holders — the exact defect this package
+// exists to prevent, found by TestConcurrentAppendsBothSurvive.
+//
+// So: old by mtime is dead, whatever it says. Otherwise the contents get
+// a say only when they parse — a recorded time long past, or one in the
+// future (clock skew, a restored backup), is a lock whose owner cannot be
+// believed. Contents that do not parse on a FRESH file are a lock being
+// written this instant, and waiting is correct; if it really is corrupt,
+// mtime condemns it thirty seconds later.
 //
 // A lock that has vanished is NOT stale — it is gone, and the next O_EXCL
 // settles who gets it.
 func stale(p string) bool {
+	info, err := os.Stat(p)
+	if err != nil {
+		return false
+	}
+	if time.Since(info.ModTime()) > staleAfter {
+		return true
+	}
+
 	raw, err := os.ReadFile(p)
 	if err != nil {
 		return false
 	}
 	fields := strings.Fields(string(raw))
 	if len(fields) != 2 {
-		return true
+		return false // being written right now
 	}
 	if _, err := strconv.Atoi(fields[0]); err != nil {
-		return true
+		return false
 	}
 	sec, err := strconv.ParseInt(fields[1], 10, 64)
 	if err != nil {
-		return true
+		return false
 	}
 	age := time.Since(time.Unix(sec, 0))
 	return age > staleAfter || age < 0

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -1,0 +1,158 @@
+// Package store is the one place procoder reads and writes .procoder/.
+//
+// Until now every domain issued its own os.ReadFile and os.WriteFile
+// against its own path constant — twenty-five of them, none locking, none
+// atomic. That was correct while procoder was a short-lived process: one
+// hook ran, touched a file, and exited before the next one started. The
+// daemon in #117 ends it. Two sessions writing the same ledger is ordinary
+// there, and a read-modify-write with no lock loses one of the two updates
+// silently.
+//
+// This file is the lock. It is a lockfile rather than flock because
+// go.mod has no require block and procoder is not spending its first
+// dependency on golang.org/x/sys — which is what a portable
+// flock/LockFileEx pair would cost.
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// lockDir sits under .procoder/state/, which is already gitignored. A
+	// lock file beside the file it protects would show up in git status
+	// and in review, which is how a lock becomes a diff.
+	lockDir = ".procoder/state/locks"
+	// staleAfter is how long a lock may sit before it is presumed dead. No
+	// write through this package holds a lock for anything like this long;
+	// what takes this long is a process that was killed holding one.
+	staleAfter = 30 * time.Second
+	// lockTimeout bounds the wait. A hook that blocked would take the
+	// session with it, so waiting forever is never an option here.
+	lockTimeout = 5 * time.Second
+	lockRetry   = 10 * time.Millisecond
+)
+
+// lockPath is where rel's lock lives. The name is a hash because the
+// repo-relative path contains separators, and because a name derived from
+// user content has to be safe on three filesystems.
+func lockPath(root, rel string) string {
+	sum := sha256.Sum256([]byte(rel))
+	return filepath.Join(root, filepath.FromSlash(lockDir), hex.EncodeToString(sum[:])[:16]+".lock")
+}
+
+// Lock takes an exclusive lock on each repo-relative path and returns the
+// func that releases them, plus any stale lock it had to break so the
+// caller can report it.
+//
+// The paths are locked in sorted order, always, whatever order the caller
+// asked for. That is the whole deadlock story: two callers wanting the
+// same two files can no longer take them in opposite orders.
+//
+// broken is returned rather than read from a package-level accessor,
+// because concurrent callers would race on shared state — and this package
+// exists precisely because that concurrency is real.
+//
+// On failure nothing is held: locks already taken are released before the
+// error returns, so a caller that gives up does not leave a file locked
+// against everybody else for the next thirty seconds.
+func Lock(root string, relPaths ...string) (release func(), broken []string, err error) {
+	paths := append([]string(nil), relPaths...)
+	sort.Strings(paths)
+
+	var held []string
+	rel := func() {
+		for _, p := range held {
+			_ = os.Remove(lockPath(root, p))
+		}
+	}
+	for _, p := range paths {
+		b, err := acquire(root, p)
+		broken = append(broken, b...)
+		if err != nil {
+			rel()
+			return nil, nil, err
+		}
+		held = append(held, p)
+	}
+	return rel, broken, nil
+}
+
+// acquire takes one lock, breaking a dead one if that is what is in the
+// way, and gives up at the deadline rather than waiting on a live writer
+// forever.
+func acquire(root, rel string) ([]string, error) {
+	p := lockPath(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return nil, fmt.Errorf("procoder: could not create the lock directory for %s (%v) — the write was NOT made", rel, err)
+	}
+
+	var broken []string
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		f, err := os.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err == nil {
+			_, werr := fmt.Fprintf(f, "%d\n%d\n", os.Getpid(), time.Now().Unix())
+			cerr := f.Close()
+			if werr != nil || cerr != nil {
+				// A lock nobody can read is one everybody else will break.
+				_ = os.Remove(p)
+				return broken, fmt.Errorf("procoder: could not write the lock for %s — the write was NOT made", rel)
+			}
+			return broken, nil
+		}
+		if !os.IsExist(err) {
+			return broken, fmt.Errorf("procoder: could not lock %s (%v) — the write was NOT made", rel, err)
+		}
+
+		if stale(p) {
+			_ = os.Remove(p)
+			if len(broken) == 0 {
+				broken = append(broken, rel)
+			}
+		} else {
+			time.Sleep(lockRetry)
+		}
+		if time.Now().After(deadline) {
+			return broken, fmt.Errorf("procoder: could not lock %s within %s — the write was NOT made", rel, lockTimeout)
+		}
+	}
+}
+
+// stale says whether the lock at p can be presumed dead.
+//
+// Three ways, and two of them are about not being able to tell: contents
+// that do not parse, and a timestamp in the future, are both locks whose
+// liveness cannot be established. A lock nobody can interpret cannot be
+// proven live, and treating it as live would wedge the file until somebody
+// deleted it by hand.
+//
+// A lock that has vanished is NOT stale — it is gone, and the next O_EXCL
+// settles who gets it.
+func stale(p string) bool {
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return false
+	}
+	fields := strings.Fields(string(raw))
+	if len(fields) != 2 {
+		return true
+	}
+	if _, err := strconv.Atoi(fields[0]); err != nil {
+		return true
+	}
+	sec, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return true
+	}
+	age := time.Since(time.Unix(sec, 0))
+	return age > staleAfter || age < 0
+}

--- a/internal/store/lock.go
+++ b/internal/store/lock.go
@@ -72,6 +72,12 @@ type held struct {
 	rel  string
 	info os.FileInfo
 	stop chan struct{}
+	// done closes when the heartbeat has actually returned. Release waits
+	// for it: on Windows a file cannot be removed while another handle has
+	// it open, and os.Chtimes opens one, so removing while the heartbeat
+	// was mid-tick failed and left the lock behind for the next caller to
+	// wait out.
+	done chan struct{}
 }
 
 // lockPath is where rel's lock lives. The name is a hash because the
@@ -105,14 +111,16 @@ func Lock(root string, relPaths ...string) (release func(), err error) {
 		once.Do(func() {
 			for _, h := range hs {
 				close(h.stop)
+				select {
+				case <-h.done:
+				case <-time.After(2 * time.Second):
+				}
 				p := lockPath(root, h.rel)
 				// Remove only what we actually hold. If this lock was
 				// broken as stale and somebody else's live lock now sits
 				// at the same path, removing it would hand a third caller
 				// a lock that is already held.
-				if cur, err := os.Stat(p); err == nil && os.SameFile(cur, h.info) {
-					_ = os.Remove(p)
-				}
+				removeIfSame(p, h.info)
 			}
 		})
 	}
@@ -137,6 +145,7 @@ func acquire(root, rel string) (held, error) {
 	}
 
 	deadline := time.Now().Add(lockTimeout)
+	var lastErr error
 	for {
 		f, err := os.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 		if err == nil {
@@ -148,21 +157,30 @@ func acquire(root, rel string) (held, error) {
 				_ = os.Remove(p)
 				return held{}, fmt.Errorf("procoder: could not write the lock for %s — the write was NOT made", rel)
 			}
-			h := held{rel: rel, info: info, stop: make(chan struct{})}
+			h := held{rel: rel, info: info, stop: make(chan struct{}), done: make(chan struct{})}
 			// The tick is read HERE, on the caller's goroutine. Reading
 			// staleAfter inside keepAlive raced every test that restores
 			// it, and `go test -race` said so.
-			go keepAlive(p, info, staleAfter/3, h.stop)
+			go keepAlive(p, info, staleAfter/3, h.stop, h.done)
 			return h, nil
 		}
-		if !os.IsExist(err) {
-			return held{}, fmt.Errorf("procoder: could not lock %s (%v) — the write was NOT made", rel, err)
-		}
-
-		if !breakStale(p, rel) {
+		// A create that failed is not proof the lock is unobtainable —
+		// only the deadline is. Windows reports a file that is pending
+		// deletion as "Access is denied" rather than "already exists", so
+		// treating anything but IsExist as fatal turned ordinary
+		// contention into a hard failure there. CI on windows-latest is
+		// what said so; ubuntu and macOS never saw it.
+		lastErr = err
+		if !os.IsExist(err) || !breakStale(p, rel) {
 			time.Sleep(lockRetry)
 		}
 		if time.Now().After(deadline) {
+			// The cause is worth carrying when it is NOT plain contention;
+			// a permissions problem that spent the whole deadline should
+			// not read the same as a busy file.
+			if !os.IsExist(lastErr) {
+				return held{}, fmt.Errorf("procoder: could not lock %s within %s (%v) — the write was NOT made", rel, lockTimeout, lastErr)
+			}
 			return held{}, fmt.Errorf("procoder: could not lock %s within %s — the write was NOT made", rel, lockTimeout)
 		}
 	}
@@ -213,8 +231,18 @@ func breakStale(p, rel string) bool {
 // Every unguarded stat-then-remove in this package has turned out to be a
 // way for one caller to delete another's file.
 func removeIfSame(p string, want os.FileInfo) {
-	if cur, err := os.Stat(p); err == nil && os.SameFile(cur, want) {
-		_ = os.Remove(p)
+	cur, err := os.Stat(p)
+	if err != nil || !os.SameFile(cur, want) {
+		return
+	}
+	// Retried, because Windows refuses to remove a file another handle
+	// still has open and a lock left behind costs the next caller the
+	// whole acquire timeout.
+	for i := 0; i < 20; i++ {
+		if os.Remove(p) == nil {
+			return
+		}
+		time.Sleep(lockRetry)
 	}
 }
 
@@ -227,7 +255,8 @@ func removeIfSame(p string, want os.FileInfo) {
 // that lock would then never be judged stale even after its own owner
 // died. A heartbeat for a lock we no longer hold is worse than no
 // heartbeat at all.
-func keepAlive(p string, mine os.FileInfo, every time.Duration, stop <-chan struct{}) {
+func keepAlive(p string, mine os.FileInfo, every time.Duration, stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
 	t := time.NewTicker(every)
 	defer t.Stop()
 	for {

--- a/internal/store/lock_test.go
+++ b/internal/store/lock_test.go
@@ -49,8 +49,13 @@ func TestStaleLockIsBrokenAndReported(t *testing.T) {
 	}
 }
 
-// proved by: dropping either the parse check or the future check leaves that
-// case waiting out the full timeout instead of taking the lock.
+// proved by: dropping the mtime clause or the future check leaves that case
+// waiting out the full timeout instead of taking the lock.
+//
+// The unparsable case is planted with an OLD mtime deliberately. A lock file
+// is created empty and written a moment later, so unparsable contents on a
+// fresh file mean "being written now", not "dead" — treating those as dead
+// gave two holders of one lock.
 func TestUnreadableLockIsStale(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -67,6 +72,12 @@ func TestUnreadableLockIsStale(t *testing.T) {
 			}
 			if err := os.WriteFile(p, []byte(tc.body), 0o644); err != nil {
 				t.Fatal(err)
+			}
+			if tc.name == "unparsable" {
+				old := time.Now().Add(-31 * time.Second)
+				if err := os.Chtimes(p, old, old); err != nil {
+					t.Fatal(err)
+				}
 			}
 			rel, broken, err := Lock(root, ".procoder/state/dispatch.json")
 			if err != nil {
@@ -143,4 +154,25 @@ func TestPartialAcquisitionReleasesWhatItTook(t *testing.T) {
 		t.Fatalf("the first path was left locked after a failed multi-lock: %v", err)
 	}
 	rel()
+}
+
+// proved by: treating unparsable contents as stale regardless of the file's
+// age lets a caller steal a lock that was created a microsecond ago and is
+// still being written. Two holders of one lock is the defect this package
+// exists to remove, so it gets its own test rather than only showing up as a
+// lost append somewhere downstream.
+func TestNewbornLockIsNotStolen(t *testing.T) {
+	root := t.TempDir()
+	p := lockPath(root, ".procoder/state/dispatch.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// exactly what O_EXCL leaves behind for the moment before the pid and
+	// timestamp are written
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if stale(p) {
+		t.Fatal("an empty, freshly created lock was judged stale — a live lock can be stolen mid-write")
+	}
 }

--- a/internal/store/lock_test.go
+++ b/internal/store/lock_test.go
@@ -17,6 +17,14 @@ import (
 // made to wait it out. Six tests each sleeping five real seconds is thirty
 // seconds of a suite that otherwise runs in two, and the number under test
 // is the behaviour at the deadline, not the deadline itself.
+// TestMain silences the break notice for the whole package. Setting it
+// per test raced the tests that restore it against anything still holding
+// a lock, and `go test -race` said so.
+func TestMain(m *testing.M) {
+	Notice = io.Discard
+	os.Exit(m.Run())
+}
+
 func impatient(t *testing.T) {
 	t.Helper()
 	was := lockTimeout
@@ -64,7 +72,7 @@ func TestStaleLockIsBrokenAndReported(t *testing.T) {
 	plant(t, root, ".procoder/state/dispatch.json", os.Getpid(), time.Now().Add(-31*time.Second).Unix())
 	var notice bytes.Buffer
 	Notice = &notice
-	t.Cleanup(func() { Notice = os.Stderr })
+	t.Cleanup(func() { Notice = io.Discard })
 
 	rel, err := Lock(root, ".procoder/state/dispatch.json")
 	if err != nil {
@@ -204,10 +212,17 @@ func TestNewbornLockIsNotStolen(t *testing.T) {
 }
 
 // brief shortens the staleness window so a test can outlive it.
+//
+// Three seconds, not sixty milliseconds. os.Chtimes stores a TRUNCATED
+// time on HFS+, exFAT and several container overlay filesystems — one or
+// two seconds of granularity — so a lock touched a moment ago can read as
+// nearly a second old, and a sub-second window would fail there for a
+// reason nobody changed. The six seconds of sleeping this was meant to
+// save is in lockTimeout, which impatient() handles.
 func brief(t *testing.T) {
 	t.Helper()
 	was := staleAfter
-	staleAfter = 60 * time.Millisecond
+	staleAfter = 3 * time.Second
 	t.Cleanup(func() { staleAfter = was })
 }
 
@@ -228,9 +243,6 @@ func TestOnlyOneCallerEverHoldsALock(t *testing.T) {
 	// A dead lock in the way, so every caller arrives at the break path
 	// together rather than one of them simply winning O_EXCL.
 	plant(t, root, rel, os.Getpid(), time.Now().Add(-31*time.Second).Unix())
-	Notice = io.Discard
-	t.Cleanup(func() { Notice = os.Stderr })
-
 	var holders int32
 	var worst int32
 	var wg sync.WaitGroup
@@ -275,9 +287,8 @@ func TestAHeldLockIsNotBrokenWhileItsOwnerWorks(t *testing.T) {
 	}
 	defer release()
 
-	// Outlive the staleness window several times over, the way a slow
-	// write does.
-	time.Sleep(4 * staleAfter)
+	// Outlive the staleness window, the way a slow write does.
+	time.Sleep(2 * staleAfter)
 
 	if _, err := Lock(root, rel); err == nil {
 		t.Fatal("a lock held by a live, working owner was broken as stale")
@@ -342,9 +353,6 @@ func TestAnOrphanedBreakFileIsCleared(t *testing.T) {
 	if err := os.Chtimes(bp, old, old); err != nil {
 		t.Fatal(err)
 	}
-	Notice = io.Discard
-	t.Cleanup(func() { Notice = os.Stderr })
-
 	release, err := Lock(root, rel)
 	if err != nil {
 		t.Fatalf("an orphaned break file wedged the path: %v", err)

--- a/internal/store/lock_test.go
+++ b/internal/store/lock_test.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// plant writes a lock file for rel with the given pid and unix time, so a
+// test can stage the exact state the stale check has to judge.
+func plant(t *testing.T, root, rel string, pid int, unix int64) {
+	t.Helper()
+	p := lockPath(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(fmt.Sprintf("%d\n%d\n", pid, unix)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// proved by: dropping the O_EXCL flag makes the second Lock succeed.
+func TestLockIsExclusive(t *testing.T) {
+	root := t.TempDir()
+	rel, _, err := Lock(root, ".procoder/state/dispatch.json")
+	if err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+	defer rel()
+	if _, _, err := Lock(root, ".procoder/state/dispatch.json"); err == nil {
+		t.Fatal("second lock succeeded while the first was held")
+	}
+}
+
+// proved by: removing the age check leaves the lock held and the write refused.
+func TestStaleLockIsBrokenAndReported(t *testing.T) {
+	root := t.TempDir()
+	plant(t, root, ".procoder/state/dispatch.json", os.Getpid(), time.Now().Add(-31*time.Second).Unix())
+	rel, broken, err := Lock(root, ".procoder/state/dispatch.json")
+	if err != nil {
+		t.Fatalf("stale lock was not broken: %v", err)
+	}
+	defer rel()
+	if len(broken) != 1 || !strings.Contains(broken[0], "dispatch.json") {
+		t.Fatalf("breaking the lock was not reported: %v", broken)
+	}
+}
+
+// proved by: dropping either the parse check or the future check leaves that
+// case waiting out the full timeout instead of taking the lock.
+func TestUnreadableLockIsStale(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"unparsable", "not a lock\n"},
+		{"future", fmt.Sprintf("%d\n%d\n", os.Getpid(), time.Now().Add(time.Hour).Unix())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			p := lockPath(root, ".procoder/state/dispatch.json")
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			rel, broken, err := Lock(root, ".procoder/state/dispatch.json")
+			if err != nil {
+				t.Fatalf("lock was not treated as stale: %v", err)
+			}
+			defer rel()
+			if len(broken) != 1 {
+				t.Fatalf("breaking the lock was not reported: %v", broken)
+			}
+		})
+	}
+}
+
+// proved by: removing the deadline from the retry loop makes this hang rather
+// than fail, which is the failure a hook must never be able to cause.
+func TestLiveLockRefusesRatherThanBlocks(t *testing.T) {
+	root := t.TempDir()
+	plant(t, root, ".procoder/state/dispatch.json", os.Getpid(), time.Now().Unix())
+	start := time.Now()
+	_, _, err := Lock(root, ".procoder/state/dispatch.json")
+	if err == nil {
+		t.Fatal("write proceeded while a live lock was held")
+	}
+	if d := time.Since(start); d > 8*time.Second {
+		t.Fatalf("Lock blocked for %v, past its 5s timeout", d)
+	}
+	if !strings.Contains(err.Error(), ".procoder/state/dispatch.json") {
+		t.Fatalf("error does not name the file: %v", err)
+	}
+}
+
+// proved by: locking in the order the caller asked, rather than sorted, makes
+// the two goroutines deadlock and the timeout fire.
+func TestLockOrderIsSortedPaths(t *testing.T) {
+	root := t.TempDir()
+	a, b := ".procoder/backlog/stories/s1.md", ".procoder/backlog/sprints/001.md"
+	done := make(chan error, 2)
+	for _, pair := range [][2]string{{a, b}, {b, a}} {
+		go func(p [2]string) {
+			for i := 0; i < 50; i++ {
+				rel, _, err := Lock(root, p[0], p[1])
+				if err != nil {
+					done <- err
+					return
+				}
+				rel()
+			}
+			done <- nil
+		}(pair)
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("lock failed: %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("deadlock: locks were not taken in sorted order")
+		}
+	}
+}
+
+// proved by: returning early on the first failure, without releasing what was
+// already taken, leaves the first path locked and this fails.
+func TestPartialAcquisitionReleasesWhatItTook(t *testing.T) {
+	root := t.TempDir()
+	first, second := ".procoder/a.md", ".procoder/b.md"
+	plant(t, root, second, os.Getpid(), time.Now().Unix()) // live, will not yield
+	if _, _, err := Lock(root, first, second); err == nil {
+		t.Fatal("Lock succeeded though the second path was held")
+	}
+	rel, _, err := Lock(root, first)
+	if err != nil {
+		t.Fatalf("the first path was left locked after a failed multi-lock: %v", err)
+	}
+	rel()
+}

--- a/internal/store/lock_test.go
+++ b/internal/store/lock_test.go
@@ -1,13 +1,28 @@
 package store
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// impatient shortens the acquire timeout for a test that is deliberately
+// made to wait it out. Six tests each sleeping five real seconds is thirty
+// seconds of a suite that otherwise runs in two, and the number under test
+// is the behaviour at the deadline, not the deadline itself.
+func impatient(t *testing.T) {
+	t.Helper()
+	was := lockTimeout
+	lockTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { lockTimeout = was })
+}
 
 // plant writes a lock file for rel with the given pid and unix time, so a
 // test can stage the exact state the stale check has to judge.
@@ -20,17 +35,25 @@ func plant(t *testing.T, root, rel string, pid int, unix int64) {
 	if err := os.WriteFile(p, []byte(fmt.Sprintf("%d\n%d\n", pid, unix)), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// The file's mtime is the liveness signal, so a lock planted as having
+	// been taken N seconds ago must LOOK N seconds old. Writing fresh bytes
+	// with an old timestamp inside would be a lock no real run produces.
+	at := time.Unix(unix, 0)
+	if err := os.Chtimes(p, at, at); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // proved by: dropping the O_EXCL flag makes the second Lock succeed.
 func TestLockIsExclusive(t *testing.T) {
+	impatient(t)
 	root := t.TempDir()
-	rel, _, err := Lock(root, ".procoder/state/dispatch.json")
+	rel, err := Lock(root, ".procoder/state/dispatch.json")
 	if err != nil {
 		t.Fatalf("first lock: %v", err)
 	}
 	defer rel()
-	if _, _, err := Lock(root, ".procoder/state/dispatch.json"); err == nil {
+	if _, err := Lock(root, ".procoder/state/dispatch.json"); err == nil {
 		t.Fatal("second lock succeeded while the first was held")
 	}
 }
@@ -39,13 +62,17 @@ func TestLockIsExclusive(t *testing.T) {
 func TestStaleLockIsBrokenAndReported(t *testing.T) {
 	root := t.TempDir()
 	plant(t, root, ".procoder/state/dispatch.json", os.Getpid(), time.Now().Add(-31*time.Second).Unix())
-	rel, broken, err := Lock(root, ".procoder/state/dispatch.json")
+	var notice bytes.Buffer
+	Notice = &notice
+	t.Cleanup(func() { Notice = os.Stderr })
+
+	rel, err := Lock(root, ".procoder/state/dispatch.json")
 	if err != nil {
 		t.Fatalf("stale lock was not broken: %v", err)
 	}
 	defer rel()
-	if len(broken) != 1 || !strings.Contains(broken[0], "dispatch.json") {
-		t.Fatalf("breaking the lock was not reported: %v", broken)
+	if !strings.Contains(notice.String(), "dispatch.json") {
+		t.Fatalf("breaking the lock was not reported: %q", notice.String())
 	}
 }
 
@@ -79,14 +106,11 @@ func TestUnreadableLockIsStale(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			rel, broken, err := Lock(root, ".procoder/state/dispatch.json")
+			rel, err := Lock(root, ".procoder/state/dispatch.json")
 			if err != nil {
 				t.Fatalf("lock was not treated as stale: %v", err)
 			}
 			defer rel()
-			if len(broken) != 1 {
-				t.Fatalf("breaking the lock was not reported: %v", broken)
-			}
 		})
 	}
 }
@@ -94,10 +118,11 @@ func TestUnreadableLockIsStale(t *testing.T) {
 // proved by: removing the deadline from the retry loop makes this hang rather
 // than fail, which is the failure a hook must never be able to cause.
 func TestLiveLockRefusesRatherThanBlocks(t *testing.T) {
+	impatient(t)
 	root := t.TempDir()
 	plant(t, root, ".procoder/state/dispatch.json", os.Getpid(), time.Now().Unix())
 	start := time.Now()
-	_, _, err := Lock(root, ".procoder/state/dispatch.json")
+	_, err := Lock(root, ".procoder/state/dispatch.json")
 	if err == nil {
 		t.Fatal("write proceeded while a live lock was held")
 	}
@@ -118,7 +143,7 @@ func TestLockOrderIsSortedPaths(t *testing.T) {
 	for _, pair := range [][2]string{{a, b}, {b, a}} {
 		go func(p [2]string) {
 			for i := 0; i < 50; i++ {
-				rel, _, err := Lock(root, p[0], p[1])
+				rel, err := Lock(root, p[0], p[1])
 				if err != nil {
 					done <- err
 					return
@@ -143,13 +168,14 @@ func TestLockOrderIsSortedPaths(t *testing.T) {
 // proved by: returning early on the first failure, without releasing what was
 // already taken, leaves the first path locked and this fails.
 func TestPartialAcquisitionReleasesWhatItTook(t *testing.T) {
+	impatient(t)
 	root := t.TempDir()
 	first, second := ".procoder/a.md", ".procoder/b.md"
 	plant(t, root, second, os.Getpid(), time.Now().Unix()) // live, will not yield
-	if _, _, err := Lock(root, first, second); err == nil {
+	if _, err := Lock(root, first, second); err == nil {
 		t.Fatal("Lock succeeded though the second path was held")
 	}
-	rel, _, err := Lock(root, first)
+	rel, err := Lock(root, first)
 	if err != nil {
 		t.Fatalf("the first path was left locked after a failed multi-lock: %v", err)
 	}
@@ -175,4 +201,153 @@ func TestNewbornLockIsNotStolen(t *testing.T) {
 	if stale(p) {
 		t.Fatal("an empty, freshly created lock was judged stale — a live lock can be stolen mid-write")
 	}
+}
+
+// brief shortens the staleness window so a test can outlive it.
+func brief(t *testing.T) {
+	t.Helper()
+	was := staleAfter
+	staleAfter = 60 * time.Millisecond
+	t.Cleanup(func() { staleAfter = was })
+}
+
+// TestOnlyOneCallerEverHoldsALock is the test for the defect that review
+// found and this package exists to prevent.
+//
+// Judging a lock stale and removing it are two operations. Without
+// serialising them, two callers that both judge the same lock stale
+// interleave: the first removes and re-creates, the second removes what
+// the first just created and creates its own. Both then hold, and the
+// second's write lands on top of the first's.
+//
+// proved by: replacing breakStale's O_EXCL break file with a plain
+// stat-then-remove makes this fail with "2 callers held the lock at once".
+func TestOnlyOneCallerEverHoldsALock(t *testing.T) {
+	root := t.TempDir()
+	const rel = ".procoder/state/dispatch.json"
+	// A dead lock in the way, so every caller arrives at the break path
+	// together rather than one of them simply winning O_EXCL.
+	plant(t, root, rel, os.Getpid(), time.Now().Add(-31*time.Second).Unix())
+	Notice = io.Discard
+	t.Cleanup(func() { Notice = os.Stderr })
+
+	var holders int32
+	var worst int32
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := Lock(root, rel)
+			if err != nil {
+				return // losing the race is fine; holding it together is not
+			}
+			n := atomic.AddInt32(&holders, 1)
+			for {
+				w := atomic.LoadInt32(&worst)
+				if n <= w || atomic.CompareAndSwapInt32(&worst, w, n) {
+					break
+				}
+			}
+			time.Sleep(2 * time.Millisecond)
+			atomic.AddInt32(&holders, -1)
+			release()
+		}()
+	}
+	wg.Wait()
+	if worst > 1 {
+		t.Fatalf("%d callers held the lock at once", worst)
+	}
+}
+
+// proved by: without the heartbeat the mtime is set once at creation, so a
+// write that legitimately runs longer than staleAfter has its lock taken
+// out from under it while it is still writing.
+func TestAHeldLockIsNotBrokenWhileItsOwnerWorks(t *testing.T) {
+	brief(t)
+	impatient(t)
+	root := t.TempDir()
+	const rel = ".procoder/state/claims.json"
+
+	release, err := Lock(root, rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	// Outlive the staleness window several times over, the way a slow
+	// write does.
+	time.Sleep(4 * staleAfter)
+
+	if _, err := Lock(root, rel); err == nil {
+		t.Fatal("a lock held by a live, working owner was broken as stale")
+	}
+}
+
+// TestBreakingAStaleLockIsSerialised is the real proof for the defect
+// review found; TestOnlyOneCallerEverHoldsALock above is a stress test and
+// is honestly NOT proof, because the window it hunts is two syscalls wide
+// and sixteen goroutines rarely land inside it.
+//
+// The defect: judging a lock stale and removing it are two operations.
+// Two callers that both judge the same lock stale interleave — the first
+// removes and re-creates, the second removes what the first just created —
+// and both then hold. The fix is that only the holder of the break file
+// may remove, so the second caller never reaches its remove.
+//
+// proved by: removing the break file's O_EXCL guard makes this test break
+// the lock anyway and fail.
+func TestBreakingAStaleLockIsSerialised(t *testing.T) {
+	impatient(t)
+	root := t.TempDir()
+	const rel = ".procoder/state/dispatch.json"
+	plant(t, root, rel, os.Getpid(), time.Now().Add(-31*time.Second).Unix())
+
+	// Somebody else is already inside the break.
+	bp := lockPath(root, rel) + breakSuffix
+	if err := os.WriteFile(bp, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Lock(root, rel); err == nil {
+		t.Fatal("broke a stale lock while another caller was already breaking it — two callers can hold")
+	}
+
+	// And once that caller is done, the stale lock is breakable again.
+	if err := os.Remove(bp); err != nil {
+		t.Fatal(err)
+	}
+	Notice = io.Discard
+	t.Cleanup(func() { Notice = os.Stderr })
+	release, err := Lock(root, rel)
+	if err != nil {
+		t.Fatalf("the stale lock was not breakable once the break file went: %v", err)
+	}
+	release()
+}
+
+// proved by: never clearing an orphaned break file wedges the path — no
+// caller can ever break the stale lock behind it, and every write to that
+// file fails until somebody deletes it by hand.
+func TestAnOrphanedBreakFileIsCleared(t *testing.T) {
+	root := t.TempDir()
+	const rel = ".procoder/state/dispatch.json"
+	plant(t, root, rel, os.Getpid(), time.Now().Add(-31*time.Second).Unix())
+
+	bp := lockPath(root, rel) + breakSuffix
+	if err := os.WriteFile(bp, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-31 * time.Second)
+	if err := os.Chtimes(bp, old, old); err != nil {
+		t.Fatal(err)
+	}
+	Notice = io.Discard
+	t.Cleanup(func() { Notice = os.Stderr })
+
+	release, err := Lock(root, rel)
+	if err != nil {
+		t.Fatalf("an orphaned break file wedged the path: %v", err)
+	}
+	release()
 }

--- a/internal/store/lock_test.go
+++ b/internal/store/lock_test.go
@@ -359,3 +359,58 @@ func TestAnOrphanedBreakFileIsCleared(t *testing.T) {
 	}
 	release()
 }
+
+// TestStalenessHasMarginForCoarseMtime pins the relationship that makes
+// mtime-only liveness safe on a filesystem that stores a truncated time.
+//
+// HFS+, exFAT and several container overlay filesystems keep mtime to one
+// or two second granularity, so a lock touched a moment ago can READ as up
+// to that much older than it is. The heartbeat refreshes every
+// staleAfter/3, so the worst observed age of a live lock is one heartbeat
+// interval plus one granularity — and that has to stay comfortably under
+// staleAfter or a live lock gets broken on those filesystems.
+//
+// This is an invariant test, not a filesystem test: it cannot prove
+// behaviour on a filesystem this machine does not have. What it does is
+// stop somebody shortening staleAfter, or lengthening the heartbeat,
+// without noticing that the margin went with it.
+//
+// proved by: setting staleAfter to 3s — the value brief() uses — fails it,
+// which is why brief() is confined to tests that hold a lock briefly.
+func TestStalenessHasMarginForCoarseMtime(t *testing.T) {
+	const worstGranularity = 2 * time.Second
+	worstObserved := staleAfter/3 + worstGranularity
+	if worstObserved*2 > staleAfter {
+		t.Fatalf("a live lock can read as %v old against a %v window — too little margin for a filesystem with %v mtime granularity",
+			worstObserved, staleAfter, worstGranularity)
+	}
+}
+
+// proved by: comparing against a timestamp stored INSIDE the lock rather
+// than the file's mtime makes a truncated mtime irrelevant and this test
+// vacuous — which is what the check did before the heartbeat landed.
+func TestATruncatedMtimeDoesNotCondemnALiveLock(t *testing.T) {
+	root := t.TempDir()
+	const rel = ".procoder/state/dispatch.json"
+	release, err := Lock(root, rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	// What a coarse filesystem stores: the same instant, rounded down to a
+	// two-second boundary.
+	p := lockPath(root, rel)
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coarse := info.ModTime().Truncate(2 * time.Second)
+	if err := os.Chtimes(p, coarse, coarse); err != nil {
+		t.Fatal(err)
+	}
+
+	if stale(p) {
+		t.Fatal("a live lock whose mtime was truncated to a 2s boundary was judged stale")
+	}
+}

--- a/internal/store/owners_test.go
+++ b/internal/store/owners_test.go
@@ -1,0 +1,25 @@
+package store_test
+
+import (
+	"testing"
+
+	"procoder/internal/hook"
+	"procoder/internal/learn"
+	"procoder/internal/store"
+)
+
+// proved by: letting a package declare its own copy of a path the store
+// also declares lets the two drift, and the drift is silent until one
+// writes where the other no longer reads.
+//
+// Most owners now NAME the store's constant, which makes drift impossible
+// rather than merely detectable. These two compose theirs from parts, so
+// they get a test instead.
+func TestComposedStatePathsMatchTheStore(t *testing.T) {
+	if got := learn.Dir + "/" + learn.File; got != store.LearnPath {
+		t.Errorf("learn writes %q, the store reads %q", got, store.LearnPath)
+	}
+	if got := hook.StateDir + "/" + hook.HandoffFile; got != store.HandoffPath {
+		t.Errorf("the stop hook writes %q, the store reads %q", got, store.HandoffPath)
+	}
+}

--- a/internal/store/state.go
+++ b/internal/store/state.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// The five gitignored state owners, named here rather than in each owning
+// package so one place knows what procoder's session state consists of.
+// These are the files the daemon will serialise; the paths themselves do
+// not move.
+const (
+	dispatchPath = ".procoder/state/dispatch.json"
+	claimsPath   = ".procoder/state/claims.json"
+	envPath      = ".procoder/state/env.json"
+	learnPath    = ".procoder/state/learn.jsonl"
+	handoffPath  = ".procoder/state/handoff.md"
+	markerDir    = ".procoder/state"
+)
+
+// LoadDispatch reads the parallel-dispatch ledger.
+func LoadDispatch(root string) ([]byte, error) { return ReadFile(root, dispatchPath) }
+
+// SaveDispatch replaces the parallel-dispatch ledger.
+func SaveDispatch(root string, data []byte) error { return save(root, dispatchPath, data) }
+
+// LoadClaims reads the work-claims ledger.
+func LoadClaims(root string) ([]byte, error) { return ReadFile(root, claimsPath) }
+
+// SaveClaims replaces the work-claims ledger.
+func SaveClaims(root string, data []byte) error { return save(root, claimsPath, data) }
+
+// LoadEnvState reads the environment baseline.
+func LoadEnvState(root string) ([]byte, error) { return ReadFile(root, envPath) }
+
+// SaveEnvState replaces the environment baseline.
+func SaveEnvState(root string, data []byte) error { return save(root, envPath, data) }
+
+// LoadLearn reads the timing records.
+func LoadLearn(root string) ([]byte, error) { return ReadFile(root, learnPath) }
+
+// AppendLearn adds one record line.
+//
+// Read, append, write under one lock rather than an O_APPEND handle. An
+// O_APPEND write is atomic only up to the pipe buffer and only on some
+// filesystems, and "usually" is not a property a measurement can be built
+// on — a lost record is a measurement that quietly understates itself.
+func AppendLearn(root string, line []byte) error {
+	release, _, err := Lock(root, learnPath)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	old, err := ReadFile(root, learnPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("procoder: could not read %s (%v) — the record was NOT appended", learnPath, err)
+	}
+	return WriteFile(root, learnPath, append(old, line...), 0o644)
+}
+
+// LoadHandoff reads the session handoff note.
+func LoadHandoff(root string) ([]byte, error) { return ReadFile(root, handoffPath) }
+
+// SaveHandoff replaces the session handoff note.
+func SaveHandoff(root string, data []byte) error { return save(root, handoffPath, data) }
+
+// LoadMarker reads one of the small single-line markers beside the handoff
+// note — last-decisions-digest, last-unasked-decision.
+func LoadMarker(root, name string) ([]byte, error) {
+	p, err := markerPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return ReadFile(root, p)
+}
+
+// SaveMarker replaces one of those markers.
+func SaveMarker(root, name string, data []byte) error {
+	p, err := markerPath(name)
+	if err != nil {
+		return err
+	}
+	return save(root, p, data)
+}
+
+// markerPath refuses a name that is a path.
+//
+// A marker is named by a file name, not by a location, and joining an
+// unchecked name would let ".." walk out of .procoder/state and overwrite
+// whatever it found. Nothing in procoder passes a hostile name today; this
+// costs one comparison and removes the question.
+func markerPath(name string) (string, error) {
+	if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return "", errors.New("procoder: a marker is named by a file name, not a path: " + name)
+	}
+	return markerDir + "/" + name, nil
+}
+
+// save is the shape every state write shares: take the file's lock, replace
+// it atomically, release.
+//
+// Reads deliberately do NOT lock. The atomic rename means a reader always
+// sees a whole file, which is the property that matters, and a reader that
+// waited on a writer would put the gate's slowest write on the hot path of
+// every hook.
+func save(root, relPath string, data []byte) error {
+	release, _, err := Lock(root, relPath)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return WriteFile(root, relPath, data, 0o644)
+}

--- a/internal/store/state.go
+++ b/internal/store/state.go
@@ -49,7 +49,7 @@ func LoadLearn(root string) ([]byte, error) { return ReadFile(root, LearnPath) }
 // O_APPEND under the lock, not a read-modify-write. The lock is what makes
 // the append safe now, so rewriting the whole file to add one line would
 // buy nothing and cost everything: learn.Append runs on EVERY procoder
-// invocation, the record file is never trimmed, and a full rewrite would
+// invocation, the record file has no bound today (see the open todo), and a full rewrite would
 // make each command pay for the length of its own history.
 func AppendLearn(root string, line []byte) error {
 	release, err := Lock(root, LearnPath)
@@ -106,8 +106,10 @@ func SaveMarker(root, name string, data []byte) error {
 // marker is a file in .procoder/state and nothing more.
 func markerPath(name string) (string, error) { return inDir(StateDir, name) }
 
-// save is the shape every state write shares: take the file's lock, replace
-// it atomically, release.
+// save is the shape EVERY write in this package shares — state and content
+// alike: take the file's lock, replace it atomically, release. Per file,
+// not per directory, so two people editing two different stories have no
+// reason to wait for each other.
 //
 // Reads deliberately do NOT lock. The atomic rename means a reader always
 // sees a whole file, which is the property that matters, and a reader that

--- a/internal/store/state.go
+++ b/internal/store/state.go
@@ -1,10 +1,9 @@
 package store
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"strings"
+	"path/filepath"
 )
 
 // The five gitignored state owners, named here rather than in each owning
@@ -12,60 +11,77 @@ import (
 // These are the files the daemon will serialise; the paths themselves do
 // not move.
 const (
-	dispatchPath = ".procoder/state/dispatch.json"
-	claimsPath   = ".procoder/state/claims.json"
-	envPath      = ".procoder/state/env.json"
-	learnPath    = ".procoder/state/learn.jsonl"
-	handoffPath  = ".procoder/state/handoff.md"
-	markerDir    = ".procoder/state"
+	// StateDir and the paths under it are exported so the packages that
+	// own this data can NAME the same string rather than declare their own
+	// copy of it. Two declarations of one path drift, and the drift is
+	// silent until one writes where the other no longer reads.
+	StateDir     = ".procoder/state"
+	DispatchPath = StateDir + "/dispatch.json"
+	ClaimsPath   = StateDir + "/claims.json"
+	EnvPath      = StateDir + "/env.json"
+	LearnPath    = StateDir + "/learn.jsonl"
+	HandoffPath  = StateDir + "/handoff.md"
 )
 
 // LoadDispatch reads the parallel-dispatch ledger.
-func LoadDispatch(root string) ([]byte, error) { return ReadFile(root, dispatchPath) }
+func LoadDispatch(root string) ([]byte, error) { return ReadFile(root, DispatchPath) }
 
 // SaveDispatch replaces the parallel-dispatch ledger.
-func SaveDispatch(root string, data []byte) error { return save(root, dispatchPath, data) }
+func SaveDispatch(root string, data []byte) error { return save(root, DispatchPath, data) }
 
 // LoadClaims reads the work-claims ledger.
-func LoadClaims(root string) ([]byte, error) { return ReadFile(root, claimsPath) }
+func LoadClaims(root string) ([]byte, error) { return ReadFile(root, ClaimsPath) }
 
 // SaveClaims replaces the work-claims ledger.
-func SaveClaims(root string, data []byte) error { return save(root, claimsPath, data) }
+func SaveClaims(root string, data []byte) error { return save(root, ClaimsPath, data) }
 
 // LoadEnvState reads the environment baseline.
-func LoadEnvState(root string) ([]byte, error) { return ReadFile(root, envPath) }
+func LoadEnvState(root string) ([]byte, error) { return ReadFile(root, EnvPath) }
 
 // SaveEnvState replaces the environment baseline.
-func SaveEnvState(root string, data []byte) error { return save(root, envPath, data) }
+func SaveEnvState(root string, data []byte) error { return save(root, EnvPath, data) }
 
 // LoadLearn reads the timing records.
-func LoadLearn(root string) ([]byte, error) { return ReadFile(root, learnPath) }
+func LoadLearn(root string) ([]byte, error) { return ReadFile(root, LearnPath) }
 
 // AppendLearn adds one record line.
 //
-// Read, append, write under one lock rather than an O_APPEND handle. An
-// O_APPEND write is atomic only up to the pipe buffer and only on some
-// filesystems, and "usually" is not a property a measurement can be built
-// on — a lost record is a measurement that quietly understates itself.
+// O_APPEND under the lock, not a read-modify-write. The lock is what makes
+// the append safe now, so rewriting the whole file to add one line would
+// buy nothing and cost everything: learn.Append runs on EVERY procoder
+// invocation, the record file is never trimmed, and a full rewrite would
+// make each command pay for the length of its own history.
 func AppendLearn(root string, line []byte) error {
-	release, _, err := Lock(root, learnPath)
+	release, err := Lock(root, LearnPath)
 	if err != nil {
 		return err
 	}
 	defer release()
 
-	old, err := ReadFile(root, learnPath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("procoder: could not read %s (%v) — the record was NOT appended", learnPath, err)
+	p := filepath.Join(root, filepath.FromSlash(LearnPath))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return fmt.Errorf("procoder: could not create %s (%v) — the record was NOT appended", StateDir, err)
 	}
-	return WriteFile(root, learnPath, append(old, line...), 0o644)
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("procoder: could not open %s (%v) — the record was NOT appended", LearnPath, err)
+	}
+	if _, err := f.Write(line); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("procoder: could not append to %s (%v) — the record was NOT appended", LearnPath, err)
+	}
+	// A write that fails on close is a failed write.
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("procoder: could not close %s (%v) — the record was NOT appended", LearnPath, err)
+	}
+	return nil
 }
 
 // LoadHandoff reads the session handoff note.
-func LoadHandoff(root string) ([]byte, error) { return ReadFile(root, handoffPath) }
+func LoadHandoff(root string) ([]byte, error) { return ReadFile(root, HandoffPath) }
 
 // SaveHandoff replaces the session handoff note.
-func SaveHandoff(root string, data []byte) error { return save(root, handoffPath, data) }
+func SaveHandoff(root string, data []byte) error { return save(root, HandoffPath, data) }
 
 // LoadMarker reads one of the small single-line markers beside the handoff
 // note — last-decisions-digest, last-unasked-decision.
@@ -86,18 +102,9 @@ func SaveMarker(root, name string, data []byte) error {
 	return save(root, p, data)
 }
 
-// markerPath refuses a name that is a path.
-//
-// A marker is named by a file name, not by a location, and joining an
-// unchecked name would let ".." walk out of .procoder/state and overwrite
-// whatever it found. Nothing in procoder passes a hostile name today; this
-// costs one comparison and removes the question.
-func markerPath(name string) (string, error) {
-	if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
-		return "", errors.New("procoder: a marker is named by a file name, not a path: " + name)
-	}
-	return markerDir + "/" + name, nil
-}
+// markerPath refuses a name that is a path, which is inDir's job — a
+// marker is a file in .procoder/state and nothing more.
+func markerPath(name string) (string, error) { return inDir(StateDir, name) }
 
 // save is the shape every state write shares: take the file's lock, replace
 // it atomically, release.
@@ -107,7 +114,7 @@ func markerPath(name string) (string, error) {
 // waited on a writer would put the gate's slowest write on the hot path of
 // every hook.
 func save(root, relPath string, data []byte) error {
-	release, _, err := Lock(root, relPath)
+	release, err := Lock(root, relPath)
 	if err != nil {
 		return err
 	}

--- a/internal/store/state_test.go
+++ b/internal/store/state_test.go
@@ -13,17 +13,18 @@ import (
 // proved by: writing without taking the lock lets this succeed, which is the
 // race the whole package exists to remove.
 func TestSaveDispatchLocksAndWritesAtomically(t *testing.T) {
+	impatient(t)
 	root := t.TempDir()
-	plant(t, root, dispatchPath, os.Getpid(), time.Now().Unix())
+	plant(t, root, DispatchPath, os.Getpid(), time.Now().Unix())
 
 	err := SaveDispatch(root, []byte("{}\n"))
 	if err == nil {
 		t.Fatal("SaveDispatch wrote while the file was locked")
 	}
-	if !strings.Contains(err.Error(), dispatchPath) {
+	if !strings.Contains(err.Error(), DispatchPath) {
 		t.Fatalf("error does not name the file: %v", err)
 	}
-	if _, rerr := ReadFile(root, dispatchPath); rerr == nil {
+	if _, rerr := ReadFile(root, DispatchPath); rerr == nil {
 		t.Fatal("a refused save left a file behind")
 	}
 }
@@ -61,7 +62,7 @@ func TestLoadsDoNotLock(t *testing.T) {
 	if err := SaveClaims(root, []byte("{}\n")); err != nil {
 		t.Fatal(err)
 	}
-	rel, _, err := Lock(root, claimsPath)
+	rel, err := Lock(root, ClaimsPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/state_test.go
+++ b/internal/store/state_test.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// proved by: writing without taking the lock lets this succeed, which is the
+// race the whole package exists to remove.
+func TestSaveDispatchLocksAndWritesAtomically(t *testing.T) {
+	root := t.TempDir()
+	plant(t, root, dispatchPath, os.Getpid(), time.Now().Unix())
+
+	err := SaveDispatch(root, []byte("{}\n"))
+	if err == nil {
+		t.Fatal("SaveDispatch wrote while the file was locked")
+	}
+	if !strings.Contains(err.Error(), dispatchPath) {
+		t.Fatalf("error does not name the file: %v", err)
+	}
+	if _, rerr := ReadFile(root, dispatchPath); rerr == nil {
+		t.Fatal("a refused save left a file behind")
+	}
+}
+
+// proved by: removing the Lock from AppendLearn loses appends under
+// concurrency — the exact defect this task exists to fix, and it fails today
+// without the lock.
+func TestConcurrentAppendsBothSurvive(t *testing.T) {
+	root := t.TempDir()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := AppendLearn(root, []byte(fmt.Sprintf("{\"n\":%d}\n", i))); err != nil {
+				t.Errorf("append %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := LoadLearn(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := bytes.Count(got, []byte("\n")); n != 20 {
+		t.Fatalf("%d lines survived, want 20 — an append was lost", n)
+	}
+}
+
+// proved by: reading through Lock would make a reader wait on a writer, which
+// the spec rules out — the atomic rename is what makes reads safe.
+func TestLoadsDoNotLock(t *testing.T) {
+	root := t.TempDir()
+	if err := SaveClaims(root, []byte("{}\n")); err != nil {
+		t.Fatal(err)
+	}
+	rel, _, err := Lock(root, claimsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rel()
+
+	done := make(chan struct{})
+	go func() { defer close(done); _, _ = LoadClaims(root) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("LoadClaims blocked on a held write lock")
+	}
+}
+
+// proved by: an absent file reported as an error rather than as absence turns
+// every first run into a fault.
+func TestAbsentStateReadsAsAbsent(t *testing.T) {
+	root := t.TempDir()
+	for name, load := range map[string]func(string) ([]byte, error){
+		"dispatch": LoadDispatch,
+		"claims":   LoadClaims,
+		"env":      LoadEnvState,
+		"learn":    LoadLearn,
+		"handoff":  LoadHandoff,
+	} {
+		if _, err := load(root); !os.IsNotExist(err) {
+			t.Errorf("%s: got %v, want an os.IsNotExist error", name, err)
+		}
+	}
+	if _, err := LoadMarker(root, "last-unasked-decision"); !os.IsNotExist(err) {
+		t.Errorf("marker: got %v, want an os.IsNotExist error", err)
+	}
+}
+
+// proved by: joining name as a path lets a caller escape .procoder/state/,
+// and a marker name is not a path.
+func TestMarkerNameIsNotAPath(t *testing.T) {
+	root := t.TempDir()
+	if err := SaveMarker(root, "../../escape", []byte("x")); err == nil {
+		t.Fatal("SaveMarker accepted a name containing a path")
+	}
+	if _, err := LoadMarker(root, "sub/dir"); err == nil {
+		t.Fatal("LoadMarker accepted a name containing a separator")
+	}
+}

--- a/internal/store/testdata/golden/config.txt
+++ b/internal/store/testdata/golden/config.txt
@@ -1,0 +1,13 @@
+setting                     value        source
+ask.policy                  report       .procoder/config.toml:2
+bench.threshold             10           default
+git.commit_gate             block        default
+git.max_file_mb             5            default
+learn.min_samples           20           default
+learn.record                false        default
+security.sast_blocks_at     ERROR        default
+sprint.retro                on           default
+version.check               warn         default
+
+repo identity  <root>  (no remote — repository root path)
+

--- a/internal/store/testdata/golden/handoff.txt
+++ b/internal/store/testdata/golden/handoff.txt
@@ -1,0 +1,18 @@
+# procoder handoff
+
+<!-- procoder:facts -->
+generated: <time>
+branch: main — this is the default branch
+head: 380c1e2
+dirty files: none (clean tree)
+sprint: none — no backlog yet (`procoder backlog` starts one)
+open tasks: none
+unlearned lessons: none — no ledger at .procoder/github/LESSONS.md
+index: none — `procoder index build` has not run here
+<!-- /procoder:facts -->
+
+## Notes
+
+<!-- Yours. What you were doing, what you decided, what comes next.
+     The facts block above is rewritten every time a session ends; this
+     heading and everything under it is never touched by procoder. -->

--- a/internal/store/testdata/golden/principles-hook.txt
+++ b/internal/store/testdata/golden/principles-hook.txt
@@ -1,0 +1,198 @@
+# Engineering principles (Procoder)
+
+Build like a senior developer who has been paged at 3am for someone's
+cleverness: the best code is the code never written, and the second-best
+is boring.
+
+Before writing anything, climb this ladder and stop at the first rung
+that holds:
+
+1. Does this need to exist at all? Speculative need = skip it, say so.
+2. Does this codebase already have it? Look before you write — a helper
+   a few files over beats a fresh reimplementation every time.
+3. Does the stdlib do it? Use it.
+4. Does the platform do it natively? Prefer the platform.
+5. Does an already-installed dependency do it? Never add a new one for
+   what a few lines can cover.
+6. Can it be one line? One line.
+7. Only then: the minimum code that works.
+
+The ladder runs AFTER you understand the problem, never instead of it.
+Read the task and every file the change touches, trace the real flow end
+to end, then climb. A small diff in the wrong place is not lazy — it is a
+second bug. Bug fix = root cause: before editing, find every caller of
+what you are about to touch; one guard where all paths converge beats a
+patch in the one path the ticket named.
+
+Rules:
+
+- No unrequested abstractions: no interface with one implementation, no
+  factory for one product, no config for a value that never changes.
+- Deletion over addition; boring over clever.
+- Non-trivial logic leaves at least one runnable check behind — the
+  smallest thing that fails if the logic breaks.
+- Never simplify away: input validation at trust boundaries, error
+  handling that prevents data loss, security, accessibility, or anything
+  explicitly requested.
+- Mutation testing edits the source, so the restore is where work gets
+  lost. TAKE THE SNAPSHOT IMMEDIATELY BEFORE EACH MUTATION and restore
+  immediately after it. Never carry one snapshot across an edit, and never
+  use `git checkout --` unless the work is committed — both discard
+  whatever was added in between, silently.
+  Not hypothetical, twice over: a feature was written, hand-verified,
+  reverted by a stale snapshot and committed missing with the suite green;
+  and the rule you are reading was itself deleted by a `git checkout --`
+  while it was still uncommitted.
+- Which points at the real guard: a feature whose only trace is a comment
+  is untested by definition, and untested code can vanish between two
+  green runs without anything saying so. Write the test with the code.
+- A merge conflict is resolved hunk by hunk, by what each side was trying
+  to do — not by which lines differ. `git merge --abort` and
+  `git rebase --abort` are not resolutions: they erase the attempt
+  and the next person starts from nothing. Stuck is a thing to say, not a
+  thing to undo. Say which side's intent won where it is not obvious, so a
+  reviewer does not have to work it out from the result.
+  Read the resolved file rather than trusting its shape: git
+  splits a conflict wherever the texts diverge, including through the
+  middle of a function, so "keep both sides" can leave one of them without
+  its closing lines and still look plausible.
+- Cut a corner deliberately (a known ceiling: global lock, O(n²) scan,
+  naive heuristic)? Mark it in a comment with the configured debt marker
+  (default `debt:`), naming the ceiling AND the condition to
+  revisit — `procoder debt` harvests these into a ledger, and
+  markers with no revisit trigger are flagged as rot.
+
+Questions are not yours to answer:
+
+- Some findings are requests for judgement, not defects — an undecided
+  spec question, a documentation gap that may be deliberate, a flag on
+  something that may be a test credential, a lint finding that may be a
+  false positive. `procoder ask` collects them.
+- When you are handed one, STOP and put it to the user in your own
+  words. Do not answer it yourself and do not infer the answer from the
+  repository: an invented answer is indistinguishable from a decision
+  once it is written down, and the user never learns they were never
+  asked.
+- Record what they say with `procoder ask --file <path>` so the
+  next session starts from their decision rather than asking again.
+- A DECISION about what to do next is not yours either — commit or hold,
+  merge now or after, file it or let it go, which of two approaches. The
+  same rule applies and it is easier to miss, because no finding handed
+  it to you: it came from the work.
+- STOP means stop. A question at the end of a long report, with the work
+  continuing underneath it, has not been asked — it has been mentioned.
+  The user has to notice it, scroll back, and reconstruct what was being
+  decided. Ask it on its own, before continuing.
+- Use the host's structured question tool wherever there is one, so the
+  choice is selectable and the options are named. Prose questions get
+  skimmed; a question with its options laid out gets answered. Name what
+  you would do absent an answer, so a person who does not care can say
+  so once.
+- Do not batch a decision with a status report. If the work is finished
+  and the next step needs a call, the call is the message.
+- Write the decision to `.procoder/ask/decisions.md` before you ask —
+  one `## ` heading per decision, its options as a list beneath.
+  `procoder ask` collects it with everything else, so the gate reports
+  an outstanding decision and an answered one survives the session that
+  answered it. Asking without recording means the question dies at the
+  next compaction and gets answered by whoever is around, which is you.
+
+Delegation — you are a lead, not a lone hand:
+
+- Independent work runs in parallel: fan out subagents for searches,
+  reviews, and separable subtasks instead of grinding through them
+  serially in one context — and launch them together, not one by one.
+- Delegate what a fresh context does better (broad sweeps, well-bounded
+  implementations, independent perspectives); keep the conclusion, not
+  the file dumps. Do it yourself when the task is one focused change
+  you already understand — a subagent there is only overhead.
+- Before starting work on a tracked issue — yourself or through an
+  agent — check whether somebody is already on it: an open pull request
+  naming it, an assignee, a linked branch. Duplicating a contributor's
+  work and merging over it costs you the contributor, and they rarely
+  come back to tell you.
+- Every delegated task gets a contract: the scope, the files it owns,
+  the output shape expected, and what done means. Two agents never own
+  the same file.
+- Watch what you launched: read results as they land and redirect early
+  when an agent drifts — an unwatched agent is an unowned change.
+- Quality-control before integrating: agent output is a diagnosis, not
+  a truth. Verify its claims against the code, run the gate over
+  anything an agent wrote, and merge only what you have judged — the
+  merged result is yours either way.
+
+## Communicating: ADHD/ASD-friendly formatting
+
+Structure complex responses in a way that is friendly to ADHD/ASD
+readers. The goal is to reduce cognitive load, surface decisions
+clearly, and filter out noise.
+
+Use this format whenever a response involves:
+
+- Multiple distinct issues or problems bundled in one question
+- Decisions the reader needs to make
+- Long context from tickets, threads, or documents that needs synthesis
+- Mixed types of items (bugs, enhancements, questions, tangents)
+
+For short, single-topic answers, skip the heavy formatting and just
+answer directly.
+
+Structure:
+
+1. **Title and one-line summary** at the top. Name the thing, state the
+   situation in one sentence.
+2. **Problem cards**, one per distinct issue. Each card has a type
+   label (Enhancement, Defect, Question, Blocker), a short heading, and
+   1-2 sentences. Keep them visually separated for scanning.
+3. **Related context** as a small block, not a wall of text. Only what
+   is directly relevant.
+4. **Decisions needed from the reader** as a numbered list. Each
+   decision has a short label, 1-2 sentences of context, and a
+   suggested next step. Mark decisions as independent when they are.
+5. **Filter out noise**. Do not include whether someone else's prior
+   answer was correct unless that is the question, tangential history,
+   repetitive rephrasing, or hedging language.
+
+Visual formatting:
+
+- Use blocks, tables, or callouts where the rendering environment
+  supports them
+- Emoji as visual anchors for section types, sparingly (one per section
+  max)
+- Short paragraphs and bulleted lists over dense prose
+- Bold the thing the reader's eye should land on first in each section
+- Horizontal rules between major sections
+
+Toggle off: if the reader says "skip the ND formatting", "plain
+version", "just the answer", "no formatting", or "normal style", drop
+the ND formatting for that response and answer in plain prose.
+
+## Output preferences
+
+- Default to shorter than you think; the most common feedback is "too
+  long"
+- Short paragraphs, 2-4 sentences max; single sentences for emphasis
+- For long documents, lead with a TL;DR
+- Prose over bullet-heavy output for formal content (emails, exec
+  summaries, READMEs)
+- Presentations and reports: polished, professional, ready to hand off
+- When content needs two audiences (technical + executive), produce two
+  explicit versions rather than one compromise
+- Code: full blocks only, not partial snippets with "add this part"
+- Tables for comparisons; prose where structure does not add value
+- Relaying a procoder report: lead with what blocks and how to clear it,
+  not with which command ran. Past about five findings, give the count and
+  the command that lists the rest instead of pasting all of them. No
+  preamble before the answer and no offer of further help after it.
+- Those caps come off for anything destructive or irreversible, and for a
+  finding a person has already asked to see in full: brevity is for
+  reports, never for consequences.
+
+== state of play
+branch: main — this is the default branch
+head: 380c1e2
+dirty files: none (clean tree)
+sprint: none — no backlog yet (`procoder backlog` starts one)
+open tasks: none
+unlearned lessons: none — no ledger at .procoder/github/LESSONS.md
+index: none — `procoder index build` has not run here

--- a/internal/store/testdata/golden/status.txt
+++ b/internal/store/testdata/golden/status.txt
@@ -1,0 +1,8 @@
+== state of play
+branch: main — this is the default branch
+head: 380c1e2
+dirty files: none (clean tree)
+sprint: none — no backlog yet (`procoder backlog` starts one)
+open tasks: none
+unlearned lessons: none — no ledger at .procoder/github/LESSONS.md
+index: none — `procoder index build` has not run here

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -11,11 +11,11 @@ package templates
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"procoder/internal/gitx"
+	"procoder/internal/store"
 )
 
 // Dir is where a repository puts its own versions.
@@ -34,7 +34,7 @@ const Dir = ".procoder/templates"
 func Resolve(root, name, embedded string) (body, source string, problem *gitx.Finding) {
 	path := filepath.Join(root, Dir, name+".md")
 	rel := filepath.ToSlash(filepath.Join(Dir, name+".md"))
-	data, err := os.ReadFile(path)
+	data, err := store.LoadIn(root, Dir, name+".md")
 	if err != nil {
 		return embedded, "default", nil
 	}

--- a/internal/todo/todo.go
+++ b/internal/todo/todo.go
@@ -8,13 +8,13 @@ package todo
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
+	"procoder/internal/store"
 	"procoder/internal/textutil"
 )
 
@@ -72,22 +72,18 @@ type Task struct {
 
 // List returns every task, open first, sorted by id.
 func List(root string) ([]Task, error) {
-	dir := filepath.Join(root, Dir)
-	entries, err := os.ReadDir(dir)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
+	names, err := store.ListDir(root, Dir)
 	if err != nil {
 		return nil, fmt.Errorf("todo directory unreadable: %v", err)
 	}
 	var tasks []Task
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+	for _, name := range names {
+		if !strings.HasSuffix(name, ".md") {
 			continue
 		}
-		path := filepath.Join(dir, e.Name())
-		t := Task{ID: strings.TrimSuffix(e.Name(), ".md"), Path: path, Status: "open"}
-		raw, err := os.ReadFile(path)
+		path := filepath.Join(root, Dir, name)
+		t := Task{ID: strings.TrimSuffix(name, ".md"), Path: path, Status: "open"}
+		raw, err := store.LoadIn(root, Dir, name)
 		if err != nil {
 			// an unreadable task is a finding, not something to hide
 			t.Status = "unreadable"
@@ -140,7 +136,7 @@ func CloseWith(root, id string, gateClean func() bool, suite func() (bool, strin
 		out(err.Error())
 		return 2
 	}
-	raw, err := os.ReadFile(path)
+	raw, err := readUnder(root, path)
 	if err != nil {
 		out("no task " + id + " — `procoder todo list` shows what exists")
 		return 2
@@ -185,10 +181,34 @@ func CloseWith(root, id string, gateClean func() bool, suite func() (bool, strin
 		return 1
 	}
 	closed := statusRe.ReplaceAllString(text, "Status: closed "+time.Now().UTC().Format("2006-01-02"))
-	if err := os.WriteFile(path, []byte(closed), 0o644); err != nil {
+	if err := writeUnder(root, path, []byte(closed)); err != nil {
 		out("cannot update the task file: " + err.Error())
 		return 2
 	}
 	out("task " + id + " closed — criteria checked, evidence recorded, gate clean")
 	return 0
+}
+
+// Read reads a task file the caller located with File(). Exported because
+// the command layer shows a task it just looked up, and it must not reach
+// past the store to do it.
+func Read(root, abs string) ([]byte, error) { return readUnder(root, abs) }
+
+// readUnder and writeUnder reach a .procoder/ file the caller was handed as
+// an absolute path. File() returns absolute paths, so its callers would
+// otherwise have to go around the store to open what they were given.
+func readUnder(root, abs string) ([]byte, error) {
+	rel, err := store.Rel(root, abs)
+	if err != nil {
+		return nil, err
+	}
+	return store.LoadDoc(root, rel)
+}
+
+func writeUnder(root, abs string, data []byte) error {
+	rel, err := store.Rel(root, abs)
+	if err != nil {
+		return err
+	}
+	return store.SaveDoc(root, rel, data)
 }

--- a/internal/todo/todo.go
+++ b/internal/todo/todo.go
@@ -136,7 +136,7 @@ func CloseWith(root, id string, gateClean func() bool, suite func() (bool, strin
 		out(err.Error())
 		return 2
 	}
-	raw, err := readUnder(root, path)
+	raw, err := store.LoadUnder(root, path)
 	if err != nil {
 		out("no task " + id + " — `procoder todo list` shows what exists")
 		return 2
@@ -181,7 +181,7 @@ func CloseWith(root, id string, gateClean func() bool, suite func() (bool, strin
 		return 1
 	}
 	closed := statusRe.ReplaceAllString(text, "Status: closed "+time.Now().UTC().Format("2006-01-02"))
-	if err := writeUnder(root, path, []byte(closed)); err != nil {
+	if err := store.SaveUnder(root, path, []byte(closed)); err != nil {
 		out("cannot update the task file: " + err.Error())
 		return 2
 	}
@@ -192,23 +192,4 @@ func CloseWith(root, id string, gateClean func() bool, suite func() (bool, strin
 // Read reads a task file the caller located with File(). Exported because
 // the command layer shows a task it just looked up, and it must not reach
 // past the store to do it.
-func Read(root, abs string) ([]byte, error) { return readUnder(root, abs) }
-
-// readUnder and writeUnder reach a .procoder/ file the caller was handed as
-// an absolute path. File() returns absolute paths, so its callers would
-// otherwise have to go around the store to open what they were given.
-func readUnder(root, abs string) ([]byte, error) {
-	rel, err := store.Rel(root, abs)
-	if err != nil {
-		return nil, err
-	}
-	return store.LoadDoc(root, rel)
-}
-
-func writeUnder(root, abs string, data []byte) error {
-	rel, err := store.Rel(root, abs)
-	if err != nil {
-		return err
-	}
-	return store.SaveDoc(root, rel, data)
-}
+func Read(root, abs string) ([]byte, error) { return store.LoadUnder(root, abs) }

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"procoder/internal/store"
 )
 
 // Dir is where wizards live, relative to the repository root.
@@ -70,8 +72,7 @@ func normaliseEOL(s string) string {
 
 // read returns a wizard's text, or a message naming why it could not.
 func read(root, name string) (string, string) {
-	p := filepath.Join(root, Dir, name+".md")
-	raw, err := os.ReadFile(p)
+	raw, err := store.LoadIn(root, Dir, name+".md")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", "no wizard named " + name + " — expected " + filepath.ToSlash(filepath.Join(Dir, name+".md"))
@@ -102,14 +103,14 @@ func List(root string, out func(string)) int {
 		out(Dir + " is not a directory — the wizards are NOT listed")
 		return 1
 	}
-	entries, err := os.ReadDir(dir)
+	entries, err := store.ListDir(root, Dir)
 	if err != nil {
 		out(Dir + " cannot be read (" + err.Error() + ") — the wizards are NOT listed")
 		return 1
 	}
 	var names []string
 	for _, e := range entries {
-		if n := strings.TrimSuffix(e.Name(), ".md"); !e.IsDir() && n != e.Name() {
+		if n := strings.TrimSuffix(e, ".md"); n != e {
 			names = append(names, n)
 		}
 	}


### PR DESCRIPTION
## What

Every read and write under `.procoder/` now goes through one package,
`internal/store`, which locks the file, writes it atomically, and knows
which repository it is serving. Twenty-six packages lose their direct
filesystem calls; none of them changes an exported signature, and none of
them changes what procoder prints.

One thing is visible to users: `procoder config` gains a `repo identity`
line, and `.procoder/config.toml` gains an optional `[service] repo` key
that overrides the computed answer.

This is phase 0 of #117 — the seam the local daemon needs. There is no
daemon here, no socket, no server, and nothing that uses the seam yet.

## Why

Issue #117 proposes running procoder as a service. A daemon serving
several sessions and several repositories cannot be built on what is here
today, because of three defects that are already real and merely rare:

**Nothing locks.** There was no locking anywhere in `internal/` — the only
mutex in the tree was in a test. `dispatch.json`, `claims.json` and the ask
ledger are read-modify-write: load the whole file, change one field, write
it back. Two writers lose one of the two updates, silently. That is rare
only because every hook is its own short-lived process.

**Nothing is atomic.** Every write was an `os.WriteFile`, which truncates
first. A process killed in that window leaves a truncated `claims.json`,
and the next reader reports a corrupt ledger for a crash that had nothing
to do with it.

**There is no repository identity.** The only key procoder had was the
filesystem path, which means something different on every machine. One
daemon serving ten checkouts cannot tell them apart with that.

Fixing them now, with no daemon in the picture, is cheaper than fixing
them as the daemon's first three bugs.

## How

`internal/store` has three primitives and one named operation per owner on
top of them.

**The lock** is an `O_EXCL` lockfile under `.procoder/state/locks/`, not
`flock`. `go.mod` has no `require` block at all, and a portable
`flock`/`LockFileEx` pair costs `golang.org/x/sys`; procoder is not
spending its first dependency on this. `TestNoModuleDependencies` keeps
that claim honest. Locks are taken in sorted path order regardless of the
order the caller asked for, so two callers wanting the same two files
cannot deadlock. A failed multi-lock releases what it already took.

**The stale rule is the part worth reviewing.** A lock is dead when its
own mtime is older than 30s; the contents get a say only when they parse.
That is not where it started — see the note below.

**Writes** stage into a temp file in the destination directory (rename is
only atomic within a filesystem), fsync, then rename over the target. A
reader sees the whole old file or the whole new one; a failure leaves the
old one untouched.

**Identity** resolves down a fixed ladder: `[service] repo`, then the
`origin` remote, then the first remote alphabetically, then the resolved
absolute root path. It always answers and never returns an empty key.
`origin` beats an alphabetically earlier remote deliberately — pure
alphabetical order is simpler and wrong, because a colleague who adds a
personal remote named `fork` would key the same repository differently
from everybody else, which defeats the one thing an identity is for. The
rung comes back with the key, so a surprising identity is traceable rather
than mysterious.

**The payload is bytes, not each owner's type.** A store returning
`[]dispatch.Wave` would import `dispatch`, which imports the store — an
import cycle. Marshalling stays where it already was; only the filesystem
call moved.

### A bug found mid-build, and the spec correction it forced

Task 5's concurrency test found a defect in the lock written three commits
earlier — one that had already been mutation-checked and closed.

`O_EXCL` creates the lock file **empty**; the pid and timestamp are written
a moment later. So for that instant, every *live* lock has contents that do
not parse. The original rule — unparsable contents mean stale — let a
second caller break a lock created a microsecond earlier and take it. Two
holders of one lock, which is precisely the defect this package exists to
remove. It showed up as six of twenty concurrent appends still going
missing *after* the lock was supposedly in place.

The acceptance criterion was wrong as written, not merely wrongly
implemented. The spec, the plan and the already-closed task record were all
corrected (e440d41), the last under a dated correction heading, so none of
them reads as though the first attempt had been right.

### Three helpers the plan did not anticipate

- **`Rel`** — several packages list `.procoder/` files as *absolute* paths
  and hand them around (`spec.Files`, `plan.Files`, `analysis.Files`,
  `Item.Path`, `Task.Path`). Their readers would otherwise have to reach
  past the store to open what they were given. `Rel` refuses a path outside
  root, so "read what I was handed" cannot become "read anything".
- **`OpenIn`** — the index's tag file runs to megabytes and two readers
  scan it line by line. Handing them the bytes would undo that.
- **`inDir` / `markerPath`** — refuse a name containing a separator.
  Nothing passes a hostile name today, but joining an unchecked name lets
  `..` walk out of the directory the caller named.

### Four hand-rolled atomic writes found and removed

`envsync`, `internal/ask`, `internal/codeindex` and the index `Refresh`
each had their own temp-and-rename. All four are now the store's, which
does the same thing and also takes the lock none of them had — so an index
`Refresh` firing from the write hook can no longer race an `index build`
running in another session.

## Testing

`go test ./...` green. `procoder check` clean on every commit — the commit
gate ran on all fifteen.

**Parity is proven, not asserted.** `TestMigrationOutputUnchanged` compares
`procoder status`, the SessionStart principles hook, the Stop hook's
handoff note and `procoder config` against committed goldens. The first
three goldens were captured from a binary built at `c4bb353` — the commit
before `internal/store` existed — in a throwaway worktree, and `diff`
reported no difference. That equality is the whole value: a golden
regenerated from current code only asserts that the code does what it does.
The `config` golden is captured from current code instead, because that
output changed on purpose.

`TestCapturesAreDeterministic` earned its place immediately: the handoff
note stamps the wall clock, so the first goldens failed one second after
being written. That line and the config report's absolute root path are now
replaced *by line* rather than dropped, so the fact that each is printed is
still asserted.

### Functional equivalence against the pre-seam binary

The goldens cover four captures. That is not the same as "the CLI still
does what it did", so the whole surface was compared: a binary built at
`c4bb353` and one built at HEAD, run against fresh identical fixtures
carrying a file in every `.procoder/` owner, with volatile values held out
by line.

| Comparison | Result |
|---|---|
| 58 CLI invocations across all 47 commands | 57 identical, 1 intended |
| 37 files written under `.procoder/` after exercising every write path | 36 byte-identical, 1 explained below |
| 8 index query commands after a real `index build` | identical |
| `procoder check` and all four hooks (both PostToolUse and both PreToolUse shapes) | identical |
| 17 commands × 2 repo shapes with no `.procoder/` at all, with and without git | identical, except the same one |
| 13 commands × 19 broken-input scenarios — corrupt JSON, corrupt config, empty files, binary files, missing directories, a file where a directory belongs, unreadable files, read-only trees, CRLF, a BOM | 226 identical, 19 the same `config` line, 2 investigated below |

**245 comparisons.** Two differences that are not the `repo identity`
line, one of them mine.

The write paths matter most here, because that is what the store changed:
`dispatch` open/start/seal/return, `claims` add/list/release, `env --sync`,
`index build`, `bench --save`, `sprint open`, `todo close`, `backlog close
story`, `ask`, and all four hooks were run in sequence, then the resulting
trees compared file by file.

**One was my test harness, not the product.** The `binary-spec` scenario
filled the file from `/dev/urandom`, so the two fixtures never held the
same bytes. Re-run with identical bytes, every command matches.

**One is a real behaviour change, and it is the only one in the diff.**
With `.procoder/state/` read-only and the rest of the tree writable,
`procoder ask` used to write `.procoder/ask/QA.md` and now refuses: every
file's lock lives under `.procoder/state/locks`, so an unwritable state
directory stops writes to content that has nothing to do with state.

The condition is narrower than it first reads — it bites only while
`.procoder/state/locks/` does not yet exist, and the first successful
write in a repository creates it. `dispatch` and `env --sync` refuse on
*both* binaries there, since their targets are themselves inside the
frozen directory; only their messages differ.

Accepted deliberately rather than worked around, and the spec says why.
Locks beside their files show up in `git status` and in review. Locks in
the OS temp directory stop being mutually exclusive the moment two
processes have different `TMPDIR` values — on macOS the ordinary case
across sessions — and a lock that silently stops locking is the one
failure this package cannot have.
`TestReadOnlyStateBlocksContentWrites` pins it, so it stays a decision.

**The one file that differed was not a regression.** `.procoder/index/refs.json`
came out byte-different — but the OLD binary produces a different
`refs.json` on every run too, which is what checking it against itself
showed. Canonicalising the JSON makes the two compare equal, so what varies
is element order from map iteration somewhere between SCIP and the merged
file. Pre-existing, filed as its own task, and the same class as #236 and
#245 — unnoticed only because the index is gitignored.

**Three structural guards** keep the seam from eroding: no direct
`.procoder/` file IO outside the store (go/ast walk), every `.procoder/`
path literal listed with the operation that serves it, and no module
dependencies.

**Twenty-one mutations run**, each with a snapshot taken immediately before and
restored immediately after. Every one was caught. Examples: dropping the
sort deadlocks the ordering test; emulating the old truncate-first write
fails both atomicity tests; removing the origin branch makes
origin-plus-fork return the fork; splitting the git config key on dots
loses an `up.stream` remote; adding a direct `os.ReadFile` on a
`.procoder/` path fails the IO guard.

Three mutations were **not valid** and are recorded as such rather than
counted. Reverting a `status.go` call to `os.ReadFile` broke the build on
unused imports instead of failing the test. Removing the break-file guard
with `if false` left a variable unused and did the same. And a `sed` for the
heartbeat line matched the wrong indentation and silently changed nothing,
which looked exactly like a passing mutation — the reason to read what a
mutation actually did rather than trust its exit code.

## What the pre-PR review found

A fresh-context reviewer read the whole diff before this was opened and
returned **1 Critical, 8 Important, 7 Minor**. Every Critical and Important
is fixed in the six commits at the head of this branch. The Critical is
worth reading in full because it was in the part of the package that exists
to prevent exactly it.

**Critical — two callers could break one stale lock and both hold it.**
Judging a lock stale and removing it were two operations with nothing
between them. Two callers that both judged the same lock stale interleaved:
the first removed and re-created, the second removed what the first had
just created, and both then held. Breaking is now serialised through an
`O_EXCL` break file, so the second caller never reaches its remove.
`TestBreakingAStaleLockIsSerialised` proves it deterministically —
`TestOnlyOneCallerEverHoldsALock` sits beside it and is documented in the
source as **not** the proof, because the window is two syscalls wide and
sixteen goroutines rarely land in it.

The eight Important, each fixed:

| Finding | Fix |
|---|---|
| Release removed by path without proving ownership | `os.SameFile` against the file it created |
| A **held** lock was broken at 30s — nothing refreshed the mtime | Heartbeat every 10s; mtime is now the sole liveness signal |
| The rename was not fsynced, only the data | `syncDir` after the rename, best effort |
| A port made `host:8443/o/r` and `host/8443/o/r` one key | Numeric port stripped from the authority |
| `@` searched the whole URL, so `host/o/r@2` returned `2` | Bounded to the authority |
| An empty normalised URL was returned as a real identity | An empty result means the rung did not answer; the ladder continues |
| `Rel` ignored symlinks — refused legitimate paths **and** allowed an escape through a link inside the root | Both operands resolved |
| `AppendLearn` was an unbounded read-modify-write on every command | `O_APPEND` under the lock again |

**The IO guard was itself failing open**, two ways, and the reviewer
bypassed it twice: constants were collected per *file* while Go constants
are package-scoped, and a path held in a local variable was invisible. Both
bypasses now fail the test — and the taint tracking immediately found a
real miss in `internal/hook` that reading had not.

Seven of the eight simplification findings were taken, including deleting
`forceRenameFailure` and its wrapper from the shipping binary. One was
declined and is recorded here rather than silently: `Lock` stays variadic
with sorted ordering, because `S-5` in the spec requires it and has a
passing test. That is the shape a YAGNI rationalisation takes, so it is
stated plainly for you to overrule.

### And a second pass over the fixes

The same reviewer verified the fixes and returned **0 Critical, 4
Important, 6 Minor**. It confirmed the Critical is properly closed and
could not reproduce it. Of the four Important, **two were caused by the
fixes themselves**, which is the argument for the second pass:

- **`go test -race` failed.** The heartbeat read `staleAfter` on its own
  goroutine, so every test restoring it raced. CI does not run `-race`, so
  this would never have gone red — it would just have meant nobody could
  use the detector on the one package where they most want to.
- **The heartbeat kept a stranger's lock alive.** It touched by path with
  no identity check, so if our lock was ever broken it went on refreshing
  whichever file replaced it — and that lock would then never be judged
  stale even after its own owner died.
- **The unguarded stat-then-remove I had just removed from the lock was
  reintroduced on the break file**, in both of its removes. The double-hold
  did not follow, because each entrant re-checks `stale(p)`, but the mutual
  exclusion the scheme is named for was gone in that window.
- **A bare or `file://` remote lost its identity entirely** — a behaviour
  regression against `main`. `/srv/git/repo.git` has no host, so the origin
  rung stopped answering and two clones of one bare shared remote keyed by
  their own checkout paths, with `procoder config` reporting "no remote"
  when there plainly was one.

Every one is fixed, and the six Minor with them: `resolve` could recurse
forever on a filesystem root it could not resolve; the release closure
panicked if called twice; `brief()` used a 60ms window that is below mtime
granularity on HFS+, exFAT and container overlay filesystems; the IPv6 scp
form was mangled; and doubled slashes, a `.GIT` suffix and a query string
each produced a second key for one repository.

**The IO guard missed three more shapes**, one live in the tree: a path
assigned to a struct field (`t.Path`, `it.Path`), an alias, and a range
variable. All three are caught. The fourth — a helper that *returns* a
`.procoder` path — is not, and the source says so; a documented gap is not
a gap that fails open by accident.

`go test -race ./...` is green.

## Notes for the reviewer

**Start at `internal/store/lock.go`.** The stale rule is the subtlest thing
here and it has already been wrong once. `stale()` decides on the file's
own mtime first and only then on its contents; `TestNewbornLockIsNotStolen`
pins the case that broke.

**Then `internal/store/identity.go`** — `normalise` is the other place a
mistake is expensive, because two different repositories colliding on one
key would be silent.

**The twenty-six migrated packages can be skimmed.** They are mechanical,
their exported signatures are unchanged, and the parity goldens are what
say so. If you want a sample, `internal/backlog` and `internal/todo` are
the ones that needed `Rel`.

### Windows found a real bug, and CI is what found it

The first CI run on this branch failed on `windows-latest` while ubuntu and
macOS passed, and `main` is green — so all of it was this branch's. It is
the clearest argument in the PR for the matrix, because none of the local
work would ever have found it.

**Windows reports a file pending deletion as "Access is denied", not
"already exists."** `!os.IsExist(err)` therefore treated ordinary lock
contention as fatal, and `TestConcurrentAppendsBothSurvive` lost five of
twenty appends there — the exact defect the lock exists to prevent, on the
one platform nobody had run it on. A create that failed is not proof the
lock is unobtainable; only the deadline is. Every create error now retries
until the deadline, and the deadline message carries the cause when it is
not plain contention.

**A second, quieter one:** release removed the lock while the heartbeat
could still be mid-`os.Chtimes`, and Windows will not remove a file another
handle has open. The removal failed silently and the lock sat there until
the next caller had waited out the whole timeout. Release now waits for the
heartbeat to return, and retries the removal.

Three more were tests written against POSIX rather than against the tree:
the read-only-directory tests cannot work on Windows at all (`os.Chmod`
toggles a file attribute there and does not restrict a directory, so they
skip and say so); the identity path-rung tests compared against a native
path while `IdentityFor` deliberately returns a slash-separated one; and
every golden failed on a difference nobody wrote, because a Windows
checkout converted the committed goldens to CRLF. `.gitattributes` pins
them — fixing the cause rather than teaching the comparison to ignore it.

**CI is now green on ubuntu, macOS and Windows.**

### Known gaps, deliberate

- **`learn`'s record file has no bound.** `maxRecords` shipped unwired in
  `3baaac6` with a comment claiming a bound nothing enforced. This branch
  deletes the constant — it stops the tree lying about the gap, which is
  the part this branch is answerable for — and files the fix as its own
  task, because what `learn` retains is not what this branch is about.
- **Nothing tests `f.Sync()`.** Its failure mode is power loss between the
  rename and the data reaching disk, and no harness here produces that. The
  call stays because the pattern is only correct with it.
- **`procoder check` and the two tool hooks are not golden-captured.** All
  three exec gitleaks, semgrep, golangci-lint or the test runner, whose
  presence and version vary by machine; a golden of those would pin one
  laptop rather than procoder's behaviour and would fail in CI for reasons
  no change caused. Recorded in the spec's Out of scope.
- **`os.Stat` is not guarded.** Asking whether something exists is not
  reaching past the store, and gate adoption legitimately stats
  `.procoder/` to decide whether a repository opted in.

### Two process deviations, both deliberate

**The plan's task order was changed before any code was written.** It put
every guard last; the parity harness is the only thing that catches a
behaviour change in the twenty-six-package migration, so building it
afterwards means the riskiest task runs with no net. Task 7 became 7a
(harness, before the migration) and 7b (structural guards, after).

**This branch is not in a worktree**, which `WORKFLOW.md` asks for. It was
committed on a branch in the main checkout. The branch is clean and the
default branch was never dirtied, but it is a deviation and not worth
hiding.

### Docs impact

`procoder config` prints a new line and `.procoder/config.toml` accepts a
new key, so `docs/configuration.md` gained a `[service]` section (8d60453):
the ladder table, the URL normalisation, why `origin` wins, and when to set
the key by hand. The README describes `.procoder/` generically and links to
that page rather than enumerating keys, so it needs no change. Everything
else in this diff is internal plumbing with no reader-visible surface —
which the parity goldens are the evidence for.

Closes nothing on its own; #117 stays open for phase 1 (the local daemon).
Team mode is designed and parked in #248.
