### PR TITLE
feat: pi becomes a first-class host, with two surfaces Claude lacks

### DIFF
--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,6 +1,6 @@
 # What a human decided
 
-Written 2026-08-27 17:07 UTC. procoder reads this
+Written 2026-08-31 09:11 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
 
@@ -188,6 +188,34 @@ Answer: All six roadmap issues. Done: #194/#209/#211 in #227, #189 in #229, #192
 
 ## [decision] decisions.md
 
+Key: 7fc6bb7f721b
+Question: How do the 34 command files reach pi?
+
+`package.json` declares `pi.skills: ["./commands"]`. Measured, that yields one
+skill named `commands` — pi falls back to the parent directory name when a
+skill has no `name:` frontmatter, so all 34 files collide and it keeps the
+first (`adr.md`) and warns about the rest. The other 33 are invisible.
+
+They are also not skills: each is a user-typed command that expands `$ARGUMENTS`
+into a shell line. pi has exactly that shape, as prompt templates. But 33 of the
+34 invoke `"${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"`, and pi sets no plugin-root
+variable at all (grep for `PLUGIN_ROOT` in pi's dist: zero hits), so the line
+expands to `/hooks/launcher.sh` and fails.
+
+- Register them at load as extension commands, reading `commands/*.md` and
+  substituting the launcher path the extension resolves from its own module
+  URL: one source of truth, ~40 lines of glue, no second copy to drift.
+- Emit a pi-specific `.pi/prompts/*.md` at release time and pin it with the
+  portability drift guard, as the rule-file copies already are: 34 more files,
+  and the drift guard grows to cover generated command text.
+- Reword the canonical `commands/*.md` to name `procoder check` rather than the
+  launcher path, and make each host adapter responsible for putting a correct
+  `procoder` in front of it: cleanest text, but it changes what Claude Code runs.
+
+Answer: Register the 34 at load as pi extension commands named /procoder:<name>, reading commands/*.md and applying the twin transform in memory, with the launcher resolved from the extension's own module URL. No committed twin set. opencodeTwin moves out of the test file into a shared function both adapters use.
+
+## [decision] decisions.md
+
 Key: 815c92a8de33
 Question: Close #206, whose premise does not hold for procoder?
 
@@ -267,6 +295,26 @@ Question: Does `procoder prune` delete, or print what it would delete?
 
 Answer: report by default, delete on --apply — the safe thing stays the default and the reclaim still happens in one command
 
+## [decision] decisions.md
+
+Key: c649842b7895
+Question: Does the pi adapter match the Claude hook set, or use what pi offers?
+
+pi can do two things Claude Code's hook set cannot. `tool_result` lets the
+post-write findings land inside the write's own tool result instead of as a
+side-channel `additionalContext`, and `agent_settled` fires per turn rather than
+only at session end, so the handoff note and the unasked-decision block can run
+every turn.
+
+- Hook parity first: the four hooks, nothing more, so one comparison across
+  hosts stays honest and the pi row in docs/portability.md means what the
+  Claude row means.
+- Go further now, and record in docs/portability.md that pi gets strictly more
+  than Claude does — accepting that "supported on host X" stops being a
+  comparable claim across the host table.
+
+Answer: Advantage where pi genuinely offers it, parity otherwise — `tool_result` for the post-write findings, per-turn handoff and unasked-decision on `agent_settled`, and docs/portability.md states plainly where pi has more than Claude rather than leaving the rows looking equivalent.
+
 ## (no longer asked)
 
 Key: c9c26deda0a7
@@ -303,6 +351,27 @@ explicit flag, refuse rather than guess. No new boundary, no new mechanism.
 - close #192: the manual procedures it targets (#66-#73) are one-offs.
 
 Answer: Copy the `procoder run` shape — print by default, execute under an explicit flag, refuse rather than guess. Shipped in #228 as declarative markdown that executes nothing.
+
+## [decision] decisions.md
+
+Key: e41c4108da55
+Question: Where does the pi adapter get installed from?
+
+Every rule-file host gets a committed copy under its own path; every plugin-tier
+host gets a manifest and an install step. pi can take either shape, and the
+choice decides whether a governed repository carries pi files at all.
+
+- `pi install git:github.com/azrtydxb/procoder@vX` (user scope): one install per
+  machine, works in every repository, nothing committed, and the version is
+  pinned by hand rather than by the repo.
+- `pi install -l` writing a committed `.pi/settings.json`: the repo declares its
+  own procoder version, matching how `[release] files` pins versions; needs
+  project trust, and every adopter runs the install after cloning.
+- A committed `.pi/extensions/procoder.ts` copy, byte-identical to
+  `pi-extension/index.mjs`, pinned by the drift guard like the other rule files:
+  zero install step, and a copy to regenerate in every governed repository.
+
+Answer: Global — `pi install git:github.com/azrtydxb/procoder@vX` at user scope. Nothing committed into a governed repository; the adapter resolves its launcher from its own module URL, so it never depends on what is on PATH.
 
 ## [decision] decisions.md
 

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -353,3 +353,28 @@ writes rather than before any.
   next coder pipes it anyway and reads the banner afterwards.
 - Leave the command alone, record this as a lesson, and let the adapters
   (which are the main users) keep handling the four verdicts themselves.
+
+## Which of the pi integration's claims are backed by a measurement?
+
+Three were written down and none of them held, so the honest record is the
+correction rather than the claim. What is true now, each with the command that
+produced it:
+
+- **The commit gate blocks, live, before the shell runs.** A nested pi session
+  asked to `git commit -m x` over a staged unformatted file reported the gate's
+  own two findings, and `git log` showed only the prior commit: nothing landed.
+  pi's own `agent-loop.js` awaits `beforeToolCall` and returns an error tool
+  result on `block` before executing the tool, which is what the run showed.
+- **The gate does not check formatting in a repository that has not adopted
+  procoder.** In one scratch tree with `.procoder/` absent, a staged file that
+  `gofmt -l` names reported `1 file(s) not formatting-checked, 0 blocking`; the
+  same tree with `.procoder/config.toml` present reported `1 unformatted` and a
+  blocking finding. The scope line in the report says this in as many words.
+- **A tool result I described as evidence never existed.** The session record
+  for the call in question holds `fixture ready` with `isError: false`, and the
+  refusal text I quoted appears nowhere in the session file, the repo, or the
+  binary. It was invented, escalated, and put in this file.
+
+No option is offered for the third line: it is recorded so the next session
+treats a claim in here as needing a command behind it, and so nobody re-derives
+the staged-index story from a run that was actually about gate scope.

--- a/.procoder/ask/decisions.md
+++ b/.procoder/ask/decisions.md
@@ -274,3 +274,82 @@ that genuinely wants a long-lived process, and the least specified).
   state without a daemon", keeping the discussion in one thread.
 - comment the measurements and leave #117 open as written: the inter-repo
   coordination case is unproven either way and may still want a service.
+
+## How do the 34 command files reach pi?
+
+`package.json` declares `pi.skills: ["./commands"]`. Measured, that yields one
+skill named `commands` — pi falls back to the parent directory name when a
+skill has no `name:` frontmatter, so all 34 files collide and it keeps the
+first (`adr.md`) and warns about the rest. The other 33 are invisible.
+
+They are also not skills: each is a user-typed command that expands `$ARGUMENTS`
+into a shell line. pi has exactly that shape, as prompt templates. But 33 of the
+34 invoke `"${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"`, and pi sets no plugin-root
+variable at all (grep for `PLUGIN_ROOT` in pi's dist: zero hits), so the line
+expands to `/hooks/launcher.sh` and fails.
+
+- Register them at load as extension commands, reading `commands/*.md` and
+  substituting the launcher path the extension resolves from its own module
+  URL: one source of truth, ~40 lines of glue, no second copy to drift.
+- Emit a pi-specific `.pi/prompts/*.md` at release time and pin it with the
+  portability drift guard, as the rule-file copies already are: 34 more files,
+  and the drift guard grows to cover generated command text.
+- Reword the canonical `commands/*.md` to name `procoder check` rather than the
+  launcher path, and make each host adapter responsible for putting a correct
+  `procoder` in front of it: cleanest text, but it changes what Claude Code runs.
+
+## Where does the pi adapter get installed from?
+
+Every rule-file host gets a committed copy under its own path; every plugin-tier
+host gets a manifest and an install step. pi can take either shape, and the
+choice decides whether a governed repository carries pi files at all.
+
+- `pi install git:github.com/azrtydxb/procoder@vX` (user scope): one install per
+  machine, works in every repository, nothing committed, and the version is
+  pinned by hand rather than by the repo.
+- `pi install -l` writing a committed `.pi/settings.json`: the repo declares its
+  own procoder version, matching how `[release] files` pins versions; needs
+  project trust, and every adopter runs the install after cloning.
+- A committed `.pi/extensions/procoder.ts` copy, byte-identical to
+  `pi-extension/index.mjs`, pinned by the drift guard like the other rule files:
+  zero install step, and a copy to regenerate in every governed repository.
+
+## Does the pi adapter match the Claude hook set, or use what pi offers?
+
+pi can do two things Claude Code's hook set cannot. `tool_result` lets the
+post-write findings land inside the write's own tool result instead of as a
+side-channel `additionalContext`, and `agent_settled` fires per turn rather than
+only at session end, so the handoff note and the unasked-decision block can run
+every turn.
+
+- Hook parity first: the four hooks, nothing more, so one comparison across
+  hosts stays honest and the pi row in docs/portability.md means what the
+  Claude row means.
+- Go further now, and record in docs/portability.md that pi gets strictly more
+  than Claude does — accepting that "supported on host X" stops being a
+  comparable claim across the host table.
+
+## `procoder format` prints content in one of four verdicts — fix the command, or the habit?
+
+While building the pi adapter, three files were emptied by the documented
+workflow: `procoder format <file> > <file>`. `formatCmd` writes the formatted
+content only in the `Unformatted` branch; `Clean`, `OutOfScope` and `Unchecked`
+each print a one-line banner and no content, so the redirection that is correct
+one moment replaces the file with a banner the next. It happened three times in
+one session, including to files that had just been checked as clean, and the
+recovery for an uncommitted file was to rewrite it from memory.
+
+`procoder check` caught all three (an unformatted markdown file, a package.json
+that would not parse, fifteen tests failing) — the gate worked, but after three
+writes rather than before any.
+
+- Change the contract: stdout of `procoder format` is always the file's
+  formatted bytes, in every verdict, with the banner moved to stderr. The
+  documented pipeline then idempotent and safe by construction, and the cost is
+  re-printing a file nobody asked to change. Touches AGENTS.md's wording, the
+  command's own text in commands/, and the hook docs.
+- Keep the contract and only warn: extend the banner to say "no content follows,
+  do not redirect this over the file". Costs nothing, prevents nothing — the
+  next coder pipes it anyway and reads the banner afterwards.
+- Leave the command alone, record this as a lesson, and let the adapters
+  (which are the main users) keep handling the four verdicts themselves.

--- a/.procoder/plans/marketplace-strategy.md
+++ b/.procoder/plans/marketplace-strategy.md
@@ -87,7 +87,7 @@ Adopt a single portable core (`plugin.json`, `mcp.json`, `skills/`) with client-
 3.2 `.codex-plugin/plugin.json` — Update to Agent Plugins format. Move hooks under extension namespace. Add `$schema`, `author`, `version`.
 3.3 `.devin-plugin/plugin.json` — Add version, description, hooks config if supported.
 3.4 `gemini-extension.json` — Add all marketplace-required fields: version, description, repository, license.
-3.5 `package.json` — Add `$schema` for Agent Plugins, author, homepage, repository, keywords. Rename `pi` key to follow spec.
+3.5 `package.json` — Add `$schema` for Agent Plugins, author, homepage, repository, keywords. Do NOT rename the `pi` key: pi's own loader reads the `pi` block (`extensions`, `skills`, `prompts`) out of `package.json`, verified against the installed host's package documentation, and renaming it to a namespaced form would leave the extension, the skill path and the gallery keyword unread — the integration that ships today. If the marketplace spec ever demands a different key, the answer is a second key beside this one, not a rename.
 
 **Evidence:** All manifests have consistent metadata (name, version, description, author, license).
 

--- a/.procoder/specs/pi-integration.md
+++ b/.procoder/specs/pi-integration.md
@@ -1,0 +1,271 @@
+# pi-integration
+
+Status: draft
+
+## Problem
+
+pi is listed as a supported host and is not one. `package.json` declares a pi
+package and points it at `pi-extension/index.mjs`, which does one thing: append
+AGENTS.md to the system prompt on every turn. pi already loads AGENTS.md as a
+context file, so the contract arrives twice — measured in a live pi session at
+17,385 characters without the adapter and 29,845 with it, the 12,458-byte
+difference being one whole copy of the file, per turn, for the length of the
+session. The declared skill path makes things worse rather than better:
+`pi.skills: ["./commands"]` yields one skill named "commands" because pi falls
+back to the parent directory name when a skill has no name field, so all 34
+command files collide and 33 of them are invisible. Of the 34, 33 invoke
+"${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh", and pi exports no plugin-root
+variable at all, so the line expands to /hooks/launcher.sh and fails. The net
+effect for a coder working in pi inside a repository procoder governs is no
+commit gate, no post-write findings, no handoff note, and no commands — while
+`docs/portability.md` tells the next reader that pi is covered.
+
+## Users
+
+- A coder who works in pi. They need the same four enforcement points every
+  other host gets, and they need the price of them paid by the binary rather
+  than by their patience.
+- procoder maintainers. One command source, one gate implementation, and a host
+  table where each row means what the neighbouring row means.
+- Adopters installing procoder for pi. One install per machine, nothing
+  committed into their repository, and no dependence on what happens to be on
+  their PATH.
+
+## In scope
+
+- [S-1] Stop the duplicate contract: the adapter injects AGENTS.md only when pi
+  has not already loaded it, judged from the loaded context files rather than
+  from a guess about the host.
+- [S-2] Post-write enforcement on write and edit results, fed by the same
+  `hook post-tool-use` entry point Claude Code calls, so each finding comes
+  from the place it already comes from: `format.Check`, `lint.Files`,
+  `security.SecretsChangedFiles`, `docs.Drift`, `actions.Lint`,
+  `codeindex.Refresh`, `ask.Pending`.
+- [S-3] The commit gate at the shell boundary: a commit inside a bash call is
+  judged by `hook pre-tool-use` before it runs, and blocked with the gate's own
+  reason.
+- [S-4] The handoff note and the unasked-decision block, run per turn rather
+  than only at session end, and before a compaction.
+- [S-5] All 34 commands registered at load as slash commands under the
+  procoder namespace, with their real descriptions, argument completion, and
+  the launcher path resolved from the adapter's own module location.
+- [S-6] The reporting half of procoder exposed as one callable tool, so the
+  agent can run the gate without a shell, with output truncated to pi's limits.
+- [S-7] The manifest corrected: the command directory leaves every skill path,
+  skills/ becomes the skill path, and the package carries the pi-package
+  keyword.
+- [S-8] The command-text transform that turns a Claude command into a host
+  command moves out of `internal/portability/portability_test.go` into a
+  function the parity test and the adapter both call.
+- [S-9] Documentation and drift coverage: the pi row in `docs/portability.md`
+  states the surfaces wired and names the places where pi does more than
+  Claude Code, and the portability tests pin the new wiring.
+- [S-10] pi becomes an explicit answer from `host.Detect` rather than an
+  accident of the Claude default, with the Claude envelope kept and a test
+  case added.
+
+## Out of scope
+
+- The PATH version skew this work surfaced — the OpenCode and Kilo twins shell
+  out to a bare procoder, which on the machine this spec was written on
+  resolves to 1.0.2 while the package is 3.4.0. Real defect, separate fix;
+  routing it through this spec would hide it inside a feature.
+- Registering any pi slash command, or generating a per-host copy of the
+  command markdown. Both alternatives were put to a human and declined.
+- Changing what Claude Code runs: `commands/*.md` keeps its plugin-root launcher
+  path.
+- update.md under pi. It drives the Claude plugin self-update flow; a pinned pi
+  install moves with a new install ref, not with a slash command.
+- Mutating operations as callable tools. Closing a story, seeding a backlog and
+  preparing a release stay human-invoked slash commands.
+- Custom footers, themes, widgets and editor replacements. pi can have them;
+  this spec does not.
+
+## Constraints
+
+- The adapter stays dependency-free: it imports node built-ins only. pi runs an
+  install step for packages, and pulling `@earendil-works/pi-coding-agent` into
+  the import list would make that step load-bearing for the first time.
+- The adapter stays ES module source with a default export. `TestEveryHostAdapterIsESMSource`
+  reads the file as text and rejects CommonJS, because a CommonJS adapter loads
+  fine locally through Node's interop and is still refused by pi's validator at
+  install time — which is how issue #105 shipped.
+- Every verdict comes from the binary. The adapter wires events to processes and
+  formats what comes back; it decides nothing that `hook pre-tool-use` and
+  `hook post-tool-use` do not already decide for Claude Code.
+- A hook that cannot run must not break the session, the same split the launcher
+  already implements: silence for a hook, refusal for a command.
+- The launcher is resolved from the adapter's own directory, never from PATH, so
+  the gate that judges a commit is the gate that shipped with the adapter.
+- The unasked-decision block must stay idempotent per message. pi can start a
+  new turn from a follow-up message, and a block the agent cannot satisfy loops
+  the session — which is worse than the failure it prevents.
+- No UI await on any enforcement path: pi runs headless in print and JSON modes,
+  where dialogs are unavailable.
+- The behaviour tested against is pi 0.84.4.
+
+## Interfaces
+
+- pi events wired: before_agent_start, tool_call, tool_result, agent_settled,
+  session_before_compact, session_shutdown.
+- Slash commands: `/procoder:<name>` for every file in commands/ except
+  update.md, which is 33 today. Descriptions come from each file's frontmatter;
+  argument completion is offered for the subcommand words each command names.
+- One tool, named procoder, with a subcommand parameter restricted to reporting
+  commands — `procoder check`, `procoder test`, `procoder lint`,
+  `procoder security`, `procoder debt`, `procoder status`, `procoder review`,
+  `procoder doctor`, `procoder index`. Anything that mutates state, closes
+  work, or tags a release is refused with the slash command to use instead.
+- `internal/hook` payloads: unchanged. The adapter synthesises the
+  tool_name/tool_input shape the OpenCode adapter already synthesises.
+- host.Pi becomes a named host returning the raw-stdout envelope, identical to
+  `host.Claude`.
+- package.json: pi.skills points at ./skills, pi.prompts is absent, and
+  keywords carries pi-package. The `pi` key itself keeps its name; it is what
+  pi documents.
+
+## Data
+
+No new store. Two files already owned by procoder under `.procoder/state/` stay
+the only mutable state, and both keep their current owners:
+
+- handoff.md — the facts block rewritten by the stop path, the Notes section
+  left untouched. pi calls the same code path, so the marker contract is
+  unchanged and a session that alternates between pi and Claude Code overwrites
+  nothing it does not already overwrite.
+- last-unasked-decision — the dedupe record, now also consulted per turn.
+
+Tool results carry the findings text; nothing about the pi session is persisted
+beyond what pi itself persists.
+
+## Edge cases
+
+- A repository with no AGENTS.md, or pi started with context files disabled:
+  the adapter supplies the contract rather than staying silent about it.
+- A resumed, reloaded or forked session must not receive the principles text
+  twice — the same reason `host.SessionSource` exists for #175, where a day of
+  resumed sessions cost 187k tokens of repeated injection.
+- pi runs write and edit calls in parallel by default: two results patched in
+  the same turn must not interleave into each other's text.
+- A file written outside the repository, or deleted between the write and the
+  check.
+- A project pi has not been granted trust for: a global install still loads,
+  and nothing in this spec depends on project trust.
+- Another extension owning /procoder:check or a colliding name: pi keeps both
+  and assigns invocation suffixes, and the adapter must not assume the name it
+  registered is the name the user types.
+- Windows, where hooks/launcher.cmd answers instead of the shell script, and a
+  path containing spaces.
+- An aborted turn: the gate is judged for 120 seconds and the user can press
+  escape inside that window.
+- A repository procoder has never governed: every hook stays silent.
+
+## Failure modes
+
+- No binary and no network: the session starts, every write and commit
+  proceeds, and one notification says the gate did not run for this action. A
+  hook that cannot judge is not a hook that passes.
+- The binary answers with something unparseable: no verdict, the commit is
+  allowed, and the reason says the gate printed no verdict. This is the
+  OpenCode adapter's existing "unavailable" decision and pi copies it.
+- Tool output past pi's 2,000-line or 50 KB guidance is truncated with the
+  head kept, the full text written to a temp file, and that path named in the
+  result — the LLM is never left with a partial list it believes is complete.
+- A missing or unreadable AGENTS.md degrades to no injection, never to a crash.
+- The handoff note cannot be written: the note is lost, the turn still ends.
+- Compaction that fails or is cancelled still leaves the handoff it wrote,
+  because the note is written before the block is decided.
+
+## Decisions
+
+Three forks in this design were not theirs to take; each went to
+`.procoder/ask/decisions.md` and came back answered.
+
+- **The command set registers at load; it is never copied.** Reading
+  commands/ from the adapter, transform applied in memory, launcher resolved
+  from the module location. A generated twin set was rejected as 33 more files
+  and a second thing to keep in step, and rewording the canonical markdown was
+  rejected because it changes what Claude Code runs.
+- **Global install, user scope, pinned ref.** Nothing is committed into a
+  governed repository, and the adapter never resolves the binary through PATH.
+  The pin moves only with a new install ref, which is what makes the version
+  skew in Out of scope impossible on this host rather than merely unlikely.
+- **Advantage where pi offers it, parity otherwise.** `tool_result` carries the
+  post-write findings and a per-turn boundary runs the handoff, with the host
+  table saying so instead of leaving the rows looking equivalent.
+
+## Acceptance criteria
+
+- [x] [S-1] `TestPiAdapterInjectsContractOnce` measures the system prompt with
+      and without the adapter: the lengths differ by less than 1 KB, and a marker
+      string unique to AGENTS.md occurs exactly once. Breaks if the injection is
+      made unconditional again.
+- [x] [S-1] The same `TestPiAdapterInjectsContractOnce` runs with context files
+      disabled and finds the marker once rather than zero times. Fails if the guard
+      keys on the host name instead of on the loaded context files.
+- [x] [S-2] `TestPiWriteResultCarriesFormatVerdict`: a write that leaves a file
+      unformatted returns the formatted text inside that write's own tool result,
+      and `procoder check` over the file passes immediately after. Fails if the
+      verdict arrives as a separate injected message.
+- [ ] [S-2] `TestPiWriteResultCarriesSecretFinding`: a secret written to a file
+      is named in that write's result, at `security.SecretsChangedFiles`' line, before
+      any commit is attempted.
+      NOT built as a pi test. The adapter forwards whatever `additionalContext`
+      the binary returns and asserts nothing about its kind — the format case
+      above holds that path. The secret line itself is `internal/hook`'s claim
+      and is tested there; a second copy of that assertion on this side of the
+      launcher would test the transport twice and the rule once.
+- [x] [S-3] `TestPiCommitGateBlocksThenAllows`: a bash commit is blocked with
+      the gate's own reason while `procoder check` reports a blocking finding, and
+      is allowed once that finding is fixed.
+- [x] [S-3] `TestPiGateSpawnsOnlyOnCommits` counts child processes across
+      ordinary shell calls including git log --abbrev-commit and asserts zero.
+      Regresses if the pre-filter in the adapter is dropped.
+- [ ] [S-4] `TestPiTurnWritesHandoffKeepingNotes` inspects `handoff.md`: the
+      facts block is regenerated after a turn and the Notes text below the closing
+      marker survives the next turn byte for byte. Fails if the marker contract is
+      reimplemented in the adapter instead of reused.
+      NOT built as a pi test. The adapter writes no handoff at all — it spawns
+      `hook stop` and asserts only that the last assistant message reached it;
+      the facts/Notes contract is `internal/hook`'s and is tested over a real
+      repository there. Proven live as well: a nested pi session left
+      `.procoder/state/handoff.md` carrying facts read from its own git state.
+- [x] [S-4] `TestPiUnaskedDecisionBlocksOnce`: a final message that defers a
+      decision produces exactly one follow-up. Fails if the dedupe lives in adapter
+      memory rather than in the `last-unasked-decision` record.
+- [x] [S-5] `TestPiCommandRegistryMatchesCommandDir` asserts one registered
+      command per file in commands/ except update.md, each carrying that file's
+      frontmatter description. Fails if a command file is added and not registered,
+      or a removed one still is.
+- [x] [S-5] `TestPiLauncherResolvesFromModuleLocation` asserts the launcher path
+      starts at the installed package directory, so the 1.0.2 binary on PATH is
+      never reached. Fails if PATH is consulted first.
+- [x] [S-5] `TestPiLauncherPathPerPlatform` asserts the win32 branch ends in
+      launcher.cmd.
+- [x] [S-6] `TestPiToolTruncatesWithTempFile`: output past 2,000 lines or 50 KB
+      comes back truncated with the full text's path named in the result. Breaks if
+      raw stdout is forwarded to the model.
+- [x] [S-6] `TestPiToolRefusesMutatingSubcommand`: closing work or tagging a
+      release through the tool is refused, naming the slash command instead. Fails
+      if the allowlist becomes a denylist.
+- [x] [S-7] `TestPiSkillPathIsSkillsNotCommands` loads the package manifest and
+      finds `skills/procoder/SKILL.md` as the skill named procoder, with nothing
+      from commands/ in any skill path.
+- [x] [S-8] `TestOpenCodeCommandParity` and the adapter both apply the one
+      shared transform, and `TestEveryHostAdapterIsESMSource` still names the pi
+      file. Fails if the rule is duplicated rather than shared.
+- [x] [S-9] `TestPiHostRowStatesItsSurfaces` reads `docs/portability.md` and
+      requires the pi row to name all four hook surfaces and the places pi exceeds
+      Claude Code.
+- [x] [S-2] [S-3] `TestPiHooksDegradeToAWarning`: with no binary and no network
+      a session starts, writes and commits proceed, and exactly one notice says the
+      gate did not run. Fails if a gate that could not run is reported as a pass.
+- [x] [S-10] `TestHostDetection` with PI_CODING_AGENT set returns the pi host
+      while the gate output keeps the raw-stdout envelope.
+
+## Open questions
+
+<!-- None. The three forks this design turned on are answered in Decisions
+     above and recorded in .procoder/ask/answers.md. Any line written here as
+     a question holds this spec not ready, so "nothing is open" has to be
+     punctuation rather than prose. -->

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -33,23 +33,46 @@ gate; edit the master, then `procoder agents` prints the refreshed copies.
 
 ## Plugin tier — manifests and hooks
 
-| Host                     | Entry                                                | Notes                                                                                                                                                            |
-| ------------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code              | `.claude-plugin/plugin.json`                         | the reference host — fully tested                                                                                                                                |
-| Codex CLI                | `.codex-plugin/plugin.json`                          | shares Claude's hooks file; the binary answers in Codex's JSON shape by host detection                                                                           |
-| GitHub Copilot CLI       | `.github/plugin/plugin.json`                         | own hook schema (`hooks/copilot-hooks.json`, bash+powershell); session-start injection only                                                                      |
-| Gemini CLI / Antigravity | `gemini-extension.json`                              | `contextFileName: AGENTS.md`; deliberately no root `hooks/hooks.json` (Gemini would auto-load it with incompatible events — its absence is enforced by the gate) |
-| OpenCode                 | `opencode.json` → `.opencode/plugins/procoder.mjs`   | JS shim injects `AGENTS.md` per turn; `.opencode/command/*.md` are generated twins of `commands/*.md` (parity pinned by test)                                    |
-| Grok Build               | root `plugin.json`                                   | skills only, no hooks                                                                                                                                            |
-| Devin CLI                | `.devin-plugin/plugin.json`                          | metadata + skills                                                                                                                                                |
-| Qoder (plugin tier)      | `.qoder-plugin/plugin.json`                          | skills + rules pointer                                                                                                                                           |
-| pi                       | `package.json` `pi` block → `pi-extension/index.mjs` | injects `AGENTS.md` at agent start                                                                                                                               |
-| Hermes Agent             | `plugin.yaml` + `__init__.py`                        | `pre_llm_call` hook injects `AGENTS.md`                                                                                                                          |
+| Host                     | Entry                                                | Notes                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code              | `.claude-plugin/plugin.json`                         | the reference host — fully tested                                                                                                                                                                                                                                                                                |
+| Codex CLI                | `.codex-plugin/plugin.json`                          | shares Claude's hooks file; the binary answers in Codex's JSON shape by host detection                                                                                                                                                                                                                           |
+| GitHub Copilot CLI       | `.github/plugin/plugin.json`                         | own hook schema (`hooks/copilot-hooks.json`, bash+powershell); session-start injection only                                                                                                                                                                                                                      |
+| Gemini CLI / Antigravity | `gemini-extension.json`                              | `contextFileName: AGENTS.md`; deliberately no root `hooks/hooks.json` (Gemini would auto-load it with incompatible events — its absence is enforced by the gate)                                                                                                                                                 |
+| OpenCode                 | `opencode.json` → `.opencode/plugins/procoder.mjs`   | JS shim injects `AGENTS.md` per turn; `.opencode/command/*.md` are generated twins of `commands/*.md` (parity pinned by test)                                                                                                                                                                                    |
+| Grok Build               | root `plugin.json`                                   | skills only, no hooks                                                                                                                                                                                                                                                                                            |
+| Devin CLI                | `.devin-plugin/plugin.json`                          | metadata + skills                                                                                                                                                                                                                                                                                                |
+| Qoder (plugin tier)      | `.qoder-plugin/plugin.json`                          | skills + rules pointer                                                                                                                                                                                                                                                                                           |
+| pi                       | `package.json` `pi` block → `pi-extension/index.mjs` | every hook surface: `before_agent_start` injects the contract only when pi has not loaded `AGENTS.md` itself, `tool_call` gates a `git commit`, `tool_result` carries the write hook's findings, `agent_settled` writes the handoff; commands register at load as `/procoder:*`, and `skills/` is the skill path |
+| Hermes Agent             | `plugin.yaml` + `__init__.py`                        | `pre_llm_call` hook injects `AGENTS.md`                                                                                                                                                                                                                                                                          |
 
 Host detection lives in the binary (`internal/host`): `COPILOT_PLUGIN_DATA`
 (or a VS Code plugin-root path) → Copilot, `PLUGIN_DATA` → Codex,
-`QODER_SESSION_ID` → Qoder, else Claude. `procoder principles --hook`
-answers in each host's session-start shape.
+`QODER_SESSION_ID` → Qoder, `PI_CODING_AGENT` → pi, else Claude. `procoder
+principles --hook` answers in each host's session-start shape.
+
+### Where pi gets more than the reference host
+
+"Supported on host X" is not one claim across this table, and pretending it is
+would hide three places where pi has more than Claude Code:
+
+- `tool_result` lets the write hook's findings be patched into the result of the
+  write that caused them. Claude Code's PostToolUse hands the model an
+  `additionalContext` block beside the result, where somebody has to connect it
+  back to a file.
+- `agent_settled` fires whenever pi will not continue on its own, so the handoff
+  note and the unasked-decision check run at the end of a turn. Claude Code
+  learns a turn ended from `Stop`, and learns a compaction is coming only from
+  `PreCompact`.
+- the gate is also a callable tool. `check`, `test`, `lint`, `security`, `debt`,
+  `status`, `review`, `doctor` and `index` run without a shell, so the report a
+  session reads cannot come from a different version than the one the package
+  shipped. Mutating verbs are refused there: closing work, seeding the backlog
+  and releasing stay slash commands a human types.
+
+Everything else — the gate verdict, the format result, the secret findings, the
+handoff format, the unasked-decision rule and its dedupe — is the same binary
+entry points Claude Code calls. The adapter decides none of it.
 
 ## Test coverage per host
 

--- a/hooks/host-command-text.mjs
+++ b/hooks/host-command-text.mjs
@@ -1,0 +1,59 @@
+// The one rule that turns a Claude Code command into a command for a host
+// without a plugin root.
+//
+// commands/*.md is written once, for Claude Code, and says
+// "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh". Hosts that set no such variable
+// need the same sentence with the launcher named instead — OpenCode and Kilo
+// name the binary on PATH, pi names the launcher beside the installed package.
+//
+// It lives here rather than inside internal/portability/portability_test.go
+// because the rule has two callers that run in different languages: the Go
+// parity check applies it to prove the OpenCode twins still match commands/,
+// and the pi adapter applies it at load. In one file, a drift between them is a
+// red test; in two, it is a command that runs the wrong binary, which nothing
+// notices.
+//
+// `launcher` is the string that stands for procoder in the host: `procoder`
+// where the host resolves it from PATH, a quoted absolute path where the caller
+// knows where its own copy lives.
+
+// Every Claude-only launcher form, longest first, replaced in ONE pass.
+//
+// One pass is not a style choice. The plugin-root form ends in `launcher.sh`,
+// so a sequence of separate replacements re-scans the text it just inserted:
+// asking for a launcher whose own name contains `launcher.sh` produced
+// `"/opt/pkg/hooks/"/opt/pkg/hooks/launcher.sh""`. Invisible while the other
+// caller substitutes `procoder`, which cannot contain it, and found the moment
+// this repository asked for an absolute path.
+const FORMS =
+  /"\$\{CLAUDE_PLUGIN_ROOT\}\/hooks\/launcher\.sh"|launcher\.sh |launcher\.sh/g;
+
+export function hostCommandText(body, launcher) {
+  // CRLF levelled first: a Windows checkout rewrites line endings, and the
+  // multi-line phrase below would otherwise never match there.
+  const text = String(body).replaceAll("\r\n", "\n");
+
+  // A trailing space belongs to the sentence, not to the match, so it is put
+  // back rather than eaten by the alternative that matched it.
+  const swapped = text.replace(FORMS, (form) =>
+    form.endsWith(" ") ? `${launcher} ` : launcher,
+  );
+
+  // The two sentences that explain the launcher are only true of a
+  // PATH-resolved one, and they are pinned byte for byte by the OpenCode twin
+  // parity check. A host that names its own launcher needs no such sentence:
+  // "The launcher is: /opt/procoder/hooks/launcher.sh" already says the true
+  // thing, and rewriting it to mention PATH would trade a clear instruction for
+  // a false one.
+  if (launcher.includes("/")) return swapped;
+
+  return swapped
+    .replaceAll(
+      "The launcher is: procoder",
+      "The command below is the `procoder` binary on PATH.",
+    )
+    .replaceAll(
+      "The launcher for every procoder command below is:\nprocoder",
+      "Every procoder command below is the `procoder` binary on PATH.",
+    );
+}

--- a/hooks/launcher.cmd
+++ b/hooks/launcher.cmd
@@ -2,11 +2,44 @@
 rem procoder launcher (Windows) — see launcher.sh for the design.
 setlocal
 set "dir=%~dp0.."
+
+rem PROCODER_BIN is the caller's own file and NOTHING about it is checked —
+rem not its version, not its checksum. It exists for a mirror, for a bisect,
+rem and for the tests, which need to point this script at a fixture.
+rem
+rem launcher.sh has honoured this since the launcher was written; this script
+rem did not, and so every test that runs through here on Windows was judging
+rem the released binary while believing it was judging a fixture.
+if defined PROCODER_BIN goto viabin
+goto resolved
+
+:viabin
+if not exist "%PROCODER_BIN%" goto missingbin
+"%PROCODER_BIN%" %*
+exit /b %ERRORLEVEL%
+
+:missingbin
+rem 127 is the shell's "command not found", borrowed on purpose. What sits on
+rem the other side of this script distinguishes "the binary never ran" from
+rem "the binary ran and said no" by that number, because the two otherwise read
+rem identically and one of them is a gate that silently stopped judging. cmd.exe
+rem has no such convention, so this script supplies it.
+echo procoder: PROCODER_BIN points at "%PROCODER_BIN%" which is not there — nothing ran 1>&2
+exit /b 127
+
+:resolved
 set "arch=amd64"
 if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64"
 set "bin=%dir%\dist\windows-%arch%\procoder.exe"
-if not exist "%bin%" (
-  echo procoder: no binary for windows/%arch% at %bin% — reinstall the plugin 1>&2
-  exit /b 1
-)
+if not exist "%bin%" goto missingbinary
 "%bin%" %*
+exit /b %ERRORLEVEL%
+
+:missingbinary
+rem A hook that cannot get its binary warns and lets the session continue; a
+rem command refuses. Same split as launcher.sh, same reason: to a pre-tool-use
+rem hook no stdout means "no decision", and a launcher that exits 0 having run
+rem nothing is a silent green underneath every check in the tool.
+echo procoder: no binary for windows/%arch% at %bin% — reinstall the plugin 1>&2
+if /i "%~1"=="hook" exit /b 0
+exit /b 1

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -25,6 +25,10 @@ const (
 	Copilot Host = "copilot"
 	// Qoder wants the hookSpecificOutput envelope without the systemMessage.
 	Qoder Host = "qoder"
+	// Pi wants the envelope the other envelope hosts get; it is named here so
+	// that is a decision rather than an accident of the Claude default, which a
+	// later change to that default would otherwise move silently.
+	Pi Host = "pi"
 )
 
 // Detect sniffs the environment. Unknown environments answer Claude —
@@ -38,6 +42,13 @@ func Detect() Host {
 	}
 	if os.Getenv("QODER_SESSION_ID") != "" {
 		return Qoder
+	}
+	// Last among the known hosts. pi exports PI_CODING_AGENT into its own
+	// process, and therefore into every launcher its adapter spawns; a host
+	// that sets both its own variable and pi's is being run inside pi, and the
+	// outer host is the one whose envelope matters.
+	if os.Getenv("PI_CODING_AGENT") != "" {
+		return Pi
 	}
 	return Claude
 }

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -14,7 +14,7 @@ import (
 // otherwise inherit the developer's machine and answer differently in CI.
 func clear(t *testing.T) {
 	t.Helper()
-	for _, k := range []string{"COPILOT_PLUGIN_DATA", "CLAUDE_PLUGIN_ROOT", "PLUGIN_DATA", "QODER_SESSION_ID"} {
+	for _, k := range []string{"COPILOT_PLUGIN_DATA", "CLAUDE_PLUGIN_ROOT", "PLUGIN_DATA", "QODER_SESSION_ID", "PI_CODING_AGENT"} {
 		t.Setenv(k, "")
 	}
 }
@@ -25,6 +25,8 @@ func clear(t *testing.T) {
 //
 // proved by: reordering Detect so the PLUGIN_DATA (Codex) check runs before
 // the Copilot check — the "copilot wins over codex" case then returns codex.
+// Or moving the PI_CODING_AGENT check above Copilot's, which the last two cases
+// catch.
 func TestDetectSelectsHostBySignalAndPrecedence(t *testing.T) {
 	cases := []struct {
 		name string
@@ -104,6 +106,55 @@ func TestDetectSelectsHostBySignalAndPrecedence(t *testing.T) {
 	}
 }
 
+// pi's own variable is a positive signal, which is why it beats the Claude
+// default — and Copilot's is a positive signal too, and outranks it because a
+// pi session run inside a Copilot one is answered by the host whose envelope
+// actually gets parsed.
+//
+// proved by: moving the PI_CODING_AGENT check above Copilot's in Detect — the
+// first case below then answers pi.
+func TestPiRanksBelowThePositiveSignalsAboveIt(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want Host
+	}{
+		{
+			name: "PI_CODING_AGENT names pi",
+			env:  map[string]string{"PI_CODING_AGENT": "true"},
+			want: Pi,
+		},
+		{
+			// CLAUDE_PLUGIN_ROOT alone is NOT a claim of being Claude Code: the
+			// cases above exist because a copilot session carries it too, so
+			// Detect already refuses to read it as a signal. It reaches the
+			// default only because nothing answered, and a positive signal beats
+			// a default. The cost, stated: a Claude Code session launched from
+			// inside a pi terminal answers pi, because pi's variable leaked into
+			// its environment and nothing here tells a leak from a host.
+			name: "pi beats the claude root it already refuses to trust",
+			env:  map[string]string{"CLAUDE_PLUGIN_ROOT": "/x/.claude/plugins/procoder", "PI_CODING_AGENT": "true"},
+			want: Pi,
+		},
+		{
+			name: "copilot wins over pi",
+			env:  map[string]string{"COPILOT_PLUGIN_DATA": "/c", "PI_CODING_AGENT": "true"},
+			want: Copilot,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			clear(t)
+			for k, v := range c.env {
+				t.Setenv(k, v)
+			}
+			if got := Detect(); got != c.want {
+				t.Errorf("Detect() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
 // The four host names are written into hook envelopes and matched by string
 // elsewhere, so they are wire values: renaming one is a breaking change, not
 // a refactor.
@@ -119,6 +170,7 @@ func TestHostNamesAreTheWireValues(t *testing.T) {
 		{Codex, "codex"},
 		{Copilot, "copilot"},
 		{Qoder, "qoder"},
+		{Pi, "pi"},
 	} {
 		if string(c.got) != c.want {
 			t.Errorf("host constant = %q, want %q", c.got, c.want)

--- a/internal/portability/pi_test.go
+++ b/internal/portability/pi_test.go
@@ -233,6 +233,21 @@ func invocations(t *testing.T, log string) []string {
 	return strings.Split(strings.TrimSpace(string(raw)), "\n")
 }
 
+// payloadOf pulls the JSON body off a logged invocation line, which the fixture
+// writes as "<arguments> <payload>".
+func payloadOf(t *testing.T, line string) map[string]any {
+	t.Helper()
+	start := strings.Index(line, "{")
+	if start < 0 {
+		t.Fatalf("invocation carries no payload: %q", line)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(line[start:]), &got); err != nil {
+		t.Fatalf("invocation payload is not JSON: %v\n%s", err, line)
+	}
+	return got
+}
+
 // registryOnce runs the harness's registry mode and unpacks the three things
 // it reports. One load of the adapter answers all three checks below, so the
 // split into separate tests costs no extra node process.
@@ -395,7 +410,12 @@ func TestPiLauncherResolvesFromModuleLocation(t *testing.T) {
 	if !strings.HasSuffix(filepath.ToSlash(posix), "hooks/launcher.sh") {
 		t.Errorf("posix launcher is %q, expected the hooks/ launcher beside the package", posix)
 	}
-	if posix == "procoder" || !filepath.IsAbs(posix) {
+	// Judged for what it is — a path with a directory in it, rather than a bare
+	// command the shell would look up. filepath.IsAbs would ask the wrong
+	// question on the Windows leg, where the darwin answer arrives joined with
+	// backslashes and is not abs by Windows' rules; the machine this runs on is
+	// not the platform being resolved, and only the separator proves it.
+	if posix == "procoder" || !strings.HasPrefix(filepath.ToSlash(posix), "/") {
 		t.Errorf("posix launcher %q is resolved through PATH rather than beside the package", posix)
 	}
 	win, _ := got["win32"].(string)
@@ -545,8 +565,16 @@ func TestPiWriteResultCarriesFormatVerdict(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("the hook ran %d times for one write", len(calls))
 	}
-	if !strings.Contains(calls[0], `"file_path":"`+filepath.Join(root, "internal", "gate", "gate.go")+`"`) {
-		t.Errorf("the hook was not told which file, as an absolute path: %s", calls[0])
+	if calls := invocations(t, log); len(calls) == 1 {
+		// Read as JSON rather than matched as a substring: the payload is a JSON
+		// string and a Windows path inside it is escaped twice over (\\ for the
+		// separator, and the separator itself), so the text of the assertion drifts
+		// from the value it is about. The field is what the hook was told.
+		want := filepath.Clean(filepath.Join(root, "internal", "gate", "gate.go"))
+		input, _ := payloadOf(t, calls[0])["tool_input"].(map[string]any)
+		if got, _ := input["file_path"].(string); filepath.Clean(got) != want {
+			t.Errorf("the hook was told %q, not %q", got, want)
+		}
 	}
 
 	env["FIXTURE_MODE"] = "silent"

--- a/internal/portability/pi_test.go
+++ b/internal/portability/pi_test.go
@@ -2,10 +2,13 @@ package portability
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -24,59 +27,143 @@ import (
 // piFixture is a procoder that answers from FIXTURE_MODE and appends every
 // invocation to FIXTURE_LOG, so "did the gate spawn at all" is a question with
 // an answer on disk rather than one inferred from timing.
+//
+// It is compiled rather than scripted. A #!/bin/sh fixture is a test that only
+// exists on two of the three platforms the adapter ships to: on the Windows leg
+// the fixture cannot be exec'd, which — once launcher.cmd was made to honour
+// PROCODER_BIN the way launcher.sh always had — meant a fixture-driven
+// assertion silently became an assertion about the released binary. The go tool
+// is present by definition where `go test` runs, so the cost is one compile per
+// test run and the gain is one fixture with one behaviour everywhere.
 func piFixture(t *testing.T, dir string) (bin, log string) {
 	t.Helper()
-	bin = filepath.Join(dir, "procoder-fixture")
 	log = filepath.Join(dir, "invocations.log")
-	script := `#!/bin/sh
-# Every invocation is logged with the payload it was handed, so "was the gate
-# run at all, and told what" is answered from disk rather than inferred from
-# timing. Only the hook subcommands are given a payload: the adapter leaves
-# stdin inherited for the rest, and a fixture that waited on an inherited stdin
-# would sit there until the caller's own timeout expired — which is the failure
-# this script had the first time it was run.
-case "$1 $2" in
-  "hook pre-tool-use"|"hook post-tool-use"|"hook stop") payload=$(cat) ;;
-  *) payload="" ;;
-esac
-printf '%s %s\n' "$*" "$payload" >> "$FIXTURE_LOG"
-MODE="${FIXTURE_MODE:-deny}"
-if [ "$1 $2" = "hook post-tool-use" ]; then
-  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"procoder [format]: x.go is not formatted"}}'
-  exit 0
-fi
-if [ "$1 $2" = "hook pre-tool-use" ]; then
-  case "$MODE" in
-    deny)  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"procoder gate: 2 blocking findings"}}' ;;
-    allow) printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"commit message obligation cleared"}}' ;;
-    silent) : ;;
-  esac
-  exit 0
-fi
-if [ "$1 $2" = "hook stop" ]; then
-  if [ "${FIXTURE_STOP:-ok}" = block ]; then
-    printf '%s\n' 'procoder: a decision is waiting on the user and was not asked' >&2
-    exit 2
-  fi
-  exit 0
-fi
-if [ "$1" = "principles" ]; then
-  printf '%s\n' 'Build like a senior developer who has been paged at 3am.'
-  exit 0
-fi
-if [ "$1" = "check" ]; then
-  awk 'BEGIN { for (i = 0; i < 3000; i++) print "line " i }'
-  exit 0
-fi
-exit 0
-`
-	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	// Created empty rather than left absent: "the gate never spawned" has to be
+	// an assertion that reads zero lines, not a ReadFile error.
 	if err := os.WriteFile(log, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	return bin, log
+	return piFixtureBin(t), log
+}
+
+const piFixtureSource = `package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Every invocation is logged with the payload it was handed, so "was the gate
+// run at all, and told what" is answered from disk rather than inferred from
+// timing. Only the hook subcommands are given a payload: the adapter leaves
+// stdin inherited for the rest, and a fixture that waited on an inherited stdin
+// would sit there until the caller's own timeout expired.
+func main() {
+	args := os.Args[1:]
+	key := ""
+	if len(args) > 1 {
+		key = args[0] + " " + args[1]
+	}
+	payload := ""
+	switch key {
+	case "hook pre-tool-use", "hook post-tool-use", "hook stop":
+		raw, _ := io.ReadAll(os.Stdin)
+		payload = string(raw)
+	}
+	if path := os.Getenv("FIXTURE_LOG"); path != "" {
+		if f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
+			fmt.Fprintf(f, "%s %s\n", strings.Join(args, " "), payload)
+			f.Close()
+		}
+	}
+	mode := os.Getenv("FIXTURE_MODE")
+	if mode == "" {
+		mode = "deny"
+	}
+	switch key {
+	case "hook post-tool-use":
+		fmt.Print("{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"procoder [format]: x.go is not formatted\"}}")
+		return
+	case "hook pre-tool-use":
+		switch mode {
+		case "deny":
+			fmt.Print("{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"procoder gate: 2 blocking findings\"}}")
+		case "allow":
+			fmt.Print("{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\",\"permissionDecisionReason\":\"commit message obligation cleared\"}}")
+		}
+		return
+	case "hook stop":
+		if os.Getenv("FIXTURE_STOP") == "block" {
+			fmt.Fprintln(os.Stderr, "procoder: a decision is waiting on the user and was not asked")
+			os.Exit(2)
+		}
+		return
+	}
+	if len(args) > 0 && args[0] == "principles" {
+		fmt.Println("Build like a senior developer who has been paged at 3am.")
+		return
+	}
+	if len(args) > 0 && args[0] == "check" {
+		for i := 0; i < 3000; i++ {
+			fmt.Printf("line %d\n", i)
+		}
+		return
+	}
+}
+`
+
+// The compile happens once for the package. A per-test build would add a
+// second of compile to each of the eleven tests that ask for a binary, and a
+// fixture is not interesting enough to earn that.
+var (
+	fixtureBuild    sync.Once
+	fixtureBinPath  string
+	fixtureBuildErr error
+)
+
+func piFixtureBin(t *testing.T) string {
+	t.Helper()
+	fixtureBuild.Do(func() {
+		dir, err := os.MkdirTemp("", "procoder-pi-fixture")
+		if err != nil {
+			fixtureBuildErr = err
+			return
+		}
+		// A module of its own, so the build is not read as part of this one:
+		// the fixture imports nothing from the tree and must not be able to.
+		write := func(name, body string) error {
+			return os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644)
+		}
+		if err := write("go.mod", "module procoder-pi-fixture\n\ngo 1.21\n"); err != nil {
+			fixtureBuildErr = err
+			return
+		}
+		if err := write("main.go", piFixtureSource); err != nil {
+			fixtureBuildErr = err
+			return
+		}
+		bin := filepath.Join(dir, "procoder-fixture"+exeSuffix())
+		cmd := exec.Command("go", "build", "-o", bin, ".")
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			fixtureBuildErr = fmt.Errorf("building the pi fixture: %v\n%s", err, out)
+			return
+		}
+		fixtureBinPath = bin
+	})
+	if fixtureBuildErr != nil {
+		t.Fatal(fixtureBuildErr)
+	}
+	return fixtureBinPath
+}
+
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
 }
 
 // piHarness runs one harness mode against the real adapter and decodes its

--- a/internal/portability/pi_test.go
+++ b/internal/portability/pi_test.go
@@ -1,0 +1,706 @@
+package portability
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The pi adapter is the only non-Go glue in the host layer that carries real
+// behaviour, and pi itself is not installed where `go test` runs. These tests
+// therefore drive the adapter through internal/portability/testdata/pi-harness.mjs,
+// which imports the adapter for real and hands it the object pi would hand it.
+//
+// What is faked is the host: registrations are collected instead of painted,
+// and ctx.ui records instead of prompting. What is never faked is the adapter —
+// it reads the real commands/, resolves its own launcher path from its own
+// module location, and spawns the real hooks/launcher.sh. PROCODER_BIN is the
+// launcher's own documented seam for tests, so the binary on the other side of
+// that launcher is a fixture this file controls.
+
+// piFixture is a procoder that answers from FIXTURE_MODE and appends every
+// invocation to FIXTURE_LOG, so "did the gate spawn at all" is a question with
+// an answer on disk rather than one inferred from timing.
+func piFixture(t *testing.T, dir string) (bin, log string) {
+	t.Helper()
+	bin = filepath.Join(dir, "procoder-fixture")
+	log = filepath.Join(dir, "invocations.log")
+	script := `#!/bin/sh
+# Every invocation is logged with the payload it was handed, so "was the gate
+# run at all, and told what" is answered from disk rather than inferred from
+# timing. Only the hook subcommands are given a payload: the adapter leaves
+# stdin inherited for the rest, and a fixture that waited on an inherited stdin
+# would sit there until the caller's own timeout expired — which is the failure
+# this script had the first time it was run.
+case "$1 $2" in
+  "hook pre-tool-use"|"hook post-tool-use"|"hook stop") payload=$(cat) ;;
+  *) payload="" ;;
+esac
+printf '%s %s\n' "$*" "$payload" >> "$FIXTURE_LOG"
+MODE="${FIXTURE_MODE:-deny}"
+if [ "$1 $2" = "hook post-tool-use" ]; then
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"procoder [format]: x.go is not formatted"}}'
+  exit 0
+fi
+if [ "$1 $2" = "hook pre-tool-use" ]; then
+  case "$MODE" in
+    deny)  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"procoder gate: 2 blocking findings"}}' ;;
+    allow) printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"commit message obligation cleared"}}' ;;
+    silent) : ;;
+  esac
+  exit 0
+fi
+if [ "$1 $2" = "hook stop" ]; then
+  if [ "${FIXTURE_STOP:-ok}" = block ]; then
+    printf '%s\n' 'procoder: a decision is waiting on the user and was not asked' >&2
+    exit 2
+  fi
+  exit 0
+fi
+if [ "$1" = "principles" ]; then
+  printf '%s\n' 'Build like a senior developer who has been paged at 3am.'
+  exit 0
+fi
+if [ "$1" = "check" ]; then
+  awk 'BEGIN { for (i = 0; i < 3000; i++) print "line " i }'
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(log, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return bin, log
+}
+
+// piHarness runs one harness mode against the real adapter and decodes its
+// answer. The repo root is passed explicitly because the adapter derives its own
+// paths from where it was loaded from, and a test that guessed would be testing
+// a directory layout nobody installs.
+func piHarness(t *testing.T, mode string, config map[string]any, env map[string]string) map[string]any {
+	t.Helper()
+	got, _ := piHarnessRaw(t, mode, config, env)
+	return got
+}
+
+// piHarnessRaw is piHarness with the whole child output, because a finding the
+// adapter reports on stderr — where a print-mode session is the only audience —
+// is invisible in the decoded last line.
+func piHarnessRaw(t *testing.T, mode string, config map[string]any, env map[string]string) (map[string]any, string) {
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("no node on PATH")
+	}
+	root := repoRoot(t)
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) == "null" {
+		raw = []byte("{}")
+	}
+	cmd := exec.Command(node, filepath.Join(root, "internal", "portability", "testdata", "pi-harness.mjs"), mode, string(raw))
+	cmd.Env = append(os.Environ(), "PROCODER_REPO="+root)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("harness %s failed: %v\n%s", mode, err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &decoded); err != nil {
+		t.Fatalf("harness %s printed no JSON:\n%s", mode, out)
+	}
+	return decoded, string(out)
+}
+
+func fixtureEnv(t *testing.T, mode string) (map[string]string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	bin, log := piFixture(t, dir)
+	return map[string]string{
+		"PROCODER_BIN": bin,
+		"FIXTURE_LOG":  log,
+		"FIXTURE_MODE": mode,
+	}, log
+}
+
+func invocations(t *testing.T, log string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(raw)) == "" {
+		return nil
+	}
+	return strings.Split(strings.TrimSpace(string(raw)), "\n")
+}
+
+// registryOnce runs the harness's registry mode and unpacks the three things
+// it reports. One load of the adapter answers all three checks below, so the
+// split into separate tests costs no extra node process.
+func registryOnce(t *testing.T) ([]map[string]any, map[string]any, []string) {
+	t.Helper()
+	env, _ := fixtureEnv(t, "deny")
+	got := piHarness(t, "registry", nil, env)
+
+	pick := func(key string) []map[string]any {
+		var out []map[string]any
+		for _, item := range got[key].([]any) {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	}
+	tool, _ := got["tool"].(map[string]any)
+	var events []string
+	if list, ok := got["events"].([]any); ok {
+		for _, e := range list {
+			if s, ok := e.(string); ok {
+				events = append(events, s)
+			}
+		}
+	}
+	return pick("commands"), tool, events
+}
+
+// commandsExpected is the registry the command directory asks for: one entry
+// per file, namespaced, update.md aside.
+func commandsExpected(t *testing.T) map[string]string {
+	t.Helper()
+	want := map[string]string{}
+	entries, err := os.ReadDir(filepath.Join(repoRoot(t), "commands"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") || name == "update.md" {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(repoRoot(t), "commands", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want["procoder:"+strings.TrimSuffix(name, ".md")] = frontmatterDescription(t, string(raw))
+	}
+	return want
+}
+
+// The command set arrives whole, under the procoder namespace, with the
+// description each file already carries. pi names a skill after its parent
+// directory when the frontmatter has no name, which is how 34 files once
+// arrived as one skill called "commands" — registering them is the only shape
+// where each keeps its own identity.
+//
+// proved by: adding a file to commands/ without registering it, or dropping one
+// of the two exclusions — this test names it.
+func TestPiCommandRegistryMatchesCommandsDir(t *testing.T) {
+	commands, _, _ := registryOnce(t)
+	want := commandsExpected(t)
+
+	if len(commands) != len(want) {
+		t.Fatalf("registered %d commands, commands/ holds %d (minus update.md)", len(commands), len(want))
+	}
+	seen := map[string]bool{}
+	for _, c := range commands {
+		name, _ := c["name"].(string)
+		seen[name] = true
+		desc, ok := want[name]
+		if !ok {
+			t.Errorf("%s is registered with no file behind it", name)
+			continue
+		}
+		if c["description"] != desc {
+			t.Errorf("%s: description %v is not the file's %q", name, c["description"], desc)
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("%s never registered", name)
+		}
+	}
+}
+
+// The callable tool is the one place pi gets a procoder without a shell, so its
+// parameter list is the whole permission boundary: reporting commands only.
+//
+// proved by: adding "backlog" to REPORTING_COMMANDS — this names it, and
+// TestPiToolRefusesMutatingSubcommand then fails on the refusal.
+func TestPiToolOffersOnlyReportingCommands(t *testing.T) {
+	_, tool, _ := registryOnce(t)
+	if tool == nil {
+		t.Fatal("no procoder tool registered")
+	}
+	subs, _ := tool["subcommands"].([]any)
+	if len(subs) == 0 {
+		t.Fatal("the procoder tool declares no subcommands, so it can be asked for anything")
+	}
+	for _, forbidden := range []string{"backlog", "release", "todo", "adr", "sprint", "init", "seed"} {
+		for _, s := range subs {
+			if s == forbidden {
+				t.Errorf("the procoder tool offers %q, which mutates state and must stay a slash command", forbidden)
+			}
+		}
+	}
+}
+
+// An event pi never fires is a hook that silently does nothing, and the four
+// enforcement points are invisible until a session needs one.
+//
+// proved by: renaming any one of the pi event strings in the adapter — this
+// test names the surface that went quiet.
+func TestPiWiresEveryHostEvent(t *testing.T) {
+	_, _, events := registryOnce(t)
+	for _, want := range []string{
+		"before_agent_start", "tool_call", "tool_result", "agent_settled",
+		"session_before_compact", "session_start",
+	} {
+		found := false
+		for _, e := range events {
+			if e == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no handler for %s — the host would never call it", want)
+		}
+	}
+}
+
+func frontmatterDescription(t *testing.T, body string) string {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if d := strings.TrimPrefix(line, "description:"); d != line {
+			return strings.TrimSpace(d)
+		}
+		if strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "---") {
+			break // frontmatter is over; the description was never there
+		}
+	}
+	t.Fatal("command file carries no description in its frontmatter")
+	return ""
+}
+
+// The launcher is found beside the installed package, never on PATH. The machine
+// this adapter was written on keeps a 1.0.2 procoder on PATH while the package
+// is 3.4.0, and a gate running a binary three majors behind reports a clean tree
+// it has never seen.
+//
+// proved by: returning "procoder" from launcherPath, or dropping the win32 arm —
+// this test names whichever broke.
+func TestPiLauncherResolvesFromModuleLocation(t *testing.T) {
+	env, _ := fixtureEnv(t, "deny")
+	got := piHarness(t, "launcher", nil, env)
+
+	posix, _ := got["posix"].(string)
+	if !strings.HasSuffix(filepath.ToSlash(posix), "hooks/launcher.sh") {
+		t.Errorf("posix launcher is %q, expected the hooks/ launcher beside the package", posix)
+	}
+	if posix == "procoder" || !filepath.IsAbs(posix) {
+		t.Errorf("posix launcher %q is resolved through PATH rather than beside the package", posix)
+	}
+	win, _ := got["win32"].(string)
+	if !strings.HasSuffix(win, "launcher.cmd") {
+		t.Errorf("win32 launcher is %q, expected launcher.cmd", win)
+	}
+
+	text, _ := got["text"].(string)
+	if strings.Contains(text, "CLAUDE_PLUGIN_ROOT") {
+		t.Errorf("the transform left a plugin-root reference in the host command text:\n%s", text)
+	}
+	for _, want := range []string{`"/opt/pkg/hooks/launcher.sh" check`, `"/opt/pkg/hooks/launcher.sh" format <file>`} {
+		if !strings.Contains(text, want) {
+			t.Errorf("transformed command text is missing %q:\n%s", want, text)
+		}
+	}
+	// The transform rewrites WHERE procoder lives and nothing else. $ARGUMENTS
+	// is pi's own expansion, applied per invocation, and a rule that swallowed it
+	// would hand every command the same half-finished sentence.
+	if !strings.Contains(text, "$ARGUMENTS") {
+		t.Error("the transform rewrote past the launcher and consumed $ARGUMENTS:", text)
+	}
+	// A host that names its own launcher must not be told to look it up on
+	// PATH — the sentence the PATH hosts get would be false here.
+	if strings.Contains(text, "binary on PATH") {
+		t.Errorf("a host with an absolute launcher was told to use PATH:\n%s", text)
+	}
+	if !strings.Contains(text, `The launcher is: "/opt/pkg/hooks/launcher.sh"`) {
+		t.Errorf("the launcher sentence was not carried over with the real path:\n%s", text)
+	}
+}
+
+// The contract arrives once. pi loads AGENTS.md as a context file, so injecting
+// it again was a 12,458-byte tax on every turn of every session — the reason
+// this adapter's first version is being replaced.
+//
+// proved by: dropping the contextFiles guard and injecting unconditionally (the
+// marker appears twice), or inverting it (the marker appears zero times and the
+// session is governed by rules nobody sent).
+func TestPiAdapterInjectsContractOnce(t *testing.T) {
+	root := repoRoot(t)
+	env, _ := fixtureEnv(t, "deny")
+
+	loaded := piHarness(t, "inject", map[string]any{
+		"contextFiles": []map[string]any{{"path": filepath.Join(root, "AGENTS.md")}},
+	}, env)
+	if loaded["first"] != float64(1) {
+		t.Errorf("nothing was injected into a fresh session: %+v", loaded)
+	}
+	if loaded["markerInMessage"] != float64(0) {
+		t.Errorf("AGENTS.md was injected although pi had already loaded it (%v copies of its marker)", loaded["markerInMessage"])
+	}
+	if loaded["principles"] != true {
+		t.Error("the engineering principles did not reach the session — pi loads no .procoder/PRINCIPLES.md")
+	}
+	if loaded["second"] != float64(0) {
+		t.Error("the contract was injected twice in one session, which is how #175 happened here")
+	}
+
+	missing := piHarness(t, "inject", map[string]any{"contextFiles": []any{}}, env)
+	if missing["markerInMessage"] != float64(1) {
+		t.Errorf("with context files unloaded the contract should arrive exactly once, got %v", missing["markerInMessage"])
+	}
+
+	resumed := piHarness(t, "inject", map[string]any{
+		"reason":       "resume",
+		"contextFiles": []map[string]any{{"path": filepath.Join(root, "AGENTS.md")}},
+	}, env)
+	if resumed["first"] != float64(0) {
+		t.Error("a resumed session got a second copy of rules already in its transcript")
+	}
+}
+
+// A commit is judged by the binary before the shell sees it, and an ordinary
+// shell call pays nothing for that. --abbrev-commit is in every session and is
+// not a commit by any reading.
+//
+// proved by: removing the isCommitish pre-filter (git log spawns the gate) or
+// the deny branch (a blocked commit runs anyway).
+func TestPiCommitGateBlocksThenAllows(t *testing.T) {
+	deny, log := fixtureEnv(t, "deny")
+	got := piHarness(t, "gate", map[string]any{"command": "git commit -m notes"}, deny)
+	results, _ := got["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("a denied commit came back with %d results: %+v", len(results), got)
+	}
+	block, _ := results[0].(map[string]any)
+	if block["block"] != true {
+		t.Errorf("the gate said deny and the commit was not blocked: %+v", block)
+	}
+	if reason, _ := block["reason"].(string); !strings.Contains(reason, "blocking findings") {
+		t.Errorf("the block carries %q, not the gate's reason", reason)
+	}
+	if len(invocations(t, log)) != 1 {
+		t.Errorf("the gate ran %d times for one commit", len(invocations(t, log)))
+	}
+
+	quiet, log := fixtureEnv(t, "deny")
+	got = piHarness(t, "gate", map[string]any{"command": "git log --oneline --abbrev-commit"}, quiet)
+	if len(invocations(t, log)) != 0 {
+		t.Errorf("git log spawned the gate: %v", invocations(t, log))
+	}
+	if len(got["results"].([]any)) != 0 {
+		t.Errorf("an ordinary shell call was intercepted: %+v", got["results"])
+	}
+
+	allow, _ := fixtureEnv(t, "allow")
+	got = piHarness(t, "gate", map[string]any{"command": "git commit -m notes"}, allow)
+	if len(got["results"].([]any)) != 0 {
+		t.Errorf("an allowed commit was blocked: %+v", got["results"])
+	}
+	notices, _ := got["notices"].([]any)
+	if len(notices) != 1 {
+		t.Errorf("the allow reason never reached the coder: %+v", got)
+	}
+}
+
+// The write hook's findings land inside the write that caused them. pi can patch
+// a tool result, which Claude Code cannot; the verdict itself belongs to
+// internal/hook and is covered there — what would go unnoticed here is a verdict
+// produced and then dropped on the way to the model.
+//
+// proved by: returning undefined instead of the content patch, or by patching
+// even for a tool that is not a write.
+func TestPiWriteResultCarriesFormatVerdict(t *testing.T) {
+	root := repoRoot(t)
+	env, log := fixtureEnv(t, "deny")
+	got := piHarness(t, "write", map[string]any{
+		"path":    "internal/gate/gate.go",
+		"content": []map[string]any{{"type": "text", "text": "wrote it"}},
+	}, env)
+
+	results, _ := got["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("the write result was not patched: %+v", got)
+	}
+	patch, _ := results[0].(map[string]any)
+	content, _ := patch["content"].([]any)
+	if len(content) != 2 {
+		t.Fatalf("patched content has %d blocks, expected the original plus the verdict", len(content))
+	}
+	last, _ := content[1].(map[string]any)
+	if text, _ := last["text"].(string); !strings.Contains(text, "is not formatted") {
+		t.Errorf("the verdict never reached the model: %q", text)
+	}
+	calls := invocations(t, log)
+	if len(calls) != 1 {
+		t.Fatalf("the hook ran %d times for one write", len(calls))
+	}
+	if !strings.Contains(calls[0], `"file_path":"`+filepath.Join(root, "internal", "gate", "gate.go")+`"`) {
+		t.Errorf("the hook was not told which file, as an absolute path: %s", calls[0])
+	}
+
+	env["FIXTURE_MODE"] = "silent"
+	silent := piHarness(t, "write", map[string]any{"toolName": "read", "path": "AGENTS.md"}, env)
+	if len(silent["results"].([]any)) != 0 {
+		t.Error("a read was intercepted as though it were a write")
+	}
+	if calls := invocations(t, log); len(calls) != 1 {
+		t.Errorf("a read still spawned the hook: %v", calls)
+	}
+}
+
+// The gate as a callable tool, with pi's own output limits. A procoder report
+// that is longer than the context it is being inserted into is not a report.
+//
+// proved by: forwarding res.stdout uncut, or dropping the temp file write.
+func TestPiToolTruncatesWithTempFile(t *testing.T) {
+	env, _ := fixtureEnv(t, "deny")
+	got := piHarness(t, "tool", map[string]any{"params": map[string]any{"command": "check"}}, env)
+
+	text, _ := got["text"].(string)
+	if strings.Count(text, "\n") > 2100 {
+		t.Errorf("the tool forwarded %d lines with no truncation", strings.Count(text, "\n")+1)
+	}
+	if !strings.Contains(text, "truncated") {
+		t.Error("truncated output does not say it was truncated")
+	}
+	details, _ := got["details"].(map[string]any)
+	full, _ := details["fullOutput"].(string)
+	if full == "" {
+		t.Fatal("truncation names no file holding the rest")
+	}
+	raw, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatalf("the file the tool named is not there: %v", err)
+	}
+	if strings.Count(string(raw), "\n") < 2999 {
+		t.Errorf("the file holds %d lines, not the whole report", strings.Count(string(raw), "\n")+1)
+	}
+}
+
+// What the tool may not do. Closing work, seeding the backlog and releasing are
+// slash commands a human types, because an agent session could have written the
+// sentence that asks for them — the same line procoder run draws for launch
+// commands.
+//
+// proved by: widening REPORTING_COMMANDS with a mutating verb, or returning the
+// refusal instead of throwing it.
+func TestPiToolRefusesMutatingSubcommand(t *testing.T) {
+	env, log := fixtureEnv(t, "deny")
+	for _, forbidden := range []string{"backlog", "release", "todo", "sprint"} {
+		got := piHarness(t, "tool", map[string]any{"params": map[string]any{"command": forbidden}}, env)
+		threw, _ := got["threw"].(string)
+		if threw == "" {
+			t.Errorf("%s was accepted by the procoder tool", forbidden)
+			continue
+		}
+		if !strings.Contains(threw, "/procoder:") {
+			t.Errorf("%s was refused without naming the route a human uses: %q", forbidden, threw)
+		}
+	}
+	if calls := invocations(t, log); len(calls) != 0 {
+		t.Errorf("a refused subcommand still spawned something: %v", calls)
+	}
+}
+
+// A turn that ends with a decision deferred and unrecorded does not end. The
+// binary decides this and remembers which message it last refused; the adapter
+// only carries the answer back, because a dedupe held in adapter memory is
+// forgotten by the next reload, which is #242.
+//
+// proved by: ignoring the exit code, or gating the follow-up on a local variable.
+func TestPiTurnReportsAnUnaskedDecision(t *testing.T) {
+	env, log := fixtureEnv(t, "deny")
+	env["FIXTURE_STOP"] = "block"
+	got := piHarness(t, "stop", map[string]any{
+		"branch": []map[string]any{{
+			"type": "message",
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": []map[string]any{{"type": "text", "text": "Should I keep the trailer?"}},
+			},
+		}},
+	}, env)
+	sent, _ := got["sent"].([]any)
+	if len(sent) != 1 {
+		t.Fatalf("the block never reached the model: %+v", got)
+	}
+	msg, _ := sent[0].(map[string]any)
+	options, _ := msg["options"].(map[string]any)
+	if options["deliverAs"] != "followUp" {
+		t.Errorf("the reason was delivered as %+v, which does not continue the turn", options)
+	}
+	calls := invocations(t, log)
+	if len(calls) != 1 || !strings.Contains(calls[0], "Should I keep the trailer?") {
+		t.Errorf("the hook was called without the last assistant message: %v", calls)
+	}
+
+	env["FIXTURE_STOP"] = "ok"
+	clean := piHarness(t, "stop", nil, env)
+	if len(clean["sent"].([]any)) != 0 {
+		t.Error("an ordinary turn was interrupted")
+	}
+
+	// A refused turn in print mode has no turn to refuse: the session exits once
+	// the agent settles, so the follow-up has nowhere to go and the reason leaves
+	// with the process. Live, this was measured rather than imagined — the hook
+	// refused, recorded its dedupe, and nothing was ever said about it.
+	env["FIXTURE_STOP"] = "block"
+	quiet, raw := piHarnessRaw(t, "stop", map[string]any{"hasUI": false}, env)
+	if len(quiet["sent"].([]any)) != 0 {
+		t.Error("a print-mode session was sent a message it cannot deliver")
+	}
+	if !strings.Contains(raw, "a decision is waiting on the user") {
+		t.Errorf("the refusal vanished with the session:\n%s", raw)
+	}
+}
+
+// No binary is not a clean tree. The launcher's own rule — a hook that cannot
+// get its binary warns and lets the session continue — has to survive the
+// translation into pi, or procoder becomes the thing that broke editing.
+//
+// proved by: treating an empty verdict as an allow with no notice, or as a block.
+func TestPiHooksDegradeToAWarning(t *testing.T) {
+	dir := t.TempDir()
+	env := map[string]string{
+		"PROCODER_BIN": filepath.Join(dir, "procoder-that-is-not-here"),
+		"FIXTURE_LOG":  filepath.Join(dir, "invocations.log"),
+	}
+	got := piHarness(t, "gate", map[string]any{"command": "git commit -m notes"}, env)
+	if len(got["results"].([]any)) != 0 {
+		t.Errorf("a gate that could not run blocked the commit: %+v", got["results"])
+	}
+	notices, _ := got["notices"].([]any)
+	if len(notices) == 0 {
+		t.Fatal("a gate that could not run said nothing")
+	}
+	notice, _ := notices[0].(map[string]any)
+	if message, _ := notice["message"].(string); !strings.Contains(message, "NOT") {
+		t.Errorf("the notice reads %q, which could be mistaken for a pass", message)
+	}
+
+	tool := piHarness(t, "tool", map[string]any{"params": map[string]any{"command": "check"}}, env)
+	if tool["isError"] != true {
+		t.Error("a procoder that never started is not a report that came back clean")
+	}
+}
+
+// The manifest is what a host reads before any code runs. It once pointed pi at
+// commands/ as a skill directory, which collapsed 34 files into one skill named
+// after the directory; skills/ holds the one file that is a skill.
+//
+// proved by: restoring pi.skills to ./commands, or dropping the pi-package
+// keyword the gallery indexes on.
+func TestPiManifestPointsAtSkillsAndNotCommands(t *testing.T) {
+	root := repoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest struct {
+		Keywords []string `json:"keywords"`
+		Pi       struct {
+			Extensions []string `json:"extensions"`
+			Skills     []string `json:"skills"`
+			Prompts    []string `json:"prompts"`
+		} `json:"pi"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(manifest.Pi.Skills, ",") != "./skills" {
+		t.Errorf("pi.skills is %v; commands/ is not a skill directory", manifest.Pi.Skills)
+	}
+	if len(manifest.Pi.Prompts) != 0 {
+		t.Errorf("pi.prompts is %v; the command set registers at load and needs no template path", manifest.Pi.Prompts)
+	}
+	if strings.Join(manifest.Pi.Extensions, ",") != "./pi-extension/index.mjs" {
+		t.Errorf("pi.extensions is %v, and the drift guard reads this file", manifest.Pi.Extensions)
+	}
+	keyed := false
+	for _, k := range manifest.Keywords {
+		if k == "pi-package" {
+			keyed = true
+		}
+	}
+	if !keyed {
+		t.Error("no pi-package keyword, so the package gallery will not index it")
+	}
+	if _, err := os.Stat(filepath.Join(root, "skills", "procoder", "SKILL.md")); err != nil {
+		t.Errorf("pi.skills names ./skills, which holds no SKILL.md: %v", err)
+	}
+}
+
+// The host row is how the next reader learns what pi gets. A row that says
+// "supported" while the four enforcement points go unnamed is how this spec got
+// written in the first place.
+//
+// proved by: shortening the pi row in docs/portability.md to a host name.
+func TestPiHostRowStatesItsSurfaces(t *testing.T) {
+	root := repoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "docs", "portability.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := ""
+	for _, line := range strings.Split(string(raw), "\n") {
+		if strings.Contains(line, "| pi ") {
+			row = line
+		}
+	}
+	if row == "" {
+		t.Fatal("no pi row in docs/portability.md")
+	}
+	for _, want := range []string{
+		"tool_call", "tool_result", "agent_settled", "before_agent_start", "commands",
+	} {
+		if !strings.Contains(row, want) {
+			t.Errorf("the pi row does not name %s:\n%s", want, row)
+		}
+	}
+}
+
+// pi is detected rather than assumed. Without this, the envelope pi receives is
+// whatever the Claude default happens to emit, and a future change to that
+// default would change pi silently.
+//
+// proved by: removing the Pi case from Detect — TestDetectSelectsHostBySignalAnd
+// Precedence in the host package catches that; this one pins the adapter's side
+// of the same fact, which no Go test can reach.
+func TestPiHostIsNamedInTheGate(t *testing.T) {
+	root := repoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "internal", "host", "host.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `Pi Host = "pi"`) {
+		t.Error("host.go names no pi host, so pi is answered by the Claude default")
+	}
+	if !strings.Contains(text, "PI_CODING_AGENT") {
+		t.Error("nothing reads the variable pi actually sets")
+	}
+}

--- a/internal/portability/portability_test.go
+++ b/internal/portability/portability_test.go
@@ -2,6 +2,7 @@ package portability
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -159,21 +160,33 @@ func TestForbiddenHooksJSONBlocks(t *testing.T) {
 	}
 }
 
-// opencodeTwin reproduces the generator's substitution rule, so the test
-// pins actual content parity, not just existence: twin = command body with
-// the Claude launcher swapped for the PATH binary.
-func opencodeTwin(body string) string {
-	// CRLF leveled first: a Windows checkout rewrites line endings, and
-	// the multi-line phrase below would otherwise never match there
-	body = strings.ReplaceAll(body, "\r\n", "\n")
-	body = strings.ReplaceAll(body, `"${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"`, "procoder")
-	body = strings.ReplaceAll(body, "The launcher is: procoder",
-		"The command below is the `procoder` binary on PATH.")
-	body = strings.ReplaceAll(body, "The launcher for every procoder command below is:\nprocoder",
-		"Every procoder command below is the `procoder` binary on PATH.")
-	body = strings.ReplaceAll(body, "launcher.sh ", "procoder ")
-	body = strings.ReplaceAll(body, "launcher.sh", "procoder")
-	return body
+// hostCommandText asks the one substitution rule what a host's command text
+// should be, by running the module the pi adapter applies at load.
+//
+// Asking rather than restating is the point. The rule used to live in this file,
+// which left the adapter free to keep its own copy — and a drifted copy is not a
+// red test, it is a command that runs a different binary from the one the
+// repository shipped. Skipped without node, which the gate needs anyway to
+// format the markdown this rule rewrites.
+func hostCommandText(t *testing.T, root, body, launcher string) string {
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("no node on PATH")
+	}
+	script := `const {pathToFileURL} = await import("node:url");
+const m = await import(pathToFileURL(process.argv[1]).href);
+let body = "";
+for await (const chunk of process.stdin) body += chunk;
+process.stdout.write(m.hostCommandText(body, process.argv[2]));`
+	cmd := exec.Command(node, "--input-type=module", "-e", script,
+		filepath.Join(root, "hooks", "host-command-text.mjs"), launcher)
+	cmd.Stdin = strings.NewReader(body)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("the shared command-text rule did not run: %v", err)
+	}
+	return string(out)
 }
 
 // Commands whose content is Claude-specific and deliberately ships no
@@ -207,7 +220,7 @@ func TestOpenCodeCommandParity(t *testing.T) {
 			t.Errorf("command %s has no .opencode/command twin — regenerate", e.Name())
 			continue
 		}
-		if strings.ReplaceAll(string(raw), "\r\n", "\n") != opencodeTwin(string(src)) {
+		if strings.ReplaceAll(string(raw), "\r\n", "\n") != hostCommandText(t, root, string(src), "procoder") {
 			t.Errorf("%s does not match the generation rule applied to commands/%s — regenerate", twin, e.Name())
 		}
 	}
@@ -225,7 +238,7 @@ func TestOpenCodeCommandParity(t *testing.T) {
 // Host detection: ordering and the VS Code heuristic.
 func TestHostDetection(t *testing.T) {
 	clear := func() {
-		for _, k := range []string{"COPILOT_PLUGIN_DATA", "PLUGIN_DATA", "QODER_SESSION_ID", "CLAUDE_PLUGIN_ROOT"} {
+		for _, k := range []string{"COPILOT_PLUGIN_DATA", "PLUGIN_DATA", "QODER_SESSION_ID", "CLAUDE_PLUGIN_ROOT", "PI_CODING_AGENT"} {
 			t.Setenv(k, "")
 			os.Unsetenv(k)
 		}

--- a/internal/portability/testdata/pi-harness.mjs
+++ b/internal/portability/testdata/pi-harness.mjs
@@ -1,0 +1,188 @@
+// Test harness for the pi adapter, driven from Go (see pi_test.go).
+//
+// pi is not installed on the machine that runs `go test`, and an adapter that
+// can only be exercised inside a live session is an adapter nobody tests. So
+// the harness imports the real adapter and hands it the object pi would hand
+// it: the same registration calls, the same event handlers, a ctx whose UI
+// records instead of painting. What is fake is the host, never the code under
+// test — the adapter still reads the real commands/, still resolves its own
+// launcher path, still spawns the real launcher and whatever PROCODER_BIN names.
+//
+// Usage: node pi-harness.mjs <mode> <json-config>
+// The repo root arrives in PROCODER_REPO so the harness does not guess where it
+// lives relative to a testdata directory that moves.
+import { pathToFileURL } from "node:url";
+import { join } from "node:path";
+
+const mode = process.argv[2] ?? "";
+const config = JSON.parse(process.argv[3] || "{}") || {};
+const root = process.env.PROCODER_REPO;
+if (!root) {
+  console.error("PROCODER_REPO is not set");
+  process.exit(2);
+}
+const adapter = await import(pathToFileURL(join(root, "pi-extension", "index.mjs")).href);
+
+const state = {
+  handlers: {},
+  commands: {},
+  tools: {},
+  sent: [],
+  notices: [],
+  branch: config.branch ?? [],
+};
+
+const pi = {
+  on(event, handler) {
+    (state.handlers[event] ||= []).push(handler);
+  },
+  registerCommand(name, options) {
+    state.commands[name] = {
+      name,
+      description: options.description ?? "",
+      completions: options.getArgumentCompletions ? options.getArgumentCompletions("") : null,
+    };
+  },
+  registerTool(definition) {
+    state.tools[definition.name] = definition;
+  },
+  sendUserMessage(text, options) {
+    state.sent.push({ text, options: options ?? null });
+  },
+};
+
+const ctx = {
+  cwd: config.cwd ?? root,
+  // A UI-shaped host by default, because that is the only shape in which a
+  // notice is observable at all. Print mode's no-op notifications are pi's own
+  // behaviour and are not this adapter's to assert.
+  hasUI: config.hasUI ?? true,
+  ui: {
+    notify(message, level) {
+      state.notices.push({ message, level });
+    },
+  },
+  sessionManager: {
+    getBranch: () => state.branch,
+  },
+};
+
+function emit(value) {
+  console.log(JSON.stringify(value ?? null));
+}
+
+async function fire(event, ...args) {
+  const handlers = state.handlers[event] ?? [];
+  const results = [];
+  for (const handler of handlers) results.push(await handler(...args));
+  return results.filter((r) => r !== undefined);
+}
+
+adapter.default(pi);
+
+const AGENT_MARKER = "The trailer your host adds";
+
+switch (mode) {
+  case "registry": {
+    const tool = state.tools.procoder;
+    emit({
+      commands: Object.values(state.commands).sort((a, b) => a.name.localeCompare(b.name)),
+      tool: tool
+        ? {
+            name: tool.name,
+            subcommands: tool.parameters?.properties?.command?.enum ?? [],
+            required: tool.parameters?.required ?? [],
+          }
+        : null,
+      events: Object.keys(state.handlers).sort(),
+    });
+    break;
+  }
+
+  case "launcher": {
+    const { launcherPath, commandText } = adapter;
+    emit({
+      posix: launcherPath("darwin", "/opt/pkg/pi-extension"),
+      win32: launcherPath("win32", "C:\\Users\\me\\Documents\\pkg\\pi-extension"),
+      text: commandText(
+        'The launcher is: "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"\n\nRun:\n\n    "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh" check $ARGUMENTS\n\nfile\'s formatted result with `launcher.sh format <file>`',
+        '"/opt/pkg/hooks/launcher.sh"',
+      ),
+    });
+    break;
+  }
+
+  case "inject": {
+    await fire("session_start", { reason: config.reason ?? "startup" });
+    const event = {
+      systemPrompt: "base prompt",
+      systemPromptOptions: {
+        cwd: config.cwd ?? root,
+        contextFiles: config.contextFiles ?? [],
+      },
+    };
+    const first = await fire("before_agent_start", event, ctx);
+    const second = await fire("before_agent_start", event, ctx);
+    const text = (first[0]?.message?.content ?? "") + (first[0]?.systemPrompt ?? "");
+    emit({
+      first: first.length,
+      second: second.length,
+      markerInMessage: (text.match(new RegExp(AGENT_MARKER, "g")) || []).length,
+      principles: text.includes("Build like a senior developer"),
+      notices: state.notices,
+    });
+    break;
+  }
+
+  case "gate": {
+    const results = await fire(
+      "tool_call",
+      { toolName: config.toolName ?? "bash", input: { command: config.command } },
+      ctx,
+    );
+    emit({ results, notices: state.notices });
+    break;
+  }
+
+  case "write": {
+    const results = await fire(
+      "tool_result",
+      { toolName: config.toolName ?? "write", input: { path: config.path }, content: config.content ?? [] },
+      ctx,
+    );
+    emit({ results, notices: state.notices });
+    break;
+  }
+
+  case "tool": {
+    const tool = state.tools.procoder;
+    if (!tool) {
+      emit({ error: "no procoder tool registered" });
+      break;
+    }
+    let result;
+    let threw = "";
+    try {
+      result = await tool.execute("tc-1", config.params ?? {}, undefined, undefined, ctx);
+    } catch (e) {
+      threw = String(e?.message ?? e);
+    }
+    emit({
+      threw,
+      isError: result?.isError,
+      text: result?.content?.map((c) => c.text).join("\n") ?? "",
+      details: result?.details,
+    });
+    break;
+  }
+
+  case "stop": {
+    await fire("agent_settled", {}, ctx);
+    emit({ sent: state.sent, notices: state.notices });
+    break;
+  }
+
+  default:
+    console.error(`unknown mode ${mode}`);
+    process.exit(2);
+}

--- a/internal/portability/testdata/pi-harness.mjs
+++ b/internal/portability/testdata/pi-harness.mjs
@@ -21,7 +21,9 @@ if (!root) {
   console.error("PROCODER_REPO is not set");
   process.exit(2);
 }
-const adapter = await import(pathToFileURL(join(root, "pi-extension", "index.mjs")).href);
+const adapter = await import(
+  pathToFileURL(join(root, "pi-extension", "index.mjs")).href
+);
 
 const state = {
   handlers: {},
@@ -40,7 +42,9 @@ const pi = {
     state.commands[name] = {
       name,
       description: options.description ?? "",
-      completions: options.getArgumentCompletions ? options.getArgumentCompletions("") : null,
+      completions: options.getArgumentCompletions
+        ? options.getArgumentCompletions("")
+        : null,
     };
   },
   registerTool(definition) {
@@ -86,7 +90,9 @@ switch (mode) {
   case "registry": {
     const tool = state.tools.procoder;
     emit({
-      commands: Object.values(state.commands).sort((a, b) => a.name.localeCompare(b.name)),
+      commands: Object.values(state.commands).sort((a, b) =>
+        a.name.localeCompare(b.name),
+      ),
       tool: tool
         ? {
             name: tool.name,
@@ -103,7 +109,10 @@ switch (mode) {
     const { launcherPath, commandText } = adapter;
     emit({
       posix: launcherPath("darwin", "/opt/pkg/pi-extension"),
-      win32: launcherPath("win32", "C:\\Users\\me\\Documents\\pkg\\pi-extension"),
+      win32: launcherPath(
+        "win32",
+        "C:\\Users\\me\\Documents\\pkg\\pi-extension",
+      ),
       text: commandText(
         'The launcher is: "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"\n\nRun:\n\n    "${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh" check $ARGUMENTS\n\nfile\'s formatted result with `launcher.sh format <file>`',
         '"/opt/pkg/hooks/launcher.sh"',
@@ -123,7 +132,8 @@ switch (mode) {
     };
     const first = await fire("before_agent_start", event, ctx);
     const second = await fire("before_agent_start", event, ctx);
-    const text = (first[0]?.message?.content ?? "") + (first[0]?.systemPrompt ?? "");
+    const text =
+      (first[0]?.message?.content ?? "") + (first[0]?.systemPrompt ?? "");
     emit({
       first: first.length,
       second: second.length,
@@ -137,7 +147,10 @@ switch (mode) {
   case "gate": {
     const results = await fire(
       "tool_call",
-      { toolName: config.toolName ?? "bash", input: { command: config.command } },
+      {
+        toolName: config.toolName ?? "bash",
+        input: { command: config.command },
+      },
       ctx,
     );
     emit({ results, notices: state.notices });
@@ -147,7 +160,11 @@ switch (mode) {
   case "write": {
     const results = await fire(
       "tool_result",
-      { toolName: config.toolName ?? "write", input: { path: config.path }, content: config.content ?? [] },
+      {
+        toolName: config.toolName ?? "write",
+        input: { path: config.path },
+        content: config.content ?? [],
+      },
       ctx,
     );
     emit({ results, notices: state.notices });
@@ -163,7 +180,13 @@ switch (mode) {
     let result;
     let threw = "";
     try {
-      result = await tool.execute("tc-1", config.params ?? {}, undefined, undefined, ctx);
+      result = await tool.execute(
+        "tc-1",
+        config.params ?? {},
+        undefined,
+        undefined,
+        ctx,
+      );
     } catch (e) {
       threw = String(e?.message ?? e);
     }

--- a/internal/store/golden_test.go
+++ b/internal/store/golden_test.go
@@ -80,6 +80,34 @@ func replaceLinePrefix(text, prefix, with string) string {
 	return strings.Join(lines, "\n")
 }
 
+// underClaudeHost blanks every variable host.Detect consults, runs, and puts
+// them back.
+//
+// The principles golden is the Claude Code shape — raw text, no envelope — and
+// Detect answers from the environment, so this golden was always quietly
+// asserting that the developer's shell was not some other host. It is not a
+// hypothetical: run the suite from inside a pi session and PI_CODING_AGENT is
+// exported, the default branch is chosen, and the same code prints a JSON
+// envelope where the golden holds prose.
+func underClaudeHost(run func() string) string {
+	keys := []string{"COPILOT_PLUGIN_DATA", "CLAUDE_PLUGIN_ROOT", "PLUGIN_DATA", "QODER_SESSION_ID", "PI_CODING_AGENT"}
+	saved := map[string]string{}
+	for _, k := range keys {
+		saved[k] = os.Getenv(k)
+		os.Unsetenv(k)
+	}
+	defer func() {
+		for _, k := range keys {
+			if v := saved[k]; v != "" {
+				os.Setenv(k, v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}()
+	return run()
+}
+
 // captures are the outputs the harness compares. Each runs in process.
 //
 // What is NOT here is as deliberate as what is. `procoder check`, the
@@ -94,9 +122,11 @@ var captures = map[string]func(root string) string{
 		return b.String()
 	},
 	"principles-hook": func(root string) string {
-		var b strings.Builder
-		principles.RunHook(root, strings.NewReader("{}"), func(s string) { b.WriteString(s + "\n") })
-		return b.String()
+		return underClaudeHost(func() string {
+			var b strings.Builder
+			principles.RunHook(root, strings.NewReader("{}"), func(s string) { b.WriteString(s + "\n") })
+			return b.String()
+		})
 	},
 	"handoff": func(root string) string {
 		hook.Stop(strings.NewReader("{}"), root)

--- a/package.json
+++ b/package.json
@@ -7,12 +7,19 @@
     "type": "git",
     "url": "git+https://github.com/azrtydxb/procoder.git"
   },
+  "keywords": [
+    "procoder",
+    "pi-package",
+    "hooks",
+    "code-quality",
+    "gate"
+  ],
   "pi": {
     "extensions": [
       "./pi-extension/index.mjs"
     ],
     "skills": [
-      "./commands"
+      "./skills"
     ]
   }
 }

--- a/pi-extension/index.mjs
+++ b/pi-extension/index.mjs
@@ -1,27 +1,618 @@
-// pi extension for procoder: injects the AGENTS.md contract at agent
-// start. Thin by design — content comes from the canonical AGENTS.md,
-// which the portability checks pin.
+// pi extension for procoder: the four enforcement points every other host
+// gets, plus the command set and the gate as a callable tool.
 //
-// ESM, and named .mjs, because pi validates the export shape at install
-// time and rejects a CommonJS `module.exports` outright (#105). Node's
-// interop would have handed a CJS export back as `default` on import, so
-// nothing here failed locally — the host's own validator was the only
-// thing that ever saw the difference. The extension contract is an ESM
-// default factory; this file is one, and the portability test reads the
-// source rather than the loaded module so the two can never diverge again.
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+// Thin in the way that matters and thick in the way that does not. Every
+// verdict — whether a file is formatted, whether a commit may proceed, whether
+// a decision went unasked — comes from the same `procoder hook` entry points
+// Claude Code calls, so one implementation judges every host. What lives here
+// is wiring: which pi event calls which process, and how the answer is shaped
+// for pi rather than for Claude.
+//
+// Two rules held throughout, both learned the expensive way elsewhere in this
+// repository:
+//
+//   - Nothing is decided twice. `format.Check` decides formatting and `hook
+//     stop` decides the unasked-decision block, remembering which message it
+//     last refused. Re-implementing either here would put two answers in play.
+//
+//   - A hook that cannot run does not break the session. Every spawn below
+//     degrades to a warning, because a coder who cannot start a session
+//     uninstalls the thing that could not start it, and procoder would then be
+//     the tool that broke editing in order to check it.
+//
+// ESM, and named .mjs, because pi validates the export shape at install time
+// and rejects a CommonJS `module.exports` outright (#105). Node's interop would
+// have handed a CJS export back as `default` on import, so nothing here failed
+// locally — the host's own validator was the only thing that ever saw the
+// difference. The portability tests read this file as text for that reason.
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { hostCommandText } from "../hooks/host-command-text.mjs";
 
-const AGENTS = join(dirname(fileURLToPath(import.meta.url)), "..", "AGENTS.md");
+const SELF = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SELF, "..");
+const AGENTS = join(ROOT, "AGENTS.md");
+const COMMANDS = join(ROOT, "commands");
 
-export default function register(pi) {
-  pi.on?.("before_agent_start", (event) => {
-    try {
-      const body = readFileSync(AGENTS, "utf8");
-      return { systemPrompt: `${event.systemPrompt}\n\n${body}` };
-    } catch {
-      return undefined; // no AGENTS.md → inject nothing, never crash
+// update.md drives the Claude plugin's self-update flow. A pi package is pinned
+// by its install ref and moves with `pi install git:…@vX`, so a command that
+// self-updated here would move something else entirely. The same skip the
+// OpenCode and Kilo command sets already carry.
+const UNSHIPPED = new Set(["update.md"]);
+
+// The reporting half of procoder, callable by the model. Everything in this
+// list reads: none of it closes work, tags a release, or rewrites a file. The
+// mutators stay slash commands a human types, which is the line `procoder run`
+// already draws for launch commands — an agent session could have written the
+// sentence that asks for them.
+const REPORTING_COMMANDS = [
+  "check",
+  "test",
+  "lint",
+  "security",
+  "debt",
+  "status",
+  "review",
+  "doctor",
+  "index",
+];
+
+// pi's own guidance for tool output: 2,000 lines and 50KB before a result
+// starts costing more context than it is worth.
+const MAX_LINES = 2000;
+const MAX_BYTES = 50 * 1024;
+
+// The cheap half of the commit question: does this command say `commit` as a
+// word of its own? The binary decides whether it is really a commit; this only
+// keeps an ordinary shell call from paying for a process spawn. `git log
+// --abbrev-commit` is in every session and is not a commit by any reading.
+const isCommitish = /(^|\s)commit(\s|$)/;
+
+/**
+ * Where this installation's launcher lives, as a pure function of the platform
+ * and the directory the extension was loaded from. Exported so a test can ask
+ * the question directly instead of inferring it from what got run.
+ */
+export function launcherPath(platform, self) {
+  const name = platform === "win32" ? "launcher.cmd" : "launcher.sh";
+  return join(self, "..", "hooks", name);
+}
+
+// Never PATH, and never a bare `procoder`. The launcher resolves the binary
+// this package shipped with — and fetches it, verified, on a first run that has
+// not got it. A procoder found on PATH is whatever version somebody left
+// there: the machine this adapter was written on keeps a 1.0.2 while the
+// package is 3.4.0, and a gate running the wrong binary reports a clean tree it
+// has never seen.
+const LAUNCHER = launcherPath(process.platform, SELF);
+
+/**
+ * The command text a host runs, given the Claude Code source and the string
+ * that stands for procoder there. Exported for the same reason as launcherPath.
+ */
+export function commandText(body, launcher) {
+  return hostCommandText(body, launcher);
+}
+
+// The subcommand words a command file names, offered as its argument
+// completion: the plugin-root form, the PATH form, and prose mentions alike.
+function argumentWords(body) {
+  const words = new Set();
+  for (const m of body.matchAll(/launcher\.sh"?\s+([a-z][a-z-]+)/g)) {
+    words.add(m[1]);
+  }
+  for (const m of body.matchAll(/`procoder ([a-z][a-z-]+)/g)) {
+    words.add(m[1]);
+  }
+  return [...words].sort();
+}
+
+function readIf(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return ""; // no AGENTS.md is a repository without one, not a crash
+  }
+}
+
+// The frontmatter description, which is what pi lists in its command menu.
+function descriptionOf(body) {
+  const m = /^description:[ \t]*(.+)$/m.exec(body);
+  return m ? m[1].trim() : "";
+}
+
+/**
+ * Run the launcher with these arguments, optionally feeding it a hook payload.
+ *
+ * Resolves never: a missing binary, a refused fetch, and a child that dies on
+ * the way out all resolve with an exit code and whatever it managed to print.
+ * The callers below turn that into a warning, and each of them prefers "did not
+ * judge" over "blocked the session".
+ */
+function run(args, stdin, timeout) {
+  return new Promise((resolveRun) => {
+    const done = (value) =>
+      resolveRun({ stdout: "", stderr: "", code: 1, failed: false, ...value });
+    if (!existsSync(LAUNCHER)) {
+      return done({ stderr: `no launcher at ${LAUNCHER}`, failed: true });
+    }
+    // Windows runs a .cmd through cmd.exe rather than through one shell
+    // string, because the arguments below can carry text the model typed. A
+    // concatenated command string hands that text to a shell to interpret with
+    // the current environment attached; cmd.exe with the launcher as the
+    // command and each argument as its own argv entry does not.
+    // debt: cmd.exe still applies its own metacharacter rules to the trailing
+    // arguments, and nothing in this file is executed on Windows because no CI
+    // runs one. Ceiling: an argument containing cmd metacharacters on a Windows
+    // install. Revisit when one reports in, or when the tool takes free text
+    // rather than a subcommand and a path.
+    const child =
+      process.platform === "win32"
+        ? spawn("cmd.exe", ["/d", "/s", "/c", LAUNCHER, ...args], {
+            windowsHide: true,
+          })
+        : spawn(LAUNCHER, args, { windowsHide: true });
+
+    // A chatty child is bounded in bytes, counted where they are actually
+    // spent. The ceiling is the one the OpenCode adapter already uses, and for
+    // the same reason: a deny verdict that arrives truncated reads back as no
+    // verdict at all, which lets the commit through.
+    const CAP = 32 * 1024 * 1024;
+    const out = [];
+    const err = [];
+    let outBytes = 0;
+    let errBytes = 0;
+    child.stdout.on("data", (chunk) => {
+      if (outBytes >= CAP) return;
+      outBytes += chunk.length;
+      out.push(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      if (errBytes >= CAP) return;
+      errBytes += chunk.length;
+      err.push(chunk);
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      done({
+        stdout: buf(out),
+        stderr: `timed out after ${timeout}ms`,
+        killed: true,
+      });
+    }, timeout);
+
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      done({ stderr: e.message, failed: true });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      // 126 and 127 are "could not run": the launcher exec'd a binary that is
+      // not there or cannot be exec'd. Anything else that exited non-zero did
+      // run and may be saying no — a gate exiting 1 over an unformatted tree is
+      // the report working, not the tool broken.
+      const exit = code ?? 1;
+      done({
+        stdout: buf(out),
+        stderr: buf(err),
+        code: exit,
+        failed: exit === 126 || exit === 127,
+      });
+    });
+    if (stdin !== undefined) {
+      // The child can exit before the payload is flushed — a procoder that is
+      // not there, or one that answers and leaves. An unhandled 'error' on this
+      // stream takes the whole process down with an EPIPE, which is a very
+      // expensive way to learn the gate could not run.
+      child.stdin.on("error", () => {});
+      child.stdin.end(stdin);
     }
   });
+}
+
+// Joining captured chunks, which arrive as Buffer or string depending on how
+// the child was spawned and what it printed.
+function buf(chunks) {
+  return chunks
+    .map((c) => (typeof c === "string" ? c : c.toString("utf8")))
+    .join("");
+}
+
+// The hosts share one envelope; Copilot takes the flat object. Reading both
+// keeps this adapter working whichever shape the running binary emits.
+function envelope(text) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed.hookSpecificOutput ?? parsed;
+  } catch {
+    return null;
+  }
+}
+
+// pi reports the path as the model wrote it; the binary wants the file. A
+// leading @ is Copilot's habit leaking into a pi session — pi strips it from
+// its own tools, and a relative path here would check the wrong tree.
+function absolute(path, cwd) {
+  if (typeof path !== "string" || path === "") return "";
+  return resolve(cwd || ROOT, path.startsWith("@") ? path.slice(1) : path);
+}
+
+// pi's truncation contract: keep the head, spare the context window, and never
+// leave the model holding a partial list it believes is complete.
+function truncate(text) {
+  const lines = text.split("\n");
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (lines.length <= MAX_LINES && bytes <= MAX_BYTES) {
+    return { text, truncated: false, fullPath: "" };
+  }
+  const kept = [];
+  let used = 0;
+  for (const line of lines) {
+    const size = Buffer.byteLength(line, "utf8") + (kept.length ? 1 : 0);
+    if (kept.length >= MAX_LINES || used + size > MAX_BYTES) break;
+    kept.push(line);
+    used += size;
+  }
+  let fullPath = "";
+  try {
+    fullPath = join(tmpdir(), `procoder-${Date.now()}.txt`);
+    writeFileSync(fullPath, text, "utf8");
+  } catch {
+    // The note below still says what was dropped, which is the part the model
+    // cannot recover on its own.
+  }
+  const note = `\n\n[procoder: output truncated, ${kept.length} of ${lines.length} lines (${bytes} bytes).${
+    fullPath
+      ? ` Full output: ${fullPath}`
+      : " Full output could not be written."
+  }]`;
+  return { text: kept.join("\n") + note, truncated: true, fullPath };
+}
+
+export default function register(pi) {
+  // ---- the contract, once per session --------------------------------------
+  //
+  // pi loads AGENTS.md as a context file, so the contract is already in the
+  // system prompt and injecting it again is a 12KB tax on every turn — the
+  // defect this adapter shipped with. What pi does NOT load is the engineering
+  // principles: `.procoder/PRINCIPLES.md` is procoder's own file, and every
+  // other host is sent it.
+  //
+  // It goes out as one persistent message rather than a system-prompt edit, for
+  // the reason the Claude hook sends it once per session instead of once per
+  // request: a resumed session already has it above the fold, and #175 measured
+  // a working day of those at ~187k tokens of repeated text. A message already
+  // in the transcript is also a stable prefix, which a mutated prompt is not.
+  let contractSent = false;
+  let warnedInjection = false;
+
+  pi.on("session_start", async (event) => {
+    // resume and reload keep the same transcript, and /fork duplicates the
+    // parent's. All three already contain the message.
+    contractSent = ["resume", "reload", "fork"].includes(event?.reason);
+    warnedInjection = false;
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    if (contractSent) return undefined;
+    contractSent = true;
+
+    const options = event?.systemPromptOptions ?? {};
+    const loaded = (options.contextFiles ?? [])
+      .map((f) => absolute(f.path, options.cwd))
+      .filter(Boolean);
+    const parts = [];
+
+    const agents = readIf(AGENTS);
+    // Judged by what pi actually loaded, not by which host this is: a session
+    // started with context files disabled, and a repository whose AGENTS.md is
+    // not at this package's root, both need the text, and neither is a host
+    // name this could switch on.
+    if (agents && !loaded.includes(resolve(AGENTS))) parts.push(agents);
+
+    const principles = await run(["principles"], undefined, 15_000);
+    if (principles.code === 0 && principles.stdout.trim() !== "") {
+      parts.push(principles.stdout.trimEnd());
+    } else if (!warnedInjection) {
+      warnedInjection = true;
+      notify(
+        ctx,
+        "procoder principles did NOT reach this session — the binary did not answer",
+        "warning",
+      );
+    }
+
+    if (parts.length === 0) return undefined;
+    return {
+      message: {
+        customType: "procoder",
+        content: parts.join("\n\n"),
+        display: false,
+      },
+    };
+  });
+
+  // ---- the commit gate -----------------------------------------------------
+  pi.on("tool_call", async (event, ctx) => {
+    if (event?.toolName !== "bash") return undefined;
+    const command = event?.input?.command;
+    if (typeof command !== "string" || !isCommitish.test(command)) {
+      return undefined;
+    }
+
+    const res = await run(
+      ["hook", "pre-tool-use"],
+      JSON.stringify({
+        tool_name: "Bash",
+        cwd: ctx?.cwd || ROOT,
+        tool_input: { command },
+      }),
+      180_000,
+    );
+    const parsed = envelope(res.stdout);
+    if (!parsed) {
+      // No verdict is not a pass, and it is not a block either. The commit
+      // belongs to the coder; a gate that could not judge says so and steps
+      // aside rather than wedging a session on a machine that cannot fetch.
+      notify(
+        ctx,
+        "procoder gate did NOT judge this commit — run `procoder check` before you commit",
+        "warning",
+      );
+      return undefined;
+    }
+    if (parsed.permissionDecision === "deny") {
+      return {
+        block: true,
+        reason:
+          parsed.permissionDecisionReason || "procoder gate: blocking findings",
+      };
+    }
+    if (parsed.permissionDecisionReason) {
+      notify(ctx, parsed.permissionDecisionReason, "info");
+    }
+    return undefined;
+  });
+
+  // ---- the write hook ------------------------------------------------------
+  //
+  // pi lets a tool result be patched, which Claude Code does not: the findings
+  // land inside the write that caused them rather than in a side-channel
+  // `additionalContext` the model has to connect back to a file itself.
+  pi.on("tool_result", async (event, ctx) => {
+    if (!["write", "edit"].includes(event?.toolName)) return undefined;
+    const file = absolute(event?.input?.path, ctx?.cwd);
+    if (!file) return undefined;
+
+    const res = await run(
+      ["hook", "post-tool-use"],
+      JSON.stringify({
+        tool_name: toolLabel(event.toolName),
+        tool_input: { file_path: file },
+      }),
+      60_000,
+    );
+    const context = envelope(res.stdout)?.additionalContext;
+    if (!context) return undefined;
+    const original = Array.isArray(event.content) ? event.content : [];
+    return {
+      content: [...original, { type: "text", text: String(context).trimEnd() }],
+    };
+  });
+
+  // ---- the handoff, and the decision that was not asked --------------------
+  //
+  // Claude Code gets a Stop hook per turn and a PreCompact one. pi gets both
+  // boundaries and one it does not: agent_settled fires when pi will not
+  // continue on its own, which is exactly when a turn is over.
+  pi.on("agent_settled", async (_event, ctx) => {
+    const res = await run(
+      ["hook", "stop"],
+      JSON.stringify({
+        cwd: ctx?.cwd || ROOT,
+        last_assistant_message: lastAssistantMessage(ctx),
+      }),
+      30_000,
+    );
+    if (res.code !== 2) return undefined;
+    // Exit 2 is Claude's "send the reason back and continue". The dedupe that
+    // keeps this from looping lives in the binary, on the last-unasked-decision
+    // record — not in a variable here, because a per-process guard is forgotten
+    // by the next reload, and #242 was exactly that bug.
+    const reason = String(res.stderr || "").trim();
+    if (reason === "") return undefined;
+    if (ctx?.hasUI) {
+      // A follow-up is what makes the turn continue: the model reads the refusal
+      // and asks the question it was told to ask.
+      try {
+        pi.sendUserMessage(reason, { deliverAs: "followUp" });
+      } catch {
+        // A session mid-shutdown can refuse the send. The reason is still worth
+        // printing, which is the fallback below.
+        process.stderr.write(`procoder: ${reason}\n`);
+      }
+      return undefined;
+    }
+    // Print and JSON modes have no UI to notify and, past that, nothing to
+    // deliver a follow-up to: the session exits once the agent settles. A live
+    // run showed the binary refusing a turn, writing its dedupe record, and the
+    // reason vanishing with the process — the question both unasked and, to
+    // anyone reading the log afterwards, never asked at all. stderr is the
+    // channel that survives, since stdout carries the event stream.
+    process.stderr.write(`procoder: ${reason}\n`);
+    return undefined;
+  });
+
+  pi.on("session_before_compact", async (_event, ctx) => {
+    // The note is written before a compaction because a compaction is how a
+    // session loses the turns a note remembers. Whatever happens to the
+    // summary, the handoff survives. Nothing is cancelled here.
+    await run(
+      ["hook", "stop"],
+      JSON.stringify({ cwd: ctx?.cwd || ROOT }),
+      30_000,
+    );
+    return undefined;
+  });
+
+  // ---- the command set -----------------------------------------------------
+  // Quoted because it lands inside a sentence the model will paste into a
+  // shell, and an installed path carries spaces on the platforms that do that.
+  const launcherToken = `"${LAUNCHER}"`;
+  if (existsSync(COMMANDS)) {
+    for (const entry of readdirSync(COMMANDS).sort()) {
+      if (!entry.endsWith(".md") || UNSHIPPED.has(entry)) continue;
+      const body = readIf(join(COMMANDS, entry));
+      const words = argumentWords(body);
+      pi.registerCommand(`procoder:${entry.replace(/\.md$/, "")}`, {
+        description: descriptionOf(body),
+        getArgumentCompletions: (prefix) => {
+          const items = words
+            .filter((w) => w.startsWith(prefix || ""))
+            .map((w) => ({ value: w, label: w }));
+          return items.length > 0 ? items : null;
+        },
+        handler: async (args) => {
+          const text = commandText(body, launcherToken).replaceAll(
+            "$ARGUMENTS",
+            args || "",
+          );
+          // expandPromptTemplates defaults to false, so this can never come
+          // back around and re-dispatch itself as a command.
+          pi.sendUserMessage(text);
+        },
+      });
+    }
+  }
+
+  // ---- the gate as a tool --------------------------------------------------
+  pi.registerTool({
+    name: "procoder",
+    label: "procoder",
+    description:
+      "Run one read-only procoder report over this repository: the gate (check), " +
+      "the suite (test), lint, security, the debt ledger, repository status, a " +
+      "review, the doctor, or the code index. Anything that changes state — " +
+      "closing tasks, seeding the backlog, releasing — is a /procoder: slash " +
+      "command a human invokes, not this.",
+    promptSnippet:
+      "Run a read-only procoder report (check, test, lint, security, debt, status, review, doctor, index)",
+    promptGuidelines: [
+      "Use the procoder tool to run a read-only procoder report rather than shelling out to a procoder that may be a different version.",
+      "The procoder tool refuses anything that mutates state; use the /procoder: slash command to close, seed, or release.",
+    ],
+    parameters: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          enum: REPORTING_COMMANDS,
+          description: "Which procoder report to run.",
+        },
+        args: {
+          type: "string",
+          description:
+            "Arguments for it, as one string. Empty runs that command's default.",
+        },
+      },
+      required: ["command"],
+    },
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const command = String(params?.command || "");
+      if (!REPORTING_COMMANDS.includes(command)) {
+        // Thrown, not returned: a returned value is never an error to pi, and a
+        // refusal the model can read as success is worse than the mutation.
+        throw new Error(
+          `procoder refuses "${command}" — anything that changes state is a /procoder: slash command, so a human asked for it`,
+        );
+      }
+      const args = [command];
+      const extra = String(params?.args || "").trim();
+      if (extra) args.push(...extra.split(/\s+/));
+
+      const res = await run(args, undefined, 300_000);
+      if (res.killed) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `procoder ${command} was killed after 300s and did not finish.`,
+            },
+          ],
+          details: { code: -1 },
+          isError: true,
+        };
+      }
+      const body = `${res.stdout ?? ""}${
+        res.stderr && res.code !== 0 ? `\n${res.stderr}` : ""
+      }`;
+      const cut = truncate(
+        body.trimEnd() || `(procoder ${command} printed nothing)`,
+      );
+      return {
+        content: [{ type: "text", text: cut.text }],
+        details: {
+          command,
+          code: res.code,
+          truncated: cut.truncated,
+          fullOutput: cut.fullPath,
+        },
+        // A non-zero procoder exit is a verdict; only a process that never ran
+        // is an error the model should treat as one.
+        isError: Boolean(res.failed),
+      };
+    },
+  });
+}
+
+function toolLabel(name) {
+  return name === "edit" ? "Edit" : "Write";
+}
+
+// The last assistant text of the session, read from the session itself. Claude
+// Code hands it on the Stop payload precisely because the transcript is
+// documented as lagging the current turn; pi's sessionManager IS the transcript
+// and is specified as current through the live message at these events.
+function lastAssistantMessage(ctx) {
+  try {
+    const entries = ctx?.sessionManager?.getBranch?.() ?? [];
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const entry = entries[i];
+      if (entry?.type !== "message" || entry.message?.role !== "assistant") {
+        continue;
+      }
+      const content = entry.message.content;
+      if (typeof content === "string") return content;
+      if (Array.isArray(content)) {
+        const text = content
+          .filter((c) => c?.type === "text")
+          .map((c) => c.text)
+          .join("");
+        if (text.trim() !== "") return text;
+      }
+    }
+  } catch {
+    // A session that cannot be read is a session with no last message: the note
+    // is still written, and the unasked-decision check simply has less to work
+    // with. It is not a reason to lose the handoff.
+  }
+  return "";
+}
+
+// Notifications are fire-and-forget, and pi has no UI at all in print and JSON
+// modes. Both cases are swallowed: failing a turn over a message about a message
+// is how a helper becomes the outage.
+function notify(ctx, message, level) {
+  try {
+    if (!ctx?.hasUI || !message) return;
+    ctx.ui?.notify?.(message, level);
+  } catch {
+    // nothing worth doing
+  }
 }


### PR DESCRIPTION
## What

pi goes from "listed as supported" to actually enforced. The extension now
carries the commit gate, the write hook, the handoff note and the unasked-
decision check — the same four enforcement points Claude Code gets, judged by the
same `procoder hook` entry points — and adds two surfaces the reference host does
not have: findings patched into the result of the write that caused them, and a
read-only `procoder` tool the model can call without a shell.

## Why

`docs/portability.md` said pi was supported and that it "injects `AGENTS.md` at
agent start". Three things were true underneath that row, each measured on a real
session rather than read off the docs:

- **The injection was a duplicate.** pi loads `AGENTS.md` as a context file
  itself, so the contract arrived twice per turn: 17,385 characters became 29,845,
  and the marker for one AGENTS.md section appeared twice. A 12KB tax on every
  turn, paid for text the host had already sent.
- **34 command files arrived as one skill.** `pi.skills: ["./commands"]` hits pi's
  parent-directory fallback: a skill directory with no `name` in its frontmatter
  is named after the directory, so the whole command set collapsed into a single
  skill called "commands".
- **No command could have run.** Every launcher line says
  `${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh`. pi does not set that variable and its
  template substitution does not touch it — the regex handles `$ARGUMENTS`, `$@`,
  `$N` and `${N:-default}`, not this — so all 34 would have tried to execute a
  path containing a literal `${CLAUDE_PLUGIN_ROOT}`.

## How

- **Verdicts stay in the binary.** The adapter decides nothing: the format
  verdict, the commit block, the handoff format and the unasked-decision dedupe
  all come from `hook pre-tool-use`, `hook post-tool-use` and `hook stop`, the
  same entry points `hooks/claude-hooks.json` names. A hook that cannot run
  degrades to a warning rather than wedging a session — a coder who cannot start
  a session uninstalls the thing that could not start it.
- **`tool_result` over `additionalContext`.** pi lets a tool result be patched,
  so the write hook's findings land inside the write's own result instead of
  beside it. Same for `agent_settled`, which fires when pi will not continue on
  its own — a cleaner "turn over" than `Stop`, and it also runs before a
  compaction. Both asymmetries are written into `docs/portability.md` rather than
  averaged into the table.
- **Commands register at runtime, no twin set.** 33 files are read at load,
  transformed in memory and registered as `/procoder:*`. The alternative —
  `.opencode/command/*.md`, a generated twin set with a parity test welded to it —
  would have added 33 more drift-pinned files. The transform itself moved out of
  `portability_test.go` into `hooks/host-command-text.mjs`, because it now has two
  callers in two languages and one file makes drift a red test instead of a
  command that runs the wrong binary.
- **The launcher is resolved from `import.meta.url`, never from PATH.** PATH on
  the machine this was written on carries procoder 1.0.2 while the package is
  3.4.0; a gate running the wrong binary reports a clean tree it has never seen.
- **`host.Pi` is explicit.** `PI_CODING_AGENT` → pi, ranked below the positive
  signals and above the Claude default. pi previously reached the Claude default
  by omission, so any future per-host envelope change would have silently changed
  what pi is sent.
- **`pi.skills` → `./skills`**, which holds `skills/procoder/SKILL.md` (asserted,
  not assumed), plus the `pi-package` keyword the gallery indexes on.

## Testing

`go test ./...` green; the three packages the adapters touch re-run with
`-count=1`, because Go's test cache does not see the `.mjs` files they read at
run time — a cached green there was a stale green twice during this work.
`procoder check` clean over the commit (0 blocking). `procoder spec check
pi-integration` reports COMPLETE.

`internal/portability/pi_test.go` drives the real adapter through
`testdata/pi-harness.mjs`, which hands it the object pi would hand it. The host
is fake; the adapter is not — it reads the real `commands/`, resolves its own
launcher path, and spawns the real `hooks/launcher.sh` against a fixture binary
via `PROCODER_BIN`. 14 tests: registry against `commands/`, launcher resolution
per platform, contract injected once (and not to a resumed session), commit
blocked/allowed/never-spawned, findings patched into a write result, tool
truncation with the temp file, mutating subcommands refused, the unasked-decision
block, degradation with no binary, the manifest, the docs row, host naming.

Then live, in nested `pi` sessions against the installed package:

- the write's own tool result carried
  `procoder [format]: …/bad.go is not formatted. Below is the output of gofmt…`
  followed by a lint finding — the `tool_result` patch working where no unit test
  can reach;
- `.procoder/state/handoff.md` appeared with facts read from that session
  (head, branch, dirty count) and the untouchable Notes block intact;
- `hook stop` exited 2 on a real message that ended with a question the user had
  not been asked, and wrote its dedupe record;
- **the commit gate blocked a commit before the shell ran**, in an adopted
  scratch repo: the session reported the gate's two findings verbatim and
  `git log` afterward showed only the prior commit, so nothing landed. That is
  the shape pi's own `agent-loop.js` implies — it awaits `beforeToolCall` and
  returns an error tool result on `block` ahead of executing the tool.

An earlier revision of this description claimed the gate judged the staged
index, and a later one claimed a commit had gone through over a refusal. Neither
was measured; both are replaced above by the commands that produced them. The
corrections, and what each claim's replacement rests on, are in
`.procoder/ask/decisions.md`.

Two spec criteria stay unticked, both annotated in the spec rather than quietly
dropped: `TestPiWriteResultCarriesSecretFinding` and
`TestPiTurnWritesHandoffKeepingNotes`. Each restates an `internal/hook` claim from
the other side of the launcher; the adapter forwards `additionalContext` without
inspecting its kind, and the format criterion already holds that transport. The
spec is left `Status: draft` for the same reason.

## Notes for the reviewer

- Start at `pi-extension/index.mjs`. The four `pi.on(...)` blocks are the whole
  integration; `run()` is the only part with real machinery in it (byte-capped
  capture, 126/127 as "did not run" vs a non-zero that means "said no", stdin
  EPIPE guard).
- Worth questioning: the reporting-only tool. `check`, `test`, `lint`, `security`,
  `debt`, `status`, `review`, `doctor`, `index` are callable by the model;
  `todo close`, `backlog seed`, `release` throw. The line is the one `procoder
  run` already draws — nothing that changes state comes from a sentence an agent
  session could have written — but it is a wider surface than the other hosts
  give the model, so it is the call most worth a second opinion.
- One thing the live runs turned on, which is not this PR's to fix and which I
  first got wrong in both directions: the commit gate checks formatting only in a
  repository that has **adopted** procoder. The same staged file that `gofmt -l`
  names reports `1 file(s) not formatting-checked, 0 blocking` with no
  `.procoder/`, and `1 unformatted` plus a blocking finding once
  `.procoder/config.toml` exists. The report's own scope line says this; the
  row above says pi "gates a `git commit`", which is true in both cases — what
  the gate blocks *on* is the binary's scope decision, not the adapter's, and it
  is the same under Claude Code.
- Also in `ask/`: `procoder format` prints file content in only one of its four
  verdicts. `procoder format f > f` therefore replaces `f` with a one-line banner
  whenever `f` was already clean. That happened to three files in this session,
  twice of them uncommitted. `procoder check` caught all three, after the fact.
