### PR TITLE
fix: procoder format printed a banner where the file should be

### DIFF
--- a/.kilo/commands/format.md
+++ b/.kilo/commands/format.md
@@ -12,10 +12,32 @@ If no files were named in the arguments, use the files you have written or
 edited in this session.
 
 The command prints each file's formatted result — it never modifies anything;
-you stay in control. For each file:
+you stay in control.
 
-- "already formatted": nothing to do.
+For ONE file, stdout is exactly the bytes that belong in that file, whatever
+the verdict: the formatter's output when it disagrees, the file's own bytes
+when it does not, when no formatter covers the type, or when the formatter
+could not answer. The verdict line goes to stderr. Capture that output to
+another path and write it yourself, and the round trip is loss-free on every
+verdict: an empty stdout means the file could not be read, never that it came
+out clean.
+
+Never redirect the output over the file it just read. The shell truncates the
+target before the command runs, so that file is already empty by the time the
+formatter could look at it, and nothing printed afterwards can put it back. The
+command notices this shape and refuses with the name of the file and how to
+restore it — that is a loud failure, not a recovery.
+
+With MORE THAN ONE file, stdout carries a header naming each one, because five
+files cannot share one stream otherwise. Read that output; never redirect a
+multi-file run over any file it names.
+
+For each file, the verdict says:
+
+- "already formatted": the bytes on stdout are the file unchanged, and there is
+  nothing to do.
 - a formatted result: review it, then write it to the file yourself.
-- "NOT checked": the formatter is missing or failed — tell the user what the
-  output says, and suggest /procoder:doctor. Do not treat the file as clean.
+- "NOT checked": the formatter is missing or failed — the exit is non-zero. Tell
+  the user what the output says, and suggest /procoder:doctor. Do not treat the
+  file as clean.
 - "out of scope": no formatter covers this file type; say so and move on.

--- a/.opencode/command/format.md
+++ b/.opencode/command/format.md
@@ -12,10 +12,32 @@ If no files were named in the arguments, use the files you have written or
 edited in this session.
 
 The command prints each file's formatted result — it never modifies anything;
-you stay in control. For each file:
+you stay in control.
 
-- "already formatted": nothing to do.
+For ONE file, stdout is exactly the bytes that belong in that file, whatever
+the verdict: the formatter's output when it disagrees, the file's own bytes
+when it does not, when no formatter covers the type, or when the formatter
+could not answer. The verdict line goes to stderr. Capture that output to
+another path and write it yourself, and the round trip is loss-free on every
+verdict: an empty stdout means the file could not be read, never that it came
+out clean.
+
+Never redirect the output over the file it just read. The shell truncates the
+target before the command runs, so that file is already empty by the time the
+formatter could look at it, and nothing printed afterwards can put it back. The
+command notices this shape and refuses with the name of the file and how to
+restore it — that is a loud failure, not a recovery.
+
+With MORE THAN ONE file, stdout carries a header naming each one, because five
+files cannot share one stream otherwise. Read that output; never redirect a
+multi-file run over any file it names.
+
+For each file, the verdict says:
+
+- "already formatted": the bytes on stdout are the file unchanged, and there is
+  nothing to do.
 - a formatted result: review it, then write it to the file yourself.
-- "NOT checked": the formatter is missing or failed — tell the user what the
-  output says, and suggest /procoder:doctor. Do not treat the file as clean.
+- "NOT checked": the formatter is missing or failed — the exit is non-zero. Tell
+  the user what the output says, and suggest /procoder:doctor. Do not treat the
+  file as clean.
 - "out of scope": no formatter covers this file type; say so and move on.

--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,6 +1,6 @@
 # What a human decided
 
-Written 2026-08-27 17:07 UTC. procoder reads this
+Written 2026-08-31 12:44 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
 
@@ -188,6 +188,34 @@ Answer: All six roadmap issues. Done: #194/#209/#211 in #227, #189 in #229, #192
 
 ## [decision] decisions.md
 
+Key: 7fc6bb7f721b
+Question: How do the 34 command files reach pi?
+
+`package.json` declares `pi.skills: ["./commands"]`. Measured, that yields one
+skill named `commands` — pi falls back to the parent directory name when a
+skill has no `name:` frontmatter, so all 34 files collide and it keeps the
+first (`adr.md`) and warns about the rest. The other 33 are invisible.
+
+They are also not skills: each is a user-typed command that expands `$ARGUMENTS`
+into a shell line. pi has exactly that shape, as prompt templates. But 33 of the
+34 invoke `"${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"`, and pi sets no plugin-root
+variable at all (grep for `PLUGIN_ROOT` in pi's dist: zero hits), so the line
+expands to `/hooks/launcher.sh` and fails.
+
+- Register them at load as extension commands, reading `commands/*.md` and
+  substituting the launcher path the extension resolves from its own module
+  URL: one source of truth, ~40 lines of glue, no second copy to drift.
+- Emit a pi-specific `.pi/prompts/*.md` at release time and pin it with the
+  portability drift guard, as the rule-file copies already are: 34 more files,
+  and the drift guard grows to cover generated command text.
+- Reword the canonical `commands/*.md` to name `procoder check` rather than the
+  launcher path, and make each host adapter responsible for putting a correct
+  `procoder` in front of it: cleanest text, but it changes what Claude Code runs.
+
+Answer: Register the 34 at load as pi extension commands named /procoder:<name>, reading commands/*.md and applying the twin transform in memory, with the launcher resolved from the extension's own module URL. No committed twin set. opencodeTwin moves out of the test file into a shared function both adapters use.
+
+## [decision] decisions.md
+
 Key: 815c92a8de33
 Question: Close #206, whose premise does not hold for procoder?
 
@@ -213,6 +241,13 @@ compiles. The exposure the issue describes is not there.
   add one.
 
 Answer: not yet — do a deep analysis first, and close only if it is 100% certain
+
+## (no longer asked)
+
+Key: 87246294ecbe
+Question: `procoder format` prints content in one of four verdicts — fix the command, or the habit?
+
+Answer: Fix the command, the first option. Given as an instruction rather than a
 
 ## (no longer asked)
 
@@ -267,6 +302,26 @@ Question: Does `procoder prune` delete, or print what it would delete?
 
 Answer: report by default, delete on --apply — the safe thing stays the default and the reclaim still happens in one command
 
+## [decision] decisions.md
+
+Key: c649842b7895
+Question: Does the pi adapter match the Claude hook set, or use what pi offers?
+
+pi can do two things Claude Code's hook set cannot. `tool_result` lets the
+post-write findings land inside the write's own tool result instead of as a
+side-channel `additionalContext`, and `agent_settled` fires per turn rather than
+only at session end, so the handoff note and the unasked-decision block can run
+every turn.
+
+- Hook parity first: the four hooks, nothing more, so one comparison across
+  hosts stays honest and the pi row in docs/portability.md means what the
+  Claude row means.
+- Go further now, and record in docs/portability.md that pi gets strictly more
+  than Claude does — accepting that "supported on host X" stops being a
+  comparable claim across the host table.
+
+Answer: Advantage where pi genuinely offers it, parity otherwise — `tool_result` for the post-write findings, per-turn handoff and unasked-decision on `agent_settled`, and docs/portability.md states plainly where pi has more than Claude rather than leaving the rows looking equivalent.
+
 ## (no longer asked)
 
 Key: c9c26deda0a7
@@ -303,6 +358,27 @@ explicit flag, refuse rather than guess. No new boundary, no new mechanism.
 - close #192: the manual procedures it targets (#66-#73) are one-offs.
 
 Answer: Copy the `procoder run` shape — print by default, execute under an explicit flag, refuse rather than guess. Shipped in #228 as declarative markdown that executes nothing.
+
+## [decision] decisions.md
+
+Key: e41c4108da55
+Question: Where does the pi adapter get installed from?
+
+Every rule-file host gets a committed copy under its own path; every plugin-tier
+host gets a manifest and an install step. pi can take either shape, and the
+choice decides whether a governed repository carries pi files at all.
+
+- `pi install git:github.com/azrtydxb/procoder@vX` (user scope): one install per
+  machine, works in every repository, nothing committed, and the version is
+  pinned by hand rather than by the repo.
+- `pi install -l` writing a committed `.pi/settings.json`: the repo declares its
+  own procoder version, matching how `[release] files` pins versions; needs
+  project trust, and every adopter runs the install after cloning.
+- A committed `.pi/extensions/procoder.ts` copy, byte-identical to
+  `pi-extension/index.mjs`, pinned by the drift guard like the other rule files:
+  zero install step, and a copy to regenerate in every governed repository.
+
+Answer: Global — `pi install git:github.com/azrtydxb/procoder@vX` at user scope. Nothing committed into a governed repository; the adapter resolves its launcher from its own module URL, so it never depends on what is on PATH.
 
 ## [decision] decisions.md
 

--- a/cmd/procoder/format_cmd_test.go
+++ b/cmd/procoder/format_cmd_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The contract these tests hold: stdout of `procoder format` is the bytes that
+// belong in the file, whatever the verdict.
+//
+// This is a regression guard with a body count. The documented way to capture
+// a formatted file was to redirect it, and there were two ways to lose the file
+// that way. Redirecting onto the file itself is not recoverable by this command
+// — the shell truncates the target before the process exists — so it is refused
+// outright, which is what collidingOutput is for. The other way belonged to
+// this command and is what these tests hold: for as long as the verdicts with no
+// formatted text printed one header line and nothing after it, a caller that
+// captured the output to a temporary path and wrote it back got a banner where a
+// file used to be. That emptied a 551-line documentation page in this repository
+// (#120) and three more files during the pi integration. The fix shipped then
+// was a gate finding for emptied Markdown, which catches one extension after the
+// fact; these hold the command itself, for every file type, on the success path.
+//
+// proved by: printing the banner to `out` instead of `notes`, or writing
+// res.Formatted unconditionally so a Clean file prints nothing.
+
+func writeFixture(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// A file the formatter already agrees with must come back byte for byte. This
+// is the exact call that destroyed docs/commands.md.
+func TestFormatFilesPrintsTheFileBackWhenItIsAlreadyFormatted(t *testing.T) {
+	dir := t.TempDir()
+	src := "package main\n\nfunc main() {}\n"
+	clean := writeFixture(t, dir, "clean.go", src)
+
+	var out, notes bytes.Buffer
+	if code := formatFiles([]string{clean}, &out, &notes); code != 0 {
+		t.Fatalf("an already-formatted file exited %d:\n%s", code, notes.String())
+	}
+	if out.String() != src {
+		t.Fatalf("the file did not come back intact, got %q", out.String())
+	}
+	if strings.Contains(out.String(), "already formatted") {
+		t.Errorf("the verdict line is on stdout, which is where the bytes go:\n%s", out.String())
+	}
+	if !strings.Contains(notes.String(), "already formatted") {
+		t.Errorf("the verdict never reached the reader: %q", notes.String())
+	}
+}
+
+// The one verdict that has new bytes must still print exactly them, with no
+// header in front: that is the shape `> file` was always safe with.
+func TestFormatFilesPrintsTheToolOutputWhenTheFormatterDisagrees(t *testing.T) {
+	dir := t.TempDir()
+	messy := "package main\n\nimport \"fmt\"\n\nfunc main() {\n    fmt.Println(\"x\")\n}\n"
+	messyPath := writeFixture(t, dir, "messy.go", messy)
+	want := "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"x\")\n}\n"
+
+	var out, notes bytes.Buffer
+	if code := formatFiles([]string{messyPath}, &out, &notes); code != 0 {
+		t.Fatalf("an unformatted file exited %d:\n%s", code, notes.String())
+	}
+	if out.String() != want {
+		t.Fatalf("stdout is not the formatter's output:\n%q", out.String())
+	}
+	if !strings.Contains(notes.String(), "review and write it") {
+		t.Errorf("the verdict never reached the reader: %q", notes.String())
+	}
+}
+
+// A file nothing can check must still survive the pipeline. The type below is
+// one procoder either does not claim or cannot run a tool for, and both of
+// those print the file's own bytes — the difference between them is the exit
+// code, asserted from whatever verdict the run actually got rather than from
+// which formatters this machine happens to have.
+func TestFormatFilesPrintsTheFileBackWhenNothingCheckedIt(t *testing.T) {
+	dir := t.TempDir()
+	src := "notes written down\nsecond line\n"
+	other := writeFixture(t, dir, "notes.unknownext", src)
+
+	var out, notes bytes.Buffer
+	code := formatFiles([]string{other}, &out, &notes)
+	if out.String() != src {
+		t.Fatalf("an unchecked file did not come back intact, got %q", out.String())
+	}
+	if strings.Contains(notes.String(), "NOT checked") && code == 0 {
+		t.Error("a file that was NOT checked exited green; the next command cannot tell")
+	}
+}
+
+// Headers exist so a caller can tell five files apart, and they are the reason
+// a multi-file run is read rather than redirected. One file therefore gets no
+// header at all — anything on stdout would be bytes the file must not gain.
+func TestFormatFilesLabelsOnlyWhenFilesShareTheStream(t *testing.T) {
+	dir := t.TempDir()
+	src := "package main\n\nfunc main() {}\n"
+	a := writeFixture(t, dir, "a.go", src)
+	b := writeFixture(t, dir, "b.go", src)
+
+	var solo bytes.Buffer
+	formatFiles([]string{a}, &solo, &bytes.Buffer{})
+	if strings.Contains(solo.String(), "== ") {
+		t.Errorf("a single file carries a header, which would be written into it:\n%s", solo.String())
+	}
+
+	var pair bytes.Buffer
+	formatFiles([]string{a, b}, &pair, &bytes.Buffer{})
+	text := pair.String()
+	for _, name := range []string{"a.go", "b.go"} {
+		if !strings.Contains(text, "== "+filepath.Join(dir, name)) {
+			t.Errorf("no header names %s when two files share one stream:\n%s", name, text)
+		}
+	}
+	if strings.Count(text, src) != 2 {
+		t.Errorf("both bodies must follow their own header:\n%s", text)
+	}
+	if !strings.Contains(text, "do not redirect") {
+		t.Error("the labelled form is the unsafe one and does not say so")
+	}
+}
+
+// The redirect the shell truncates before this process exists. The file cannot
+// be saved by anything printed here — the point of the check is that the
+// failure is loud, names the file, and exits non-zero instead of printing a
+// verdict into the hole and calling it success.
+func TestFormatRefusesWhenStdoutIsTheFileBeingRead(t *testing.T) {
+	dir := t.TempDir()
+	victim := writeFixture(t, dir, "victim.go", "package main\n\nfunc main() {}\n")
+	other := writeFixture(t, dir, "other.go", "package main\n\nfunc main() {}\n")
+
+	out, err := os.Create(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+
+	if got := collidingOutput([]string{other, victim}, out); got != victim {
+		t.Errorf("stdout is %s and the check missed it, naming %q", victim, got)
+	}
+	// A pipe or a terminal is never the file: this is the case the check must
+	// not fire on, or every ordinary run would be refused.
+	if got := collidingOutput([]string{victim}, nil); got != "" {
+		t.Errorf("no stdout to compare and it named %q", got)
+	}
+	// The order of the arguments must not decide which file gets named.
+	if got := collidingOutput([]string{victim, other}, out); got != victim {
+		t.Errorf("the first argument won over the real collision: %q", got)
+	}
+}

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -1529,20 +1529,118 @@ func specCmd(args []string) int {
 // P-CONTROL. Multiple files are separated by headers so the agent can tell
 // which output belongs to which file.
 func formatCmd(files []string) int {
+	if clash := collidingOutput(files, os.Stdout); clash != "" {
+		// Say it and stop. The truncation has already happened — the shell
+		// empties the target before the command is exec'd — so nothing can be
+		// read and there is no verdict to print. The only thing left worth doing
+		// is naming the recovery, instead of printing a plausible banner into the
+		// hole and exiting green, which is what the old success path did.
+		fmt.Fprintf(os.Stderr,
+			"procoder format: stdout IS %s, which the shell truncated before this command ran.\n"+
+				"Nothing was read and nothing was written. Restore the file (git checkout -- %s, or\n"+
+				"your editor's undo), then capture somewhere else and write it yourself:\n"+
+				"    procoder format %s > %s.formatted\n",
+			clash, clash, clash, clash)
+		return 1
+	}
+	return formatFiles(files, os.Stdout, os.Stderr)
+}
+
+// collidingOutput names the input file stdout points at, if any.
+//
+// This is the half of the loss an output contract cannot reach: with
+// `procoder format f > f` the shell has cut f to zero bytes before the process
+// exists, so the command reads an empty file whatever it then prints.
+// Detecting it is the value — silent data loss becomes a message that names the
+// file and the way back. A pipe, a terminal and /dev/null are never a
+// collision; only a regular file can be the same file as an argument.
+func collidingOutput(files []string, out *os.File) string {
+	if out == nil {
+		return ""
+	}
+	stat, err := out.Stat()
+	if err != nil || !stat.Mode().IsRegular() {
+		return ""
+	}
+	for _, f := range files {
+		if info, err := os.Stat(f); err == nil && os.SameFile(info, stat) {
+			return f
+		}
+	}
+	return ""
+}
+
+// formatFiles decides what a caller sees, and the rule took a repository's
+// documentation to learn: stdout is the bytes that belong in the file, in
+// EVERY verdict.
+//
+// Capturing this command's output was documented as `procoder format f > f`,
+// and there were two distinct ways to lose the file with it. The first is the
+// one this function owns: for as long as the three verdicts with no formatted
+// text printed a header and nothing after it, a caller that captured the output
+// to a temporary path and wrote it back — the correct pattern, and the only one
+// that can work — got a banner where a file used to be. It emptied a
+// 551-line documentation page in this repository (#120) and three more files
+// during the pi integration, twice of them uncommitted and rewritten from
+// memory. #120's fix was downstream: an emptied Markdown file became a blocking
+// finding, which catches one file type after the fact and leaves the trap set
+// for every other one.
+//
+// So the verdict line moves to stderr, where it belongs — it is for whoever is
+// reading a transcript, not for a pipe, and a banner that cannot be redirected
+// over a file cannot empty one. What lands on stdout is the tool's output for
+// Unformatted and the file's own bytes for the other three, which makes writing
+// a captured result back a no-op rather than a deletion.
+//
+// The second way to lose the file is the redirect itself, and it is refused in
+// formatCmd rather than papered over here: pointed at the file being read,
+// stdout is not the problem, the empty file is.
+//
+// More than one file keeps its headers, and keeps them on stdout, because five
+// files cannot share one stream without them. A multi-file run is read, never
+// redirected, and the header says so on the first line rather than assuming the
+// caller remembered which shape is safe.
+func formatFiles(files []string, out, notes io.Writer) int {
 	code := 0
+	labelled := len(files) > 1
 	for _, f := range files {
 		res := format.Check(f)
 		switch res.Verdict {
 		case format.Clean:
-			fmt.Printf("== %s — already formatted\n", f)
+			fmt.Fprintf(notes, "== %s — already formatted\n", f)
 		case format.OutOfScope:
-			fmt.Printf("== %s — out of scope: %s\n", f, res.Reason)
+			fmt.Fprintf(notes, "== %s — out of scope: %s\n", f, res.Reason)
 		case format.Unchecked:
-			fmt.Printf("== %s — NOT checked: %s\n", f, res.Reason)
+			fmt.Fprintf(notes, "== %s — NOT checked: %s\n", f, res.Reason)
 			code = 1
 		case format.Unformatted:
-			fmt.Printf("== %s — formatted result (%s), review and write it:\n", f, res.Tool)
-			os.Stdout.Write(res.Formatted)
+			fmt.Fprintf(notes, "== %s — formatted result (%s), review and write it:\n", f, res.Tool)
+		}
+
+		content := res.Formatted
+		if res.Verdict != format.Unformatted {
+			raw, err := os.ReadFile(f)
+			if err != nil {
+				// Nothing on stdout for a file that cannot be read. The verdict
+				// line above says why, and there is nothing here to destroy: a
+				// file that cannot be read cannot be redirected over either.
+				continue
+			}
+			content = raw
+		}
+		if labelled {
+			// The header is what makes a multi-file run readable, and what makes
+			// it unsafe to redirect onto any one of these files. Say which.
+			fmt.Fprintf(out, "== %s — these bytes belong in this file; do not redirect a multi-file run over one of them\n", f)
+		}
+		if _, err := out.Write(content); err != nil {
+			// A closed stdout (`| head`) is the ordinary case. Say which file did
+			// not make it out and leave a non-zero exit behind, because a format
+			// run that printed nothing is exactly the shape this command had when it
+			// was emptying files, and it must not read as success twice over.
+			fmt.Fprintf(notes, "== %s — could not be written out: %v\n", f, err)
+			code = 1
+			return code
 		}
 	}
 	return code

--- a/commands/format.md
+++ b/commands/format.md
@@ -12,10 +12,32 @@ If no files were named in the arguments, use the files you have written or
 edited in this session.
 
 The command prints each file's formatted result — it never modifies anything;
-you stay in control. For each file:
+you stay in control.
 
-- "already formatted": nothing to do.
+For ONE file, stdout is exactly the bytes that belong in that file, whatever
+the verdict: the formatter's output when it disagrees, the file's own bytes
+when it does not, when no formatter covers the type, or when the formatter
+could not answer. The verdict line goes to stderr. Capture that output to
+another path and write it yourself, and the round trip is loss-free on every
+verdict: an empty stdout means the file could not be read, never that it came
+out clean.
+
+Never redirect the output over the file it just read. The shell truncates the
+target before the command runs, so that file is already empty by the time the
+formatter could look at it, and nothing printed afterwards can put it back. The
+command notices this shape and refuses with the name of the file and how to
+restore it — that is a loud failure, not a recovery.
+
+With MORE THAN ONE file, stdout carries a header naming each one, because five
+files cannot share one stream otherwise. Read that output; never redirect a
+multi-file run over any file it names.
+
+For each file, the verdict says:
+
+- "already formatted": the bytes on stdout are the file unchanged, and there is
+  nothing to do.
 - a formatted result: review it, then write it to the file yourself.
-- "NOT checked": the formatter is missing or failed — tell the user what the
-  output says, and suggest /procoder:doctor. Do not treat the file as clean.
+- "NOT checked": the formatter is missing or failed — the exit is non-zero. Tell
+  the user what the output says, and suggest /procoder:doctor. Do not treat the
+  file as clean.
 - "out of scope": no formatter covers this file type; say so and move on.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -380,9 +380,12 @@ it wins; leave it out and Procoder's own is used.
 
 An **empty** template file is an error, not a fallback. It blocks, and
 Procoder uses its own template for that run while saying so. The reason is
-specific: `procoder format` prints a single header line for a file that is
-already formatted and nothing after it, so a pipeline that strips the
-header and writes the rest empties the file on the success path. Falling
+that an empty file is indistinguishable from an emptied one — written out
+by an editor, truncated by a bad merge, or replaced by a pipeline that
+printed a header and nothing else. (`procoder format` did exactly that on
+its already-formatted path until the contract changed: stdout now carries
+the bytes that belong in the file for every verdict, and the verdict line
+went to stderr where it cannot overwrite anything.) Either way, falling
 back quietly would mean a team discovers their customised template is gone
 when their next story comes out in Procoder's shape instead of theirs.
 


### PR DESCRIPTION
## What

`procoder format <file>` now prints, on stdout, the bytes that belong in that file — for every verdict, not one of them. The verdict line moved to stderr. And the command refuses when you point its stdout at the file it was asked to read.

## Why

The command printed formatted content only on the `Unformatted` branch. `Clean`, `OutOfScope` and `Unchecked` printed a one-line header and no content, so the pattern that works — capture stdout to a temporary path, review, write it back — wrote a banner over the file, for three verdicts out of four.

This has now emptied files three times in one session (a markdown page, `package.json`, a pi adapter, two of them uncommitted and rewritten from memory) and once before, publicly: #120 records a 551-line documentation page destroyed the same way. What shipped for #120 was a gate finding for emptied Markdown files — a net under the trampoline. It catches one extension, after the fact, and leaves the trap armed for every other one. The command is the thing that had a success path which deletes its own input.

There is a second, different way to lose the file, and it is not this command's to fix: with `procoder format f > f` the shell truncates `f` before the process exists, so the formatter reads an empty file and no output can put it back. That shape is now refused outright, naming the file and the recovery, instead of printing a plausible header into the hole and exiting 0.

## How

- `formatFiles(files, out, notes)` takes its writers, so the branches are testable without a subprocess.
- stdout: `Formatted` for `Unformatted`, the file's own bytes for the other three. Writing a captured result back is a no-op rather than a deletion.
- stderr: the `== file — already formatted / out of scope / NOT checked / review and write it` lines. Exit codes are unchanged — `NOT checked` still exits 1, because "did not judge" must not read as clean.
- Multiple files keep per-file headers on stdout, since five files cannot share one stream, and the header says on its first line that this is the run not to redirect.
- `collidingOutput` compares stdout against each named file with `os.SameFile`; only a regular file can collide, so pipes, terminals and `/dev/null` are never refused.
- `commands/format.md` and both derived command sets say the same thing now, which `TestOpenCodeCommandParity` and `TestKiloCommandParity` hold.
- `docs/configuration.md` justified the empty-template rule by citing this behaviour as a standing hazard; it is marked as history closed at the source, with the rule itself untouched.

## Testing

`go test -count=1 ./cmd/procoder/ ./internal/portability/` green over this branch; `procoder check` 0 blocking.

The new tests were checked against the old code before being trusted, because a guard that never fails is a comment with a `func` in front of it. Mutating `formatFiles` back to the old shape fails three of them, and the Clean case fails by returning the destroyed file exactly as it happened in the session:

```
the file did not come back intact, got "== /tmp/.../clean.go — already formatted\n"
```

Against the built binary, both shapes were run for real:

- `procoder format messy.go > messy.go` → exit 1, `stdout IS messy.go, which the shell truncated before this command ran`, and the message names `git checkout -- messy.go`. The file is still zero bytes — nothing printed can undo that — but the failure is now loud instead of green.
- `procoder format clean.go > /tmp/out.tmp` → stdout is the file's bytes, verdict on stderr. Before: stdout empty, which is what made the write-back destructive.

## Notes for the reviewer

- The one judgement call worth challenging: printing a Clean file's own bytes means a caller that pipes one file at a time sees full contents where it used to see a header. That is the point — the bytes are what belong there — but it is a visible change in volume for anything scraping this command's stdout, and I found nothing in the tree that does.
- `AGENTS.md` still reads "prints the formatted result; you review and write it", which stayed true; it was left alone deliberately, since regenerating the eleven derived rule files for a sentence that did not become false is a different change.
