### PR TITLE
fix: recorded answers outlive a reflow; a command's own heredoc reaches the gate

### DIFF
--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,20 +1,13 @@
 # What a human decided
 
-Written 2026-08-31 15:50 UTC. procoder reads this
+Written 2026-08-31 18:31 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 04896a8efa23
 Question: PR #241 is a probe that must not merge
-
-It adds timing steps to the gate job and exists only to answer where the
-441s went. It has answered.
-
-- revert the probe steps and close #241 unmerged.
-- keep the runner-cores line, drop the rest: the cores line is a permanent
-  diagnostic; the PROBE steps are not.
 
 Answer: Revert all of it, including the runner-cores line, and close #241 unmerged.
 
@@ -25,45 +18,10 @@ Question: Is v3.1.1 tagged once the PRs are merged?
 
 Answer: merge only — do NOT tag. The maintainer will say when.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 2101f169020f
 Question: #211 asks for a claim the issue record contradicts
-
-**Decided: write it accurately.** Sources are named as sources; the
-convergence argument is made only where it holds.
-
-#211's acceptance criteria require a "framing paragraph [that] makes the
-'independent convergence as evidence' argument explicit" about unlazy,
-addyosmani/agent-skills and mattpocock/skills.
-
-Checked against this repo's own issue record, that framing is false for
-those three. #199 (leases), #200 (approval binding), #201 (never-execute),
-#202 (dispatch waves) and #207 (depth scaling) each open with
-"## Source — Leonxlnx/unlazy's ..." and were all filed on 2026-08-26 in one
-research sweep. #189's anti-rationalization table cites addyosmani's repo
-the same way. Procoder did not converge on these independently; it read
-them and took them, deliberately and recently.
-
-Verified against each project's own repo today: unlazy does ship the Depth
-Tree, lease coordination, a Stop hook, and pre-execution PATH disclosure;
-addyosmani/agent-skills does ship per-skill rationalization tables, a
-docs/comparison.md and a docs/skill-anatomy.md.
-
-A convergence claim is still available, but only for what procoder had
-BEFORE the sweep — the gate, the quality controllers, evidence-gated
-closes — which unlazy arrived at separately. That is a narrower and
-checkable claim.
-
-- write it accurately: name unlazy and agent-skills as SOURCES in
-  influences.md (a fifth relationship: borrowed from, recently), and make
-  the convergence argument only for the pre-sweep features where it holds.
-- follow the criteria as written: make the broad convergence argument.
-  Publishing a claim this repo's own issues contradict, in a document whose
-  purpose is credibility.
-- split: comparable-projects.md lists the projects factually with no
-  convergence framing; the argument moves to #209's research page or is
-  dropped.
 
 Answer: Write it accurately. unlazy and agent-skills are named as SOURCES in influences.md; the convergence argument is made only for the gate and evidence-gated closes, which predate the 2026-08-26 research sweep.
 
@@ -81,27 +39,10 @@ Question: What is the timeline for each marketplace review cycle?
 
 Answer: Keep open, deliberately. Not researched now.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 2d2e81cade64
 Question: The tracked-tree gate is 787 gitleaks process startups — batch it?
-
-`Secrets` calls `scanOne` once per path, and `scanOne` starts a gitleaks
-process. Over 787 tracked files that is 787 startups. A probe scanned the
-whole tree with ONE invocation in about a second, which accounts for the
-~290s of the 341s CI step that four other explanations did not.
-
-`SastChanged` in the same file already solves this shape: scan the tree
-once, then filter the FINDINGS to the paths asked about, rather than naming
-targets. Its comment says why — naming targets made semgrep scan files its
-own default selection skips.
-
-- batch above a threshold: one scan when the path set is large, per-file
-  when it is small. Keeps a three-file commit from scanning a monorepo.
-- always scan the tree and filter, like SastChanged: one rule, no
-  threshold, no heuristic to tune — and a large repository pays it on
-  every commit.
-- leave it: the local cost is 41s and only CI sees the full tree.
 
 Answer: Batch above a threshold — one whole-tree gitleaks scan when the path set is large, per-file below it, so a three-file commit does not scan a monorepo.
 
@@ -126,18 +67,10 @@ Question: Does the decisions queue and its principles change ship in v3.1.1, or 
 
 Answer: in v3.1.1 — ADR 0003 governs major, and 2.0.1 already shipped new enforcement in a patch
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 612a37231e9b
 Question: Label #209 and #211 roadmap alongside #194?
-
-All three are documentation-positioning work: an evidence bibliography, a
-comparable-projects doc, and the docs-hardening issue already labelled
-roadmap. They are one cluster and none is small.
-
-- label both roadmap: the cluster reads as direction rather than queued
-  work, which is what the label was created for.
-- leave them unlabelled: they stay in the ordinary queue.
 
 Answer: yes, label both
 
@@ -148,137 +81,38 @@ Question: Which of #177 and #181 is next, given #172 and #175 are both in review
 
 Answer: #181 (procoder prune) — already specified with guardrails agreed, start immediately
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 6625130ff945
 Question: The gitleaks batching premise was wrong — batch, or run concurrently?
 
-CORRECTION. The decision to "batch above a threshold" was taken on my
-figure that one whole-tree gitleaks call costs about a second, from a CI
-probe. Measured locally it costs 27.8s, and the CI step carried `|| true`,
-so whether it scanned anything at all is unknown.
-
-The real local numbers: per-file 0.05s × 787 = 39.4s, whole tree 27.8s. A
-30% saving, not the ~290s I implied. And the whole-tree scan reads `.git`,
-`dist` and ignored directories the per-file scan never looks at — it finds
-115 leaks there, all outside the tracked set.
-
-Which of the ~240s unaccounted for in CI is gitleaks remains unproven. I
-attributed it to per-file startup; that was inference, not measurement.
-
-- run the per-file scans concurrently: attacks process startup directly,
-  scans exactly what it scans today, helps whether the leg is 41s or 240s,
-  and is the pattern already used for the formatter pass.
-- batch above a threshold as originally agreed: fewer processes, but 30%
-  locally rather than the number the decision was made on, and it changes
-  WHAT is scanned.
-- measure gitleaks in CI properly first, then decide: one more probe cycle
-  before any code changes.
-
 Answer: Run the per-file scans concurrently. It attacks process startup directly, scans exactly what it scans today, and does not depend on the whole-tree figure I got wrong.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 6684d6433b84
 Question: What is next after v3.3.0?
 
-**Decided: all of them.** Working the six roadmap issues in dependency
-order: #194, then #211, then #209 (the docs cluster, which cross-reference
-each other), then #192, then #189, then #190 last as the largest.
-
-The ordinary queue is empty; all six open issues are roadmap-labelled.
-
-- #189 SKILL.md hardening: smallest, and its own research note calls it the
-  single highest-leverage change. Three of its four criteria still apply.
-- #194 + #211 docs cluster: pitfalls tables, honest-limits, positioning,
-  comparable projects. Medium, low risk, aimed at a skeptical adopter.
-- #209 research bibliography: needs real external citations, verified. The
-  one item where the failure mode is fabricating a source in a document
-  whose entire purpose is evidentiary honesty.
-- #190 `procoder learn`: largest by far, and the issue itself says it needs
-  a spec before any implementation.
-
 Answer: All six roadmap issues. Done: #194/#209/#211 in #227, #189 in #229, #192 in #228, #190's spec in #232 and #234.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 7fc6bb7f721b
 Question: How do the 34 command files reach pi?
 
-`package.json` declares `pi.skills: ["./commands"]`. Measured, that yields one
-skill named `commands` — pi falls back to the parent directory name when a
-skill has no `name:` frontmatter, so all 34 files collide and it keeps the
-first (`adr.md`) and warns about the rest. The other 33 are invisible.
-
-They are also not skills: each is a user-typed command that expands `$ARGUMENTS`
-into a shell line. pi has exactly that shape, as prompt templates. But 33 of the
-34 invoke `"${CLAUDE_PLUGIN_ROOT}/hooks/launcher.sh"`, and pi sets no plugin-root
-variable at all (grep for `PLUGIN_ROOT` in pi's dist: zero hits), so the line
-expands to `/hooks/launcher.sh` and fails.
-
-- Register them at load as extension commands, reading `commands/*.md` and
-  substituting the launcher path the extension resolves from its own module
-  URL: one source of truth, ~40 lines of glue, no second copy to drift.
-- Emit a pi-specific `.pi/prompts/*.md` at release time and pin it with the
-  portability drift guard, as the rule-file copies already are: 34 more files,
-  and the drift guard grows to cover generated command text.
-- Reword the canonical `commands/*.md` to name `procoder check` rather than the
-  launcher path, and make each host adapter responsible for putting a correct
-  `procoder` in front of it: cleanest text, but it changes what Claude Code runs.
-
 Answer: Register the 34 at load as pi extension commands named /procoder:<name>, reading commands/*.md and applying the twin transform in memory, with the launcher resolved from the extension's own module URL. No committed twin set. opencodeTwin moves out of the test file into a shared function both adapters use.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 815c92a8de33
 Question: Close #206, whose premise does not hold for procoder?
 
-#206 asks for ReDoS defence — bounded, sandboxed regex evaluation — because
-procoder "evaluates regex in several places that ultimately read
-repo-controlled or config-controlled text".
-
-Checked rather than taken on trust, the way #201's premise was:
-
-- there is no `regexp.Compile` anywhere in the tree;
-- the only two `MustCompile` calls with a non-literal argument build their
-  pattern from constants in source (`gitx.aiIdentities`,
-  `security.pyDeps`);
-- `.procoder/lint/RULES.md`'s `checks` list is passed to clang-tidy as its
-  `--checks` value. It never reaches a Go regex engine.
-
-So no repository- or config-controlled text becomes a pattern procoder
-compiles. The exposure the issue describes is not there.
-
-- close it, with the evidence recorded, and reopen if a runtime-compiled
-  pattern is ever introduced.
-- keep it open as a standing constraint on future work — a reminder not to
-  add one.
-
 Answer: not yet — do a deep analysis first, and close only if it is 100% certain
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: 856460402b0c
 Question: Issue #60: who sends the awesome-ai-plugins listing PR, and how far do we go?
-
-The blocking work is one README line in `hashgraph-online/awesome-ai-plugins`,
-under `## Community Plugins` → `### Development & Workflow`, between `Praxis`
-and `Project Autopilot`. Three hard gates: case-insensitive alphabetical order,
-the entry regex, and a reachable public repo — the last already passes.
-
-Everything else they describe is optional and declared so in their own
-CONTRIBUTING.md: scanner CI in procoder's own workflows (absence costs 10% of a
-trust score, blocks nothing), the local `plugin-scanner` preflight, the HOL
-registry ownership claim (a read-only GitHub OAuth grant), and the trust/Guard
-badges.
-
-- I fork and open the listing PR now, listing only, no scanner CI and no
-  registry claim — the smallest thing that satisfies what was already agreed
-  on the issue.
-- I prepare the branch and the exact diff, and you send it: the PR is outward
-  facing under your name in someone else's repository.
-- listing PR plus the pinned-SHA scanner action in procoder's CI: takes the
-  full trust score, at the cost of a third-party action in the pipeline.
 
 Answer: Keep #60 open. No listing PR is sent now, by us or by anyone — none of
 
@@ -310,28 +144,10 @@ Question: Do the four large features stay open as a roadmap?
 
 Answer: keep open, but label them roadmap/large so they stop reading as queued work
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: b2c54f852d82
 Question: Remove the cached 3.1.0 plugin too, or keep it as the rollback?
-
-**Decided: keep 3.1.0.** The rollback is worth 45 MB; prune's
-active-plus-one-previous policy stands as written.
-
-`procoder prune --apply` removed 3.0.0 and reclaimed 45 MB. It kept 3.1.0
-deliberately: the policy is the active version plus one previous, so a
-release that misbehaves has somewhere to fall back to. Removing 3.1.0 is
-outside what prune will do — it would be a manual `rm -rf` of
-`~/.claude/plugins/cache/procoder/procoder/3.1.0`.
-
-The trade is a fixed ~45 MB against the one-step rollback. Note that 3.1.0
-is now three releases behind and predates `release.maintainers`, so as a
-rollback target it would reintroduce the false positive that blocked the
-3.3.0 release commit.
-
-- keep 3.1.0: prune's own policy, and a rollback that costs 45 MB.
-- remove 3.1.0: reclaims the space; rollback then means reinstalling from
-  the marketplace rather than a local directory.
 
 Answer: Keep 3.1.0. prune's active-plus-one-previous policy stands; the rollback is worth ~45 MB.
 
@@ -351,53 +167,45 @@ Answer: report by default, delete on --apply — the safe thing stays the defaul
 
 ## [decision] decisions.md
 
+Key: c02f75b2d860
+Question: `procoder format` prints content in one of four verdicts — fix the command, or the habit?
+
+While building the pi adapter, three files were emptied by the documented
+workflow: `procoder format <file> > <file>`. `formatCmd` writes the formatted
+content only in the `Unformatted` branch; `Clean`, `OutOfScope` and `Unchecked`
+each print a one-line banner and no content, so the redirection that is correct
+one moment replaces the file with a banner the next. It happened three times in
+one session, including to files that had just been checked as clean, and the
+recovery for an uncommitted file was to rewrite it from memory.
+
+`procoder check` caught all three (an unformatted markdown file, a package.json
+that would not parse, fifteen tests failing) — the gate worked, but after three
+writes rather than before any.
+
+- Change the contract: stdout of `procoder format` is always the file's
+  formatted bytes, in every verdict, with the banner moved to stderr. The
+  documented pipeline then idempotent and safe by construction, and the cost is
+  re-printing a file nobody asked to change. Touches AGENTS.md's wording, the
+  command's own text in commands/, and the hook docs.
+- Keep the contract and only warn: extend the banner to say "no content follows,
+  do not redirect this over the file". Costs nothing, prevents nothing — the
+  next coder pipes it anyway and reads the banner afterwards.
+- Leave the command alone, record this as a lesson, and let the adapters
+  (which are the main users) keep handling the four verdicts themselves.
+
+Answer: Fix the command, the first option — given as the instruction "FIX ALL
+
+## (no longer asked)
+
 Key: c649842b7895
 Question: Does the pi adapter match the Claude hook set, or use what pi offers?
 
-pi can do two things Claude Code's hook set cannot. `tool_result` lets the
-post-write findings land inside the write's own tool result instead of as a
-side-channel `additionalContext`, and `agent_settled` fires per turn rather than
-only at session end, so the handoff note and the unasked-decision block can run
-every turn.
-
-- Hook parity first: the four hooks, nothing more, so one comparison across
-  hosts stays honest and the pi row in docs/portability.md means what the
-  Claude row means.
-- Go further now, and record in docs/portability.md that pi gets strictly more
-  than Claude does — accepting that "supported on host X" stops being a
-  comparable claim across the host table.
-
 Answer: Advantage where pi genuinely offers it, parity otherwise — `tool_result` for the post-write findings, per-turn handoff and unasked-decision on `agent_settled`, and docs/portability.md states plainly where pi has more than Claude rather than leaving the rows looking equivalent.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: c6ae2c5e09ef
 Question: Issue #107 is not reachable — close it, or ship the comment too?
-
-Probing the real host inverts the issue. OpenCode and Kilo are Bun binaries;
-Bun auto-detects module format and ignores `type`. A probe project with a
-`type`-less `.opencode/package.json` loaded BOTH an `import`-using plugin and
-one mixing `require()` with `export default` — which Node rejects under every
-setting. The reported failure cannot occur in a host.
-
-Worse, the discovery glob in both loaders is `{plugin,plugins}/*.{ts,js}`:
-`.mjs` is NOT matched, so renaming would silently stop Kilo loading procoder.
-The `.js` extension is load-bearing. And `.kilo/package.json` is Kilo-generated
-and gitignored (`.kilo/.gitignore:2`), so the proposed fix cannot ship at all;
-a root-level `"type"` works only until Kilo writes that file.
-
-The only real casualty is procoder's own Node harness
-(`TestEveryHostAdapterLoadsWithACallableDefault`), which leans on Node's
-syntax-detection fallback for the Kilo entry alone.
-
-- close #107 with the evidence, and add a comment to the plugin header saying
-  why the extension is `.js` and must stay `.js` — the rename risk is the only
-  live one, and nothing in the repo records it.
-- close #107 with the evidence and change no code: a rename already fails
-  loudly (`portability_test.go:307` t.Fatals, `adapter_test.go` names the
-  missing path), so the comment is belt on braces.
-- comment the findings on #107 but leave it open: keep it as the record until
-  someone with a real Kilo install confirms the fork matches OpenCode here.
 
 Answer: 1a — close it with the evidence, AND ship the comment. The `.js`
 
@@ -415,33 +223,10 @@ Question: Does the Claude Code marketplace offer a "curated" tier beyond communi
 
 Answer: Keep open, deliberately. Not researched now.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: d9cc806ecc55
 Question: `procoder wizard` (#192): what shape may it take?
-
-CORRECTED after reading the code. An earlier pass here claimed #192
-contradicts AGENTS.md and that #200 shipped a fingerprinted approval to
-gate it on. Both were wrong, and both came from grepping a summary line
-instead of reading what shipped.
-
-The rule reads "never executed AUTOMATICALLY", and it names `procoder run`
-as the shape to copy: prints the candidates, executes only under `--exec`,
-refuses when more than one candidate exists. `procoder run --exec` already
-executes a command the repository declared. So a human typing
-`procoder wizard run <name>` is the sanctioned shape, not a violation.
-
-What #200 actually shipped is ten lines in internal/runcmd/runcmd.go that
-print which binary `--exec` resolved to on PATH. There is no fingerprint
-store and no approval record. Anything needing one builds it first.
-
-**Decided: the `procoder run` shape.** Print by default, execute under an
-explicit flag, refuse rather than guess. No new boundary, no new mechanism.
-
-- build it in the `procoder run` shape: print by default, execute under an
-  explicit flag, refuse rather than guess. No new boundary needed.
-- build the fingerprinted approval first, then the wizard on top of it.
-- close #192: the manual procedures it targets (#66-#73) are one-offs.
 
 Answer: Copy the `procoder run` shape — print by default, execute under an explicit flag, refuse rather than guess. Shipped in #228 as declarative markdown that executes nothing.
 
@@ -452,76 +237,24 @@ Question: Which sections of this spec's Criteria table are release blockers and 
 
 Answer: Keep open, deliberately. The spec is not gating this release, so the
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: e41c4108da55
 Question: Where does the pi adapter get installed from?
 
-Every rule-file host gets a committed copy under its own path; every plugin-tier
-host gets a manifest and an install step. pi can take either shape, and the
-choice decides whether a governed repository carries pi files at all.
-
-- `pi install git:github.com/azrtydxb/procoder@vX` (user scope): one install per
-  machine, works in every repository, nothing committed, and the version is
-  pinned by hand rather than by the repo.
-- `pi install -l` writing a committed `.pi/settings.json`: the repo declares its
-  own procoder version, matching how `[release] files` pins versions; needs
-  project trust, and every adopter runs the install after cloning.
-- A committed `.pi/extensions/procoder.ts` copy, byte-identical to
-  `pi-extension/index.mjs`, pinned by the drift guard like the other rule files:
-  zero install step, and a copy to regenerate in every governed repository.
-
 Answer: Global — `pi install git:github.com/azrtydxb/procoder@vX` at user scope. Nothing committed into a governed repository; the adapter resolves its launcher from its own module URL, so it never depends on what is on PATH.
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: e721d4e97e3f
 Question: Do #210 now, before #193?
 
-`docs/influences.md` credits superpowers, ponytail and serena. BMad appears
-in it zero times, while `internal/planning/bmad.go` has shipped since 2.0.0
-and `[planning] method = "bmad"` reads BMad's own artifacts. Verified: the
-integration is real and the doc gap is real.
-
-Small, factual, and the trademark constraint is already understood — BMad
-is named to describe interoperation, never as a procoder feature name.
-
-- do it now: ten minutes, and it closes a verified gap in a provenance
-  record that is currently wrong by omission.
-- after #193: #193 was already chosen as the next piece of work.
-
 Answer: no — #193 as planned
 
-## [decision] decisions.md
+## (no longer asked)
 
 Key: f13acf27a984
 Question: Issue #117 (procoder as a service): the perf case is inverted — what now?
-
-Measured, 3.4.0 binary, 25 runs after warmup: bare spawn floor 2.9ms;
-`procoder hook pre-tool-use` direct 9.2ms; `curl` to a local HTTP service —
-the proposal's own hook command — 11.1ms; via `launcher.sh` 25.8ms;
-`principles --hook` 194ms direct, 235ms via launcher.
-
-A hook command is spawned either way, so the service pays a spawn PLUS a TCP
-round trip and comes out slower than the binary it replaces. The proposal's
-"~10-50ms to ~2-5ms" is wrong at both ends.
-
-"Stateless" conflates process state with system state: `.procoder/` already
-persists adr, ask, backlog, plans, specs, state, todo, index, security, bench.
-The real gap is that nothing is user-global — no `~/.procoder`, no
-`UserConfigDir` anywhere in `internal/`. That is a question of where the store
-lives, not whether a daemon fronts it.
-
-Three items survive: cross-repo memory (small, no daemon), a shared code-index
-cache (a cache-location problem), and inter-repo coordination (the only one
-that genuinely wants a long-lived process, and the least specified).
-
-- close #117 and open one narrow issue for the user-global store: take the
-  gap that is real, drop the architecture that was proposed to reach it.
-- comment the measurements on #117 and rescope it in place to "cross-repo
-  state without a daemon", keeping the discussion in one thread.
-- comment the measurements and leave #117 open as written: the inter-repo
-  coordination case is unproven either way and may still want a service.
 
 Answer: Verbatim: "i don't care about the speed." The measurements are not the
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,12 @@ marker = "debt:"
 # verdict alone; "block" refuses the commit until a human has answered.
 policy = "report"
 
+# A question's identity is its words, not its line breaks. Recording an
+# answer under a section that a formatter later rewrapped keeps the answer
+# valid — the question was not reworded. Rewording it asks it again, and an
+# answer recorded by an older build (whose key hashed the text as written)
+# still reads as an answer.
+
 [version]
 # "warn" (default) reports a newer release at session start; "off" silences
 # it for CI and scripted runs. There is deliberately no third value: a

--- a/internal/answers/answers.go
+++ b/internal/answers/answers.go
@@ -52,9 +52,40 @@ type Store map[string]Entry
 // reworded — the old answer belonged to a different question. Source and
 // origin are in the hash because the same sentence from two domains is two
 // questions.
+//
+// Key is the legacy identifier: it hashes the text AS WRITTEN, so a
+// reformatted or re-wrapped question changed the hash and orphaned every
+// answer recorded under it — an answered decision came back on the next
+// run. New code keys by KeyStable and reads the store through Settled, which
+// also finds what Key recorded; a store full of legacy entries stays
+// readable rather than re-asking what was already settled.
 func Key(source, origin, text string) string {
 	sum := sha1.Sum([]byte(source + "\x00" + origin + "\x00" + text)) // nosemgrep: use-of-sha1
 	return hex.EncodeToString(sum[:])[:12]
+}
+
+// KeyStable is Key over the question's WORDS rather than its line breaks.
+// A formatter reflowing a section, or a question re-wrapped across lines,
+// keeps the key it was answered under; changing a word changes the key, and
+// a reworded question is asked again, exactly as Key documented.
+func KeyStable(source, origin, text string) string {
+	return Key(source, origin, strings.Join(strings.Fields(text), " "))
+}
+
+// Settled reports whether the store holds an answer to the question, under
+// either generation of key. Recording an answer used Key, so a store written
+// before KeyStable was introduced must still read as settled, or every
+// recorded decision would be re-asked the first time after the upgrade.
+func (s Store) Settled(source, origin, text string) bool {
+	k := KeyStable(source, origin, text)
+	if _, ok := s[k]; ok {
+		return true
+	}
+	if legacy := Key(source, origin, text); legacy != k {
+		_, ok := s[legacy]
+		return ok
+	}
+	return false
 }
 
 // Path is the answers file for a repository.

--- a/internal/answers/answers_test.go
+++ b/internal/answers/answers_test.go
@@ -1,0 +1,94 @@
+package answers
+
+import (
+	"strings"
+	"testing"
+)
+
+// A question re-wrapped across lines is the same question. The legacy Key
+// hashes the text as written, so a reformatted section changed the hash and
+// orphaned every answer recorded under it — the answered decision came back
+// on the next run. KeyStable hashes the words, not the line breaks.
+//
+// proved by: KeyStable made to hash the raw text — the reflow case fails.
+func TestAReflowedQuestionKeepsItsKey(t *testing.T) {
+	oneliner := "Issue #107 is not reachable — close it, or ship the comment too?"
+	// The same question the way a formatter rewraps it across lines:
+	reflowed := "Issue #107 is not reachable — close it, or\nship the comment too?"
+
+	if KeyStable("decision", "decisions.md", oneliner) != KeyStable("decision", "decisions.md", reflowed) {
+		t.Error("a reflowed question changed its key, so an answer recorded under the old line breaks would be re-asked")
+	}
+	if Key("decision", "decisions.md", oneliner) == Key("decision", "decisions.md", reflowed) {
+		t.Log("note: legacy Key happens to agree here — the reflow cases that disagree are the ones this fix exists for")
+	}
+
+	// Double spaces and trailing whitespace are line breaks in disguise:
+	padded := "  Issue #107 is not reachable — close it,   or\nship the comment too? "
+	if KeyStable("decision", "decisions.md", oneliner) != KeyStable("decision", "decisions.md", padded) {
+		t.Error("whitespace-only differences changed the stable key")
+	}
+}
+
+// A reworded question is a new question: the answer belonged to different
+// words. This is the behaviour Key documented and the test pins, so the
+// stability fix is not read as a blanket "answers never expire".
+//
+// proved by: KeyStable made to ignore the text entirely — both keys collide.
+func TestARewordedQuestionGetsANewKey(t *testing.T) {
+	a := KeyStable("decision", "decisions.md", "Merge before or after?")
+	b := KeyStable("decision", "decisions.md", "Merge before, after, or not at all?")
+	if a == b {
+		t.Fatal("a reworded question kept its key, so a stale answer would silence it")
+	}
+
+	// The same sentence from two domains is still two questions:
+	if KeyStable("spec", "s.md", a) == KeyStable("decision", "d.md", a) {
+		t.Error("source and origin must stay in the key")
+	}
+}
+
+// A store written before KeyStable was introduced holds its answers under
+// the legacy key. Settled must find them, or the upgrade re-asks every
+// decision that was already settled.
+//
+// proved by: the legacy lookup removed from Settled — the case fails.
+func TestSettledFindsAnswersRecordedUnderTheLegacyKey(t *testing.T) {
+	// Multi-line on purpose: that is exactly the shape where the two
+	// generations of key disagree.
+	body := "Issue #107 is not reachable — close it, or ship the comment too?\n\n" +
+		"- close it, with the evidence\n- ship the comment as well"
+
+	store := Store{
+		Key("decision", "decisions.md", body): {Question: body, Answer: "close it, with the evidence"},
+	}
+	if !store.Settled("decision", "decisions.md", body) {
+		t.Fatal("an answer recorded under the legacy key did not read as settled")
+	}
+
+	// And an answer recorded under the STABLE key settles the question too:
+	stable := Store{
+		KeyStable("decision", "decisions.md", body): {Question: body, Answer: "ship the comment"},
+	}
+	if !stable.Settled("decision", "decisions.md", body) {
+		t.Fatal("an answer recorded under the stable key did not read as settled")
+	}
+
+	// A question nobody answered is open under either generation:
+	if store.Settled("decision", "decisions.md", "A different question entirely?") {
+		t.Error("an unrelated question read as settled")
+	}
+}
+
+// Key and KeyStable agree on the text neither generation needs to repair —
+// a single-line, already-canonical question — so a store full of single-line
+// answers is readable without the fallback ever firing.
+func TestTheTwoGenerationsOfKeyAgreeOnCanonicalText(t *testing.T) {
+	text := "Which version of the Agent Plugins specification is current?"
+	if Key("spec", "marketplace-strategy", text) != KeyStable("spec", "marketplace-strategy", text) {
+		t.Error("canonical text must key identically in both generations")
+	}
+	if strings.Count(text, "\n") != 0 {
+		t.Error("the test premise is a single-line question")
+	}
+}

--- a/internal/ask/ask.go
+++ b/internal/ask/ask.go
@@ -32,9 +32,16 @@ type Question struct {
 	Text   string
 }
 
-// Key identifies the question across runs — see answers.Key for why it
-// hashes what was asked rather than where it appeared.
-func (q Question) Key() string { return answers.Key(q.Source, q.Origin, q.Text) }
+// Key identifies the question across runs — see answers.KeyStable for why
+// it hashes the question's words rather than its line breaks, and answers.Key
+// for the legacy identifier a store may still be written in.
+func (q Question) Key() string { return answers.KeyStable(q.Source, q.Origin, q.Text) }
+
+// LegacyKey is the pre-KeyStable identifier: the hash of the text as written.
+// Stores recorded before the change hold answers under it, so a lookup that
+// only knows Key would re-ask everything that was settled. Both readers of
+// the store try the stable key first and this one second.
+func (q Question) LegacyKey() string { return answers.Key(q.Source, q.Origin, q.Text) }
 
 // Label is the one-line heading a question is filed under.
 func (q Question) Label() string {

--- a/internal/ask/decisions_test.go
+++ b/internal/ask/decisions_test.go
@@ -249,3 +249,63 @@ func TestTheGeneratedFilesAreFormatStable(t *testing.T) {
 		}
 	}
 }
+
+// The defect that shipped as "answered questions come back": the key hashed
+// the section AS WRITTEN, so a decision whose body was reflowed (by a
+// formatter, by recording the decision under it, by a re-wrap) got a new key
+// and its recorded answer was orphaned — the queue re-asked what a human had
+// already settled.
+//
+// proved by: Question.Key() made to hash the text as written — the reflowed
+// section's answer no longer reads as settled and the question comes back.
+func TestAReflowedDecisionKeepsItsRecordedAnswer(t *testing.T) {
+	root := repo(t)
+	writeDecisions(t, root, `## Merge #187 before or after #181?
+
+- before: the gate fix lands first
+- after: one release
+`)
+	first, _ := Collect(root)
+	var q *Question
+	for i := range first {
+		if first[i].Source == "decision" && strings.Contains(first[i].Text, "Merge #187") {
+			q = &first[i]
+		}
+	}
+	if q == nil {
+		t.Fatal("no decision collected")
+	}
+
+	// The same decision, rewrapped across lines: same words, new breaks.
+	writeDecisions(t, root, `## Merge #187 before or after #181?
+
+- before: the gate fix
+  lands first
+- after: one release
+`)
+	second, _ := Collect(root)
+	var r Question
+	for _, qq := range second {
+		if qq.Source == "decision" {
+			r = qq
+		}
+	}
+	if r.Text == "" {
+		t.Fatal("no decision collected after the reflow")
+	}
+	if r.Key() != q.Key() {
+		t.Fatalf("a reflowed decision changed its key: %q → %q — its answer would be re-asked", q.Key(), r.Key())
+	}
+
+	// And both generations of record settle it: an answer stored under the
+	// stable key, and one stored under the legacy key a pre-upgrade store
+	// would still carry.
+	store := Answers{r.Key(): {Question: r.Text, Answer: "before"}}
+	if left := Unanswered([]Question{r}, store); len(left) != 0 {
+		t.Errorf("an answer recorded under the stable key did not settle the reflowed question: %v", left)
+	}
+	legacy := Answers{r.LegacyKey(): {Question: r.Text, Answer: "before"}}
+	if left := Unanswered([]Question{r}, legacy); len(left) != 0 {
+		t.Errorf("an answer recorded under the legacy key did not settle the question: %v", left)
+	}
+}

--- a/internal/ask/file.go
+++ b/internal/ask/file.go
@@ -27,11 +27,13 @@ type Answers = answers.Store
 // Path is where one of the two files lives.
 func Path(root, name string) string { return filepath.Join(root, filepath.FromSlash(Dir), name) }
 
-// Unanswered is the questions still waiting on a person.
+// Unanswered is the questions still waiting on a person. A question answered
+// under the legacy key — the store was written before KeyStable — counts as
+// answered, or the upgrade would re-ask everything already settled.
 func Unanswered(qs []Question, answers Answers) []Question {
 	var out []Question
 	for _, q := range qs {
-		if _, done := answers[q.Key()]; !done {
+		if !answers.Settled(q.Source, q.Origin, q.Text) {
 			out = append(out, q)
 		}
 	}

--- a/internal/ask/run.go
+++ b/internal/ask/run.go
@@ -141,7 +141,13 @@ func FromFile(root, file string, out func(string)) int {
 	}
 	known := map[string]bool{}
 	for _, q := range qs {
+		// both generations of key: an answer file written before KeyStable
+		// carries the legacy one, and it must count as known rather than as
+		// "a question no domain is asking".
 		known[q.Key()] = true
+		if lk := q.LegacyKey(); lk != q.Key() {
+			known[lk] = true
+		}
 	}
 	recorded, unknown := 0, 0
 	for key, entry := range given {

--- a/internal/hook/commit.go
+++ b/internal/hook/commit.go
@@ -77,7 +77,14 @@ func PreToolUse(stdin io.Reader, stdout io.Writer) int {
 	}
 
 	if c.message == "" && c.messageFile != "" {
-		c.message = readMessageFile(commitDir(p.Cwd, c.dir), c.messageFile)
+		// The command's own heredoc may be what the file will hold when git
+		// reads it, and the shell has not run yet, so the file read is the
+		// honest fallback only when the command does not write to it.
+		if body, ok := heredocInto(p.ToolInput.Command, c.messageFile); ok {
+			c.message = body
+		} else {
+			c.message = readMessageFile(commitDir(p.Cwd, c.dir), c.messageFile)
+		}
 	}
 
 	code, findings, timedOut := runGate(root, c.message)
@@ -328,6 +335,83 @@ func cutFlagValue(word, long, short string) (string, bool) {
 		return v, true
 	}
 	return "", false
+}
+
+// heredocInto returns the body of the heredoc the command WRITES to file —
+// what `git commit -F <file>` will read once the command's own shell has
+// run — and says whether the command's heredocs write to it at all.
+//
+// The message file a commit names is often the command's own output: `cat >
+// msg.txt <<'EOF' … EOF` followed by `git commit -F msg.txt`. The gate
+// judges the command BEFORE the shell runs, so the file does not exist yet
+// and a read of it hands back empty — the acknowledgment line was in the
+// heredoc all along, right in the command line, and this reads it from
+// there. The same shape that blocked a real merge: a resolved file whose
+// message was staged through a heredoc-built file, the gate reporting "no
+// commit message reached this check" while the message was sitting in the
+// command it was judging.
+//
+// What it deliberately does not attempt: a `>>` append (the file's prior
+// content is not knowable), a heredoc piped through another command, or a
+// target spelled differently from the `-F` argument (an absolute path
+// against a relative one). When none of the command's heredocs truncate
+// exactly the file the commit names, the read of the file stands and the
+// message stays empty, said as such.
+func heredocInto(command, file string) (string, bool) {
+	lines := strings.Split(command, "\n")
+	var body []string
+	inBody, stripTabs := false, false
+	delim, target := "", ""
+	for _, line := range lines {
+		if inBody {
+			c := strings.TrimRight(line, " \t\r")
+			if stripTabs {
+				c = strings.TrimLeft(c, "\t")
+			}
+			if c == delim {
+				if target == file {
+					return strings.Join(body, "\n"), true
+				}
+				inBody, body = false, nil
+				continue
+			}
+			body = append(body, line)
+			continue
+		}
+		i := strings.Index(line, "<<")
+		if i < 0 {
+			continue
+		}
+		rest := line[i+2:]
+		// `<<-DELIM` lets the terminator be tab-indented; the minus is part
+		// of the marker, not the delimiter, and it is quoted forms that
+		// turn off expansion.
+		stripTabs = strings.HasPrefix(rest, "-")
+		rest = strings.TrimPrefix(rest, "-")
+		delim = strings.Trim(strings.TrimSpace(rest), "\"'")
+		if delim == "" {
+			continue // a `<<` with no delimiter on the line is not one we can vouch for
+		}
+		inBody = true
+		target = truncateTarget(line)
+	}
+	return "", false
+}
+
+// truncateTarget is the target of the last TRUNCATING redirect on the line,
+// read the way a shell reads `cat > f`: the word after a `>` that is not
+// itself `>>`. Append is deliberately not a target — the file's prior
+// content is not in the command, and a message the gate cannot fully see is
+// no message.
+func truncateTarget(line string) string {
+	var target string
+	fields := strings.Fields(line)
+	for i := 0; i < len(fields); i++ {
+		if fields[i] == ">" && i+1 < len(fields) {
+			target = fields[i+1]
+		}
+	}
+	return target
 }
 
 // heredocBody returns the body of the first heredoc in the command — what

--- a/internal/hook/commit_test.go
+++ b/internal/hook/commit_test.go
@@ -346,3 +346,65 @@ func TestInstallGitPrintsAndWritesNothing(t *testing.T) {
 		t.Fatalf("InstallGit must write nothing; found %v (%v)", entries, err)
 	}
 }
+
+// The message file a commit names with -F is often the command's own
+// output — `cat > msg.txt <<'EOF' … EOF` then `git commit -F msg.txt` — and
+// the gate judges the command BEFORE the shell has run, so the file does
+// not exist yet. The acknowledgment was in the heredoc all along, in the
+// command line the gate was handed, and this is the shape that blocked a
+// real merge with "no commit message reached this check".
+//
+// proved by: the heredocInto call removed from PreToolUse — the case that
+// carries the acknowledgment in its own heredoc re-blocks on the obligation.
+func TestACommandOwnedMessageFileClearsTheObligation(t *testing.T) {
+	requireGit(t)
+	root := gitRepo(t)
+	// the obligation only BLOCKS when the repository says docs are blocking;
+	// the default is report, and a report would let both the control and the
+	// negative case through, so the fixture opts in the way the procoder
+	// repository's own config does.
+	writeAt(t, root, ".procoder/config.toml", "[docs]\npolicy = \"block\"\n")
+	writeAt(t, root, "README.md", "# demo\n\n.toolpin pins the tool versions.\n")
+	commitAll(t, root)
+	writeAt(t, root, ".toolpin", "RUFF=0.1\n")
+
+	ack := "cat > msg.txt <<'EOF'\nchore: pin bump\n\ndocs: none — the pin file is self-describing\nEOF\ngit commit -F msg.txt"
+	if v, r := decisionOf(t, commitPayload(t, root, ack)); v == "deny" {
+		t.Fatalf("an acknowledgment in the command's own heredoc must clear the obligation: %s", r)
+	}
+
+	noAck := "cat > msg2.txt <<'EOF'\nchore: pin bump\nEOF\ngit commit -F msg2.txt"
+	v, r := decisionOf(t, commitPayload(t, root, noAck))
+	if v != "deny" {
+		t.Fatalf("without the acknowledgment line the obligation must still block, got %q (%s)", v, r)
+	}
+	if !strings.Contains(r, "documentation obligation") {
+		t.Fatalf("the refusal must name the obligation:\n%s", r)
+	}
+
+	// the body carries no apostrophe on purpose: a lone quote opens the
+	// tokenizer's quoted state, which a heredoc body must never leave dangling.
+	other := "cat > other.txt <<'EOF'\ndocs: none — not for this commit\nEOF\ngit commit -F msg3.txt"
+	if v, r := decisionOf(t, commitPayload(t, root, other)); v != "deny" {
+		t.Fatalf("a heredoc that writes a different file must not answer for this commit's message: %s", r)
+	}
+}
+
+func TestHeredocIntoReadsOnlyTheHeredocThatWritesTheNamedFile(t *testing.T) {
+	cmd := "cat > msg.txt <<'EOF'\nchore: x\n\ndocs: none — reason\nEOF\ngit commit -F msg.txt"
+	if got, ok := heredocInto(cmd, "msg.txt"); !ok || !strings.Contains(got, "docs: none") {
+		t.Errorf("the heredoc that writes msg.txt must read as its message: ok=%v got=%q", ok, got)
+	}
+	if _, ok := heredocInto(cmd, "other.txt"); ok {
+		t.Error("a heredoc that writes msg.txt must not answer for other.txt")
+	}
+	if _, ok := heredocInto("git commit -F msg.txt", "msg.txt"); ok {
+		t.Error("a command with no heredoc has no heredoc message")
+	}
+	// an append leaves the file's prior content unknown: the gate cannot
+	// vouch for a message it cannot see in full
+	appe := "cat >> msg.txt <<'EOF'\nx\nEOF"
+	if _, ok := heredocInto(appe, "msg.txt"); ok {
+		t.Error("an append must not be read as the whole message")
+	}
+}

--- a/internal/hook/commit_test.go
+++ b/internal/hook/commit_test.go
@@ -368,25 +368,24 @@ func TestACommandOwnedMessageFileClearsTheObligation(t *testing.T) {
 	commitAll(t, root)
 	writeAt(t, root, ".toolpin", "RUFF=0.1\n")
 
+	// Assert the OBLIGATION, not a clean gate: a machine without the security
+	// tools carries NOT-checked findings in an adopted repository whether or
+	// not this test exists, and those are environment, not the mechanism
+	// under test.
 	ack := "cat > msg.txt <<'EOF'\nchore: pin bump\n\ndocs: none — the pin file is self-describing\nEOF\ngit commit -F msg.txt"
-	if v, r := decisionOf(t, commitPayload(t, root, ack)); v == "deny" {
-		t.Fatalf("an acknowledgment in the command's own heredoc must clear the obligation: %s", r)
+	if _, r := decisionOf(t, commitPayload(t, root, ack)); strings.Contains(r, "documentation obligation") {
+		t.Fatalf("an acknowledgment in the command's own heredoc must clear the obligation:\n%s", r)
 	}
 
 	noAck := "cat > msg2.txt <<'EOF'\nchore: pin bump\nEOF\ngit commit -F msg2.txt"
 	v, r := decisionOf(t, commitPayload(t, root, noAck))
-	if v != "deny" {
-		t.Fatalf("without the acknowledgment line the obligation must still block, got %q (%s)", v, r)
-	}
 	if !strings.Contains(r, "documentation obligation") {
-		t.Fatalf("the refusal must name the obligation:\n%s", r)
+		t.Fatalf("without the acknowledgment line the obligation must still block (decision %q):\n%s", v, r)
 	}
 
-	// the body carries no apostrophe on purpose: a lone quote opens the
-	// tokenizer's quoted state, which a heredoc body must never leave dangling.
 	other := "cat > other.txt <<'EOF'\ndocs: none — not for this commit\nEOF\ngit commit -F msg3.txt"
-	if v, r := decisionOf(t, commitPayload(t, root, other)); v != "deny" {
-		t.Fatalf("a heredoc that writes a different file must not answer for this commit's message: %s", r)
+	if _, r := decisionOf(t, commitPayload(t, root, other)); !strings.Contains(r, "documentation obligation") {
+		t.Fatalf("a heredoc that writes a different file must not answer for this commit's message:\n%s", r)
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -247,7 +247,9 @@ func openQuestions(root, path string) (unanswered []string, answered int) {
 		return questions, 0
 	}
 	for _, q := range questions {
-		if _, ok := recorded[answers.Key("spec", name, q)]; ok {
+		// Settled, not a bare lookup: an answer recorded under the legacy
+		// key — the store predates KeyStable — is an answer too.
+		if recorded.Settled("spec", name, q) {
 			answered++
 			continue
 		}


### PR DESCRIPTION
Two record-keeping gaps found in use, each with its failing reproduction:

**1. A reflowed question orphaned its recorded answer.** The question key hashed the text as written, so a formatter rewrap of a decision section (or a spec question) changed the key and the queue re-asked a settled question. `answers.KeyStable` now hashes the words, not the line breaks; a reworded question still gets a new key; and `answers.Settled` reads both generations, so pre-upgrade stores keep their history.

**2. A commit's own heredoc was invisible to the gate.** When the message file a `git commit -F <file>` names is created by the same command's `cat > <file> <<'EOF'`, the gate's check-time read finds nothing and the docs-acknowledgment line — sitting in the heredoc, in the command being judged — could not clear the obligation (the exact block this repository hit on a real merge). The gate now reads that heredoc's body; truncating redirects only, other files' heredocs never answer for this commit's message.

Mutation-checked: with each fix removed, its new test fails. Full suite green. Docs updated in docs/configuration.md under `[ask]`.
