### PR TITLE
records: the pi install is repointed at v3.5.0; the todo closes

### DIFF
--- a/.procoder/todo/20260831-repoint-the-pi-install-at-a-released-tag.md
+++ b/.procoder/todo/20260831-repoint-the-pi-install-at-a-released-tag.md
@@ -1,6 +1,6 @@
 # repoint the pi install at a released tag
 
-Status: open
+Status: closed 2026-09-01
 Created: 2026-08-31
 
 ## Description
@@ -19,13 +19,35 @@ holding.
 
 ## Acceptance criteria
 
-- [ ] `~/.pi/agent/settings.json` names
+- [x] `~/.pi/agent/settings.json` names
       `git:github.com/azrtydxb/procoder@v<release>` (or the equivalent install
       form pi documents) instead of a local path, and no local path entry
       remains.
-- [ ] The repoint happens only AFTER the release it names is cut; pointing at a
+- [x] The repoint happens only AFTER the release it names is cut; pointing at a
       tag that does not exist is the failure this record exists to prevent.
-- [ ] A fresh `pi` session loads the extension and the commit gate still
+- [x] A fresh `pi` session loads the extension and the commit gate still
       blocks an unclean commit (one probe, `git log` shows nothing landed).
 
 ## Evidence
+
+2026-09-01, after v3.5.0 was published (release job 33537811388, green, the
+five platform binaries and SHA256SUMS under the GitHub release):
+
+- `pi remove ../../Development/procoder` then
+  `pi install git:github.com/azrtydxb/procoder@v3.5.0`; the settings file now
+  carries `"packages": ["git:github.com/azrtydxb/procoder@v3.5.0"]` and the
+  local path entry is gone. The clone sits at
+  `~/.pi/agent/git/github.com/azrtydxb/procoder`, and its
+  `.claude-plugin/plugin.json` says `"version": "3.5.0"`.
+- Probe: a scratch repo with a staged, un-parseable `bad.go` and a
+  `.procoder/` config; `pi --no-session` asked to run `git commit -m probe`
+  reported the gate's refusal — `bad.go` UNCHECKED (gofmt found no package
+  clause) with a blocking finding — and `git log` on that repo shows no
+  commits: `your current branch 'main' does not have any commits yet`.
+- The install's own launcher closed the loop the record was written to
+  prevent: `hooks/launcher.sh` read `3.5.0` from the installed manifest,
+  fetched the release binary, verified it against the published SHA256SUMS,
+  and `procoder version --check` answered `procoder 3.5.0 is the latest
+release — nothing to do`. Nothing on this machine moves with a
+  `git checkout` any more.
+

--- a/.procoder/todo/20260831-repoint-the-pi-install-at-a-released-tag.md
+++ b/.procoder/todo/20260831-repoint-the-pi-install-at-a-released-tag.md
@@ -33,7 +33,12 @@ holding.
 2026-09-01, after v3.5.0 was published (release job 33537811388, green, the
 five platform binaries and SHA256SUMS under the GitHub release):
 
-- `pi remove ../../Development/procoder` then
+- The local entry in the settings file had been reworded since this record
+  was written — the Description names the absolute
+  `/Users/pascal/Development/procoder`; on 2026-09-01 the entry read the
+  relative `../../Development/procoder`, and `pi remove` takes the spec
+  string as written. So the command was
+  `pi remove ../../Development/procoder`, then
   `pi install git:github.com/azrtydxb/procoder@v3.5.0`; the settings file now
   carries `"packages": ["git:github.com/azrtydxb/procoder@v3.5.0"]` and the
   local path entry is gone. The clone sits at


### PR DESCRIPTION
The pi-install repoint todo, closed through its controller after v3.5.0 shipped. One file: the evidence record and the checked criteria.

The release it names is published (tag v3.5.0 on commit 29ffccb, the five binaries and SHA256SUMS under the GitHub release), so criterion 2 — the repoint only happens after the release it names is cut — holds by construction.