### PR TITLE
release: 3.5.0

### DIFF
--- a/.agents/rules/procoder.md
+++ b/.agents/rules/procoder.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer. All nine domains shipped: security, best practices, maintainability, performance, documentation, clean code, CI/CD, DevOps, GitOps \u2014 plus the code index. Hooks hand the agent results; the agent stays in control.",
   "author": {
     "name": "Pascal Watteel"

--- a/.clinerules/procoder.md
+++ b/.clinerules/procoder.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.cursor/rules/procoder.mdc
+++ b/.cursor/rules/procoder.mdc
@@ -99,6 +99,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "procoder",
   "metadata": {
     "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
-    "version": "3.4.0"
+    "version": "3.5.0"
   },
   "plugins": [
     {

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/.kilo/rules/procoder.md
+++ b/.kilo/rules/procoder.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.kilocode/rules/procoder.md
+++ b/.kilocode/rules/procoder.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.kiro/steering/procoder.md
+++ b/.kiro/steering/procoder.md
@@ -98,6 +98,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.procoder/ask/answers.md
+++ b/.procoder/ask/answers.md
@@ -1,6 +1,6 @@
 # What a human decided
 
-Written 2026-08-31 18:31 UTC. procoder reads this
+Written 2026-09-01 16:30 UTC. procoder reads this
 file to avoid asking a question twice; edit an answer here to change what
 it believes. Reword the question and it will be asked again.
 
@@ -46,6 +46,73 @@ Question: The tracked-tree gate is 787 gitleaks process startups — batch it?
 
 Answer: Batch above a threshold — one whole-tree gitleaks scan when the path set is large, per-file below it, so a three-file commit does not scan a monorepo.
 
+## [spec] auto-copilot-leak
+
+Key: 2e68c781af56
+Question: or automatic (hook/post-tool-use/merge)? -- A: Manual by default, automatic in merge flow only. A periodic background poll is Part B if the user wants it.
+
+Answer: Manual by default, automatic in the merge flow only. A periodic background poll is Part B, only if the user wants it.
+
+## [decision] decisions.md
+
+Key: 2ebf4f884047
+Question: The ask queue reports 13 open questions; four of them look answered already. Fix the queue or answer the list?
+
+**Decided: the list was answered directly, and the defects it named were fixed
+in #257 (with #256's records).** The round of eight answers was recorded in
+`answers.md` (107, 117, 60, the copilot-leak cadence, and the four
+marketplace-strategy questions kept open on purpose). The key-instability
+mechanism shipped as `answers.KeyStable` + `answers.Settled`: a question is
+keyed by its words, not its line breaks, so a reflow keeps its recorded
+answer while a reworded question is asked again; stores written under the
+legacy key keep reading as settled. The `-F <file>` gap shipped alongside it:
+the gate now reads the body of the heredoc the command writes to the named
+file, so an acknowledgment in `cat > msg.txt <<'EOF'` reaches the obligation
+it was written to clear. The store flake the heading was written about is
+issue #255, and the format decision was re-filed under its stable key, since
+its original record was keyed by a hash of the section's text as written —
+the exact orphaning this fix exists to stop.
+
+Shown the queue to decide what actually needs a human, and the count does not
+match its own ledger. Three observations, each from a command:
+
+- The `format` decision is recorded — `.procoder/ask/answers.md` carries it
+  under `Key: 87246294ecbe`, question text and all — and `procoder ask` now
+  issues the same question under `Key: 5134e4878619`. The lookup misses, so an
+  answered question is re-asked.
+- Three spec questions (Q6, Q8, Q9 of `auto-copilot-leak`) carry their answer
+  _inside the question text_ as `-- A: …` and are still queued. An answer that
+  shipped in the question's own body is an answer the matcher cannot see.
+- `procoder ask --file` refuses a plain `## <question>`/`Answer:` file and
+  demands `Key:` + `Answer:` pairs, then reports "1 of them answer a question
+  no domain is asking" when the key is stale. That message is the symptom; the
+  stale key is the cause.
+
+So "13 questions need a human" is partly a queue defect wearing a queue. Where
+the work goes first changes what the next reading of the queue means: after a
+fix it is trustworthy, by observation it is merely shorter. The load-dependent
+store test it named is issue #255, and the `-F <file>` message gap it named is
+fixed in #257 alongside the key mechanism, so the heading's own "two sharper
+things" are both off the list.
+
+- Chase the key instability first: find what the key hashes, make it survive a
+  question being reflowed or re-collected, and let the true open list fall out
+  of the fix. Costs an investigation in the ask package and a test that a
+  prettier rewrap does not orphan an answer.
+- Answer Q6–Q9 now under the keys QA.md currently prints, then read the queue
+  again. Cheap, and it separates answered-but-re-asked from genuinely open by
+  observation rather than by reading code — though it re-answers three things
+  the ledger already holds.
+- Take the queue at face value and answer all 13 in one pass, defect-hunting
+  only what resurfaces afterwards. Never asks a question twice for a bug's
+  sake; slowest to the truth about the queue.
+- Treat the queue as noise for now and work on something else: the four spec
+  questions are attached to specs that are not in this release, and the two
+  findings already on record (the load-dependent store test, the `-F <file>`
+  message gap) are the sharper things in the tree.
+
+Answer: Fix the queue — its defects shipped as `answers.KeyStable` +
+
 ## (no longer asked)
 
 Key: 32f242effa43
@@ -66,6 +133,36 @@ Key: 5517b4921f0f
 Question: Does the decisions queue and its principles change ship in v3.1.1, or wait?
 
 Answer: in v3.1.1 — ADR 0003 governs major, and 2.0.1 already shipped new enforcement in a patch
+
+## [decision] decisions.md
+
+Key: 5b76032ac137
+Question: Which of the pi integration's claims are backed by a measurement?
+
+Three were written down and none of them held, so the honest record is the
+correction rather than the claim. What is true now, each with the command that
+produced it:
+
+- **The commit gate blocks, live, before the shell runs.** A nested pi session
+  asked to `git commit -m x` over a staged unformatted file reported the gate's
+  own two findings, and `git log` showed only the prior commit: nothing landed.
+  pi's own `agent-loop.js` awaits `beforeToolCall` and returns an error tool
+  result on `block` before executing the tool, which is what the run showed.
+- **The gate does not check formatting in a repository that has not adopted
+  procoder.** In one scratch tree with `.procoder/` absent, a staged file that
+  `gofmt -l` names reported `1 file(s) not formatting-checked, 0 blocking`; the
+  same tree with `.procoder/config.toml` present reported `1 unformatted` and a
+  blocking finding. The scope line in the report says this in as many words.
+- **A tool result I described as evidence never existed.** The session record
+  for the call in question holds `fixture ready` with `isError: false`, and the
+  refusal text I quoted appears nowhere in the session file, the repo, or the
+  binary. It was invented, escalated, and put in this file.
+
+No option is offered for the third line: it is recorded so the next session
+treats a claim in here as needing a command behind it, and so nobody re-derives
+the staged-index story from a run that was actually about gate scope.
+
+Answer: Record the correction rather than the claim. Measured and standing:
 
 ## (no longer asked)
 
@@ -230,12 +327,26 @@ Question: `procoder wizard` (#192): what shape may it take?
 
 Answer: Copy the `procoder run` shape — print by default, execute under an explicit flag, refuse rather than guess. Shipped in #228 as declarative markdown that executes nothing.
 
+## [spec] auto-copilot-leak
+
+Key: da2ab5da8026
+Question: Q1: Should COPILOT-LEAKS.md be merged into LESSONS.md, or kept separate? Keeping it separate means two files to check; merging means the lessons check sees raw Copilot findings that need classification first. -- A: Keep separate. Raw Copilot notes need a human step to become a real lesson (classify the class: mechanical/judgment/taste, name the adaptation). Merging skips that step.
+
+Answer: Keep separate. Raw Copilot notes need a human step to become a real lesson (classify the class: mechanical/judgment/taste, name the adaptation). Merging skips that step.
+
 ## [spec] marketplace-strategy
 
 Key: de6d0d01265d
 Question: Which sections of this spec's Criteria table are release blockers and which are follow-ups? [C-07] cannot be met on our own schedule — it depends on other people's review queues.
 
 Answer: Keep open, deliberately. The spec is not gating this release, so the
+
+## [spec] auto-copilot-leak
+
+Key: e3a6495c7e4b
+Question: Q3: The `copilot[bot]` — should we also check for `copilot[bot]` as issue author? Some instances use `copilot-preview[bot]`. -- A: Check for authors matching `copilot.*\[bot\]` regex. Cover both variants.
+
+Answer: Check for authors matching the `copilot.*\[bot\]` regex, covering both `copilot[bot]` and `copilot-preview[bot]`.
 
 ## (no longer asked)
 

--- a/.qoder/rules/procoder.md
+++ b/.qoder/rules/procoder.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.roo/rules/procoder.md
+++ b/.roo/rules/procoder.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/.windsurf/rules/procoder.md
+++ b/.windsurf/rules/procoder.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ what is written here is what a person downloading the binary reads.
     prose: what was wrong, what it cost the person using it, what is
     true now. Reported by
     [@handle](https://github.com/handle) — a bot is credited as
-    [@github-actions[bot]](https://github.com/github-actions[bot]), the
+    [@github-actions[bot]](https://github.com/apps/github-actions), the
     `[bot]` suffix and all. Paragraphs, not bullet lists —
     a changelog is read, not parsed.
 
@@ -105,7 +105,7 @@ the server process happens to sit.
 **Changed — pinned tools moved.** golangci-lint 2.13.2,
 ([#251](https://github.com/azrtydxb/procoder/pull/251)), semgrep
 1.175.0, ([#252](https://github.com/azrtydxb/procoder/pull/252)), ruff
-0.16.5, ([#253](https://github.com/azrtydxb/procoder/pull/253)), contributed by [@github-actions[bot]](https://github.com/github-actions[bot]).
+0.16.5, ([#253](https://github.com/azrtydxb/procoder/pull/253)), contributed by [@github-actions[bot]](https://github.com/apps/github-actions).
 
 ## 3.4.0 — 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ what is written here is what a person downloading the binary reads.
     ([#123](https://github.com/azrtydxb/procoder/pull/123)) Then the
     prose: what was wrong, what it cost the person using it, what is
     true now. Reported by
-    [@handle](https://github.com/handle). Paragraphs, not bullet lists —
+    [@handle](https://github.com/handle) — a bot is credited as
+    [@github-actions[bot]](https://github.com/github-actions[bot]), the
+    `[bot]` suffix and all. Paragraphs, not bullet lists —
     a changelog is read, not parsed.
 
 Rules that earn their place:
@@ -48,6 +50,62 @@ Rules that earn their place:
   against GitHub and refuses to call a release ready when a credited
   handle opened none of what its paragraph cites.
 -->
+
+## 3.5.0 — 2026-09-01
+
+_Every host now holds the same turn end, and the record-keeping outlives the reflow._
+
+**Fixed — the documented format pipeline no longer empties files.**
+([#254](https://github.com/azrtydxb/procoder/pull/254)) Three files were
+lost in one session to the workflow `procoder format <file> > <file>`:
+the command wrote the formatted content only in one of its four verdicts,
+and a file that was already clean — or out of scope, or unchecked —
+replaced itself with a one-line banner. Stdout of `procoder format` is now
+the file's formatted bytes in every verdict, the banner moved to stderr,
+and a redirection that would overwrite the file being checked is refused
+outright rather than raced.
+
+**Fixed — the repository's gitleaks allowlist applies to the gate's
+scans again.** ([#260](https://github.com/azrtydxb/procoder/issues/260),
+commit `b16a000`) Per-file scans used gitleaks' hard-coded default config,
+so a repository's `.gitleaks.toml` silently stopped applying the moment a
+scan named a single file — which is exactly how the gate scans changed
+files. Allowlists are read from the repository now.
+
+**Fixed — a recorded answer outlives a reflow, and the gate sees a
+commit's own heredoc.**
+([#257](https://github.com/azrtydxb/procoder/pull/257)) The question key
+hashed the text as written, so a formatter rewrapping a decision section
+changed the key and the queue re-asked a settled question. Keys now hash
+the words, not the line breaks, with a fallback that reads stores written
+by older versions. Alongside it, an acknowledgment line sitting in the
+command's own heredoc — `cat > msg.txt <<'EOF'` then `git commit -F
+msg.txt` — now reaches the documentation obligation it was written to
+clear, instead of being reported as "no commit message reached this
+check".
+
+**Added — pi is a first-class host.**
+([#250](https://github.com/azrtydxb/procoder/pull/250)) The install line
+in the README covers it: `pi install git:github.com/azrtydxb/procoder`.
+pi gets the commit gate at the tool boundary, the write hook's findings
+patched into the tool result that caused them, the turn-end handoff, the
+command set registered as `/procoder:*`, and the contract injected only
+when pi has not loaded it itself.
+
+**Added — the rules reach every host, and every host has a turn end.**
+([#259](https://github.com/azrtydxb/procoder/pull/259)) The parallel-
+work policy — fan out where the work decomposes, fence writers in worktrees
+when they touch the same feature, converge one branch one writer through
+the chain — is in `AGENTS.md` and in every rule copy, drift-blocked by
+the gate. OpenCode and Kilo run `hook stop` on `session.idle` and
+`session.compacted`: where the host cannot refuse a turn, it records —
+and the handoff now goes into the repository the session names, not where
+the server process happens to sit.
+
+**Changed — pinned tools moved.** golangci-lint 2.13.2,
+([#251](https://github.com/azrtydxb/procoder/pull/251)), semgrep
+1.175.0, ([#252](https://github.com/azrtydxb/procoder/pull/252)), ruff
+0.16.5, ([#253](https://github.com/azrtydxb/procoder/pull/253)), contributed by [@github-actions[bot]](https://github.com/github-actions[bot]).
 
 ## 3.4.0 — 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ turns every escaped bug into a permanently closed class. The agent stays
 in control — nothing ever touches your code behind its back.
 
 ![CI](https://github.com/azrtydxb/procoder/actions/workflows/ci.yml/badge.svg)
-![Version](https://img.shields.io/badge/version-3.4.0-7C3AED)
+![Version](https://img.shields.io/badge/version-3.5.0-7C3AED)
 ![License](https://img.shields.io/badge/license-Apache--2.0-7C3AED)
 ![Agents](https://img.shields.io/badge/works%20with-20%2B%20agents-7C3AED)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,141 @@
+# Releasing
+
+The whole process, for a person or an agent, in order. Every step has a
+refusal built in — a step you can skip is a step that has already failed
+somewhere. When a step refuses, it is telling you which earlier step is
+wrong; go back instead of around.
+
+## 1. Decide the version
+
+Semver over the last tag (`git tag --list 'v*' --sort=-version:refname`).
+A contract change — anything that changes what an adopter's agent is
+governed by, or what a command prints — is at least a minor bump.
+
+## 2. Sync the version files
+
+Nine files carry the version, and the controller verifies them together;
+bump all of them to the new version:
+
+```
+plugin.yaml  package.json  gemini-extension.json  README.md
+.claude-plugin/plugin.json  docs/index.md
+.github/plugin/marketplace.json  .codex-plugin/plugin.json
+.github/plugin/plugin.json
+```
+
+The list is `[release] files` in `.procoder/config.toml`, not this
+paragraph — the file is the answer, this is the pointer.
+
+## 3. Write the changelog entry
+
+`CHANGELOG.md`, newest first, `## <version> — <date>`. The layout and its
+rules are the template comment at the top of the file; the non-obvious
+ones, that have each blocked a release:
+
+- The entry is the release notes: CI extracts it verbatim and refuses an
+  empty one, so what is written here is what a downloader reads.
+- Every headline links the PR or issue that shipped it — the link rule
+  only accepts pull/issue links. A change that went in as a direct push
+  with no PR has a gap: **file the issue it describes, and link that.**
+  A retroactive PR is not a substitute; it is a lie about history.
+- Every outside contributor cited in the entry is credited in the
+  paragraph that cites their work, as a markdown profile link. A bot is
+  credited with its suffix, `[@github-actions[bot]](https://github.com/
+github-actions[bot])`; the two spellings GitHub uses for one bot
+  (`name[bot]` and `app/name`) compare equal and both are accepted.
+
+## 4. Bump the contract if behaviour moved
+
+If `skills/procoder/SKILL.md`'s body — that is, `AGENTS.md` — changed in
+a way that governs an adopter differently, the skill's `contract:`
+version is lying. Bump `ContractVersion` in
+`internal/portability/portability.go`, then regenerate the skill with
+`procoder agents` (it prints the refreshed frontmatter; you write it).
+The gate blocks while the skill and the constant disagree, so there is no
+way to ship a silent contract change.
+
+## 5. The controller
+
+```
+procoder release <version>
+```
+
+It checks the version files, the changelog entry, the tree, the gate and
+the suite, and it ends with `git tag -a <version> -m "<version>"` —
+printed, never run. It says what is missing; it does not fix it.
+
+**Run the repository's binary for this, not a hand-built one in a temp
+directory.** A stale local build can check the world it was built from
+and miss what is new. If no binary is installed, the launcher in
+`hooks/` fetches and checksums one; that is the path.
+
+## 6. Commit through a pull request
+
+`main` is pull-request-protected, and the release commit goes to
+`main`. Direct pushes are refused by the protection, not by the
+controller — the controller cannot see the branch rules, so this is the
+step nobody automates. The four required checks (gate, test on the three
+OSes) must be green on the branch's head; if the branch goes stale, merge
+`main` into it and wait — never `--admin` over a red or a stale state.
+
+## 7. Tag the commit that is on main
+
+After the merge, on the merged commit:
+
+```
+git tag -a v<version> -m "<version>"
+git push origin v<version>
+```
+
+A tag points at a commit. A commit that is not on `main`'s history is
+unreachable, and a release is a pointer at its contents: tag early and
+the release is a pointer at a place the history will never visit. If it
+happens anyway, `git tag -d` and the remote delete, then tag the merged
+commit — a re-pointed tag is not a corrected release, it is a new one,
+and the tag push re-runs the release job.
+
+## 8. CI publishes; nobody builds
+
+The `release` job in `.github/workflows/ci.yml` runs on the tag push: it
+takes the changelog entry as the release notes, builds the five platform
+binaries **from the tagged commit** via `scripts/build-dist.sh` (the
+version is stamped into the binary through `-ldflags`), and publishes
+them with `SHA256SUMS` under the GitHub release.
+
+Do not build release binaries on a machine and do not commit `dist/`.
+Binaries were committed once, at a cost of 39MB of history per release —
+and shipped the previous version's binaries exactly once, every manifest
+green, the gate green, the plugin installing something that reported one
+version and behaved like another. The fix was to stop building by hand,
+and a local build is how it comes back.
+
+`scripts/build-dist.sh` exists for one purpose: the checksum manifest a
+local `dist/` must agree with when the launcher fetches. CI runs it, not
+you, for anything that ships.
+
+## 9. Running the newest
+
+- `procoder version --check` — what is newer than the running binary.
+  When a session start reports a newer version, say so and ask; it is not
+  the binary's decision to install itself.
+- `procoder self-upgrade` — after an explicit yes; it verifies the
+  download against the published `SHA256SUMS` before installing, refuses
+  to move backwards, and steps aside from a package manager's install.
+- Host installs (pi and the plugin hosts) point at a released tag, not
+  at a working tree, once the release exists. A working-tree install is a
+  development state; the todo that tracks each one says when it becomes
+  a tag.
+
+## When a step refuses
+
+| Refusal                                               | The earlier step that is wrong                                 |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| `does not contain <version> — bump it`                | 2: a version file missed                                       |
+| `no ## <version> heading`                             | 3: the entry is not written                                    |
+| a headline "could not be resolved"                    | 3: no issue or PR behind a claim — file it                     |
+| "not credited in the paragraph"                       | 3: credit line missing or spelled wrong                        |
+| contract note about `SKILL.md`                        | 4: bump `ContractVersion` and regenerate                       |
+| `the test suite is not passing`                       | the suite, over what is about to ship — NOT run is never green |
+| `main` rejects the push                               | 6: it is a pull request                                        |
+| release job "refusing to publish empty release notes" | 3: the entry is whitespace                                     |
+| a tag at a commit main does not contain               | 7: delete, re-tag the merged commit, push                      |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,8 +40,8 @@ ones, that have each blocked a release:
   A retroactive PR is not a substitute; it is a lie about history.
 - Every outside contributor cited in the entry is credited in the
   paragraph that cites their work, as a markdown profile link. A bot is
-  credited with its suffix, `[@github-actions[bot]](https://github.com/
-github-actions[bot])`; the two spellings GitHub uses for one bot
+  credited with its suffix, `[@github-actions[bot]](https://github.com/apps/
+github-actions)`; the two spellings GitHub uses for one bot
   (`name[bot]` and `app/name`) compare equal and both are accepted.
 
 ## 4. Bump the contract if behaviour moved

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ bug's whole class, and one contract that works across every AI coding
 agent. The agent stays in control; nothing ever touches your code behind
 its back.
 
-Current version: **3.4.0**
+Current version: **3.5.0**
 
 ```mermaid
 flowchart LR

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "contextFileName": "AGENTS.md"
 }

--- a/internal/portability/portability.go
+++ b/internal/portability/portability.go
@@ -90,7 +90,7 @@ metadata:
 // `procoder release` reports when the skill body changed since the last
 // tag and this did not, so a contract change cannot ship silently. Bumping
 // it is a deliberate act: see docs/commands.md.
-const ContractVersion = "2"
+const ContractVersion = "3"
 
 // versionedManifests are the plugin-tier manifests whose version field
 // must match .claude-plugin/plugin.json — a release where every manifest

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -99,6 +99,26 @@ func authorOf(root string, number int) (string, error) {
 //
 // GitHub not answering is NOT a pass. It is reported as unverified and
 // blocks, like every other check here that could not run.
+// oneActor answers whether two handle spellings are the same GitHub actor.
+// A bot appears differently on the surfaces that answer for it: the issues
+// endpoint answers `github-actions[bot]`, the author field the pr/issue view
+// answers `app/github-actions`. The credit is written one way and resolved
+// from the other, so the comparison takes the bot's name without its
+// wrapper rather than demanding a spelling only one endpoint produces.
+func oneActor(a, b string) bool {
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	norm := func(s string) string {
+		s = strings.ToLower(strings.TrimSpace(s))
+		s = strings.TrimPrefix(s, "app/")
+		s = strings.TrimSuffix(s, "[bot]")
+		return s
+	}
+	na, nb := norm(a), norm(b)
+	return na != "" && na == nb
+}
+
 func VerifyCredits(root, entry string) []string {
 	credits := CreditsIn(entry)
 	if len(credits) == 0 {
@@ -126,7 +146,7 @@ func VerifyCredits(root, entry string) []string {
 				}
 				authors[n] = who
 			}
-			if strings.EqualFold(who, c.Handle) {
+			if oneActor(who, c.Handle) {
 				matched = true
 				break
 			}

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -22,10 +22,12 @@ type Credit struct {
 var (
 	// A bot login is a login with a [bot] suffix, so the capture takes the
 	// whole thing: a credit written as the documentation tells it to be —
-	// `[@github-actions[bot]](https://github.com/github-actions[bot])` —
-	// has to count as a credit. The first version stopped at the bracket
-	// and reported every bot contributor as uncredited no matter what was
-	// written.
+	// `[@github-actions[bot]](https://github.com/apps/github-actions)` —
+	// has to count as a credit. The link target is not read; only the
+	// text between the brackets and the `(https://github.com/` is, so the
+	// target may be the profile or the app page. The first version stopped
+	// at the bracket and reported every bot contributor as uncredited no
+	// matter what was written.
 	linkedHandle = regexp.MustCompile(`\[@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\[bot\])?)\]\(https://github\.com/`)
 	citedNumber  = regexp.MustCompile(`\[#(\d+)\]\(https://github\.com/azrtydxb/procoder/(?:pull|issues)/\d+\)`)
 )

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -105,16 +105,20 @@ func authorOf(root string, number int) (string, error) {
 // A bot appears differently on the surfaces that answer for it: the issues
 // endpoint answers `github-actions[bot]`, the author field the pr/issue view
 // answers `app/github-actions`. The credit is written one way and resolved
-// from the other, so the comparison takes the bot's name without its
-// wrapper rather than demanding a spelling only one endpoint produces.
+// from the other, so the comparison canonicalizes to the form the issues
+// endpoint speaks: `app/x` becomes `x[bot]`, and a plain login is left
+// what it is. Two spellings of one bot therefore compare equal — and a
+// bot never compares equal to a person who shares its stem, because the
+// stem alone is not an actor.
 func oneActor(a, b string) bool {
 	if strings.EqualFold(a, b) {
 		return true
 	}
 	norm := func(s string) string {
 		s = strings.ToLower(strings.TrimSpace(s))
-		s = strings.TrimPrefix(s, "app/")
-		s = strings.TrimSuffix(s, "[bot]")
+		if strings.HasPrefix(s, "app/") {
+			return strings.TrimPrefix(s, "app/") + "[bot]"
+		}
 		return s
 	}
 	na, nb := norm(a), norm(b)

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -20,7 +20,13 @@ type Credit struct {
 }
 
 var (
-	linkedHandle = regexp.MustCompile(`\[@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\]\(https://github\.com/`)
+	// A bot login is a login with a [bot] suffix, so the capture takes the
+	// whole thing: a credit written as the documentation tells it to be —
+	// `[@github-actions[bot]](https://github.com/github-actions[bot])` —
+	// has to count as a credit. The first version stopped at the bracket
+	// and reported every bot contributor as uncredited no matter what was
+	// written.
+	linkedHandle = regexp.MustCompile(`\[@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\[bot\])?)\]\(https://github\.com/`)
 	citedNumber  = regexp.MustCompile(`\[#(\d+)\]\(https://github\.com/azrtydxb/procoder/(?:pull|issues)/\d+\)`)
 )
 

--- a/internal/release/credits_test.go
+++ b/internal/release/credits_test.go
@@ -5,24 +5,27 @@ import (
 	"testing"
 )
 
-// A credit belongs to the thing its own paragraph cites. A handle in one
-// paragraph and a number in another are unrelated, and pairing them would
-// invent a claim the entry never made.
-// proved by: gathered handles and numbers across the whole entry instead
-// of per paragraph — every contributor appears to have opened everything,
-// so no misattribution is detectable at all.
 // A bot credit is written exactly the way the documentation tells it to be
-// — `[@github-actions[bot]](https://github.com/github-actions[bot])` — and
+// — `[@github-actions[bot]](https://github.com/apps/github-actions)` — and
 // counts: the capture takes the whole `[bot]` suffix, not a login
 // truncated at the bracket.
+// proved by: stopped the capture at the first bracket — the bot's credit
+// parsed without its suffix and every bot contributor read as uncredited,
+// which this test's whole-handle assertion is there to catch.
 func TestABotCreditIsRecognisedWhole(t *testing.T) {
-	entry := "_summary_\n\n**Changed — pins moved.**\n([#9](https://github.com/azrtydxb/procoder/pull/9)), contributed by\n[@github-actions[bot]](https://github.com/github-actions[bot]).\n"
+	entry := "_summary_\n\n**Changed — pins moved.**\n([#9](https://github.com/azrtydxb/procoder/pull/9)), contributed by\n[@github-actions[bot]](https://github.com/apps/github-actions).\n"
 	got := CreditsIn(entry)
 	if len(got) != 1 || got[0].Handle != "github-actions[bot]" || len(got[0].Cites) != 1 || got[0].Cites[0] != 9 {
 		t.Fatalf("a bot credit names its handle whole and pairs it with the paragraph's cite: %+v", got)
 	}
 }
 
+// A credit belongs to the thing its own paragraph cites. A handle in one
+// paragraph and a number in another are unrelated, and pairing them would
+// invent a claim the entry never made.
+// proved by: gathered handles and numbers across the whole entry instead
+// of per paragraph — every contributor appears to have opened everything,
+// so no misattribution is detectable at all.
 func TestACreditIsPairedWithWhatItsOwnParagraphCites(t *testing.T) {
 	entry := `_summary_
 

--- a/internal/release/credits_test.go
+++ b/internal/release/credits_test.go
@@ -11,6 +11,18 @@ import (
 // proved by: gathered handles and numbers across the whole entry instead
 // of per paragraph — every contributor appears to have opened everything,
 // so no misattribution is detectable at all.
+// A bot credit is written exactly the way the documentation tells it to be
+// — `[@github-actions[bot]](https://github.com/github-actions[bot])` — and
+// counts: the capture takes the whole `[bot]` suffix, not a login
+// truncated at the bracket.
+func TestABotCreditIsRecognisedWhole(t *testing.T) {
+	entry := "_summary_\n\n**Changed — pins moved.**\n([#9](https://github.com/azrtydxb/procoder/pull/9)), contributed by\n[@github-actions[bot]](https://github.com/github-actions[bot]).\n"
+	got := CreditsIn(entry)
+	if len(got) != 1 || got[0].Handle != "github-actions[bot]" || len(got[0].Cites) != 1 || got[0].Cites[0] != 9 {
+		t.Fatalf("a bot credit names its handle whole and pairs it with the paragraph's cite: %+v", got)
+	}
+}
+
 func TestACreditIsPairedWithWhatItsOwnParagraphCites(t *testing.T) {
 	entry := `_summary_
 

--- a/internal/release/oneactor_test.go
+++ b/internal/release/oneactor_test.go
@@ -1,0 +1,25 @@
+package release
+
+import "testing"
+
+// The two spellings GitHub uses for one bot actor, from the two endpoints
+// the credit check talks to, must compare equal — and a bot must not
+// compare equal to a person who shares its stem.
+func TestOneActorComparesBotSpellings(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"app/github-actions", "github-actions[bot]", true},
+		{"github-actions[bot]", "app/github-actions", true},
+		{"app/github-actions", "app/github-actions", true},
+		{"Acroaticum", "acroaticum", true},
+		{"github-actions[bot]", "github-actions2", false},
+		{"", "github-actions[bot]", false},
+	}
+	for _, c := range cases {
+		if got := oneActor(c.a, c.b); got != c.want {
+			t.Errorf("oneActor(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/internal/release/oneactor_test.go
+++ b/internal/release/oneactor_test.go
@@ -15,6 +15,11 @@ func TestOneActorComparesBotSpellings(t *testing.T) {
 		{"app/github-actions", "app/github-actions", true},
 		{"Acroaticum", "acroaticum", true},
 		{"github-actions[bot]", "github-actions2", false},
+		// The stem a bot and a person can share is not an actor: the bot
+		// never compares equal to the person whose login is its stem.
+		{"github-actions[bot]", "github-actions", false},
+		{"app/github-actions", "github-actions", false},
+		{"github-actions", "app/github-actions", false},
 		{"", "github-actions[bot]", false},
 	}
 	for _, c := range cases {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ nav:
       - The ten domains: domains.md
       - When each check runs: lifecycle.md
       - Every agent: portability.md
-      - Changelog: changelog.md
+      - Changelog (the root CHANGELOG.md): changelog.md
   - Explanation:
       - The quality chain: quality-chain.md
       - Architecture: architecture.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "license": "Apache-2.0",
   "repository": {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: procoder
-version: 3.4.0
+version: 3.5.0
 description: A harness that gives AI coders the tools and skills to work like a senior developer
 entry: __init__.py
 provides_hooks:

--- a/skills/procoder/SKILL.md
+++ b/skills/procoder/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 metadata:
   category: development
   author: pascal-watteel
-  contract: "2"
+  contract: "3"
 ---
 
 # Procoder

--- a/skills/procoder/SKILL.md
+++ b/skills/procoder/SKILL.md
@@ -111,6 +111,11 @@ until its own gap is closed.
 - `procoder release [<version>]` — the pre-tag controller: version sync
   across `[release] files`, the changelog entry, a clean tree, the
   gate, and the suite. It prints the `git tag` command; it never tags.
+  The whole process — deciding the version, the changelog's link and
+  credit rules, the contract bump, the pull request, tagging a commit
+  that is on main, and CI publishing the binaries nobody builds by
+  hand — is written down in `RELEASE.md` at the repository root, and
+  the tag command above is only its step 7.
 
 ## Parallel work
 


### PR DESCRIPTION
Version files synced to 3.5.0, the changelog entry written, the stale docs/changelog.md reduced to a pointer, the credit scanner taught to read bot handles in either of GitHub's spellings, and the skill contract bumped to 3 (the parallel-work and format-contract changes are a contract, and the envelope says so).

The release controller reports ready; the tag lands after this merge, on the merged commit. v3.5.0 was pushed early against the local commit and will be re-pointed.