### PR TITLE
release: a cited number that does not fit an int is skipped, not wrapped

### DIFF
--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -45,7 +45,12 @@ func CreditsIn(entry string) []Credit {
 		var nums []int
 		for _, m := range citedNumber.FindAllStringSubmatch(para, -1) {
 			var n int
-			fmt.Sscanf(m[1], "%d", &n)
+			// The regex already promised digits, so a failure here means
+			// only that the number does not fit an int — skipping it keeps
+			// the credit honest rather than citing a wrapped value.
+			if _, perr := fmt.Sscanf(m[1], "%d", &n); perr != nil {
+				continue
+			}
 			nums = append(nums, n)
 		}
 		for _, m := range linkedHandle.FindAllStringSubmatch(para, -1) {
@@ -332,7 +337,9 @@ func missingCreditsWith(entry string, who func() ([]string, error), resolve func
 		var nums []int
 		for _, m := range citedNumber.FindAllStringSubmatch(para, -1) {
 			var n int
-			fmt.Sscanf(m[1], "%d", &n)
+			if _, perr := fmt.Sscanf(m[1], "%d", &n); perr != nil {
+				continue
+			}
 			nums = append(nums, n)
 		}
 		if len(nums) == 0 {

--- a/internal/release/credits.go
+++ b/internal/release/credits.go
@@ -45,9 +45,10 @@ func CreditsIn(entry string) []Credit {
 		var nums []int
 		for _, m := range citedNumber.FindAllStringSubmatch(para, -1) {
 			var n int
-			// The regex already promised digits, so a failure here means
-			// only that the number does not fit an int — skipping it keeps
-			// the credit honest rather than citing a wrapped value.
+			// The regex already promised digits, so the only parse failure is a
+			// range error: a value too large to name a PR or issue, and the
+			// value the scanner leaves behind is not one the entry cited.
+			// Skipping it keeps the credit honest.
 			if _, perr := fmt.Sscanf(m[1], "%d", &n); perr != nil {
 				continue
 			}

--- a/internal/release/credits_test.go
+++ b/internal/release/credits_test.go
@@ -109,3 +109,27 @@ func TestGitHubNotAnsweringBlocksRatherThanPasses(t *testing.T) {
 		t.Errorf("naming what it could not check: %q", got[0])
 	}
 }
+
+// A cited number too large to be an int is skipped, not misread: the
+// regex already promised digits, so the only parse failure is a range
+// error, and an ignored Sscanf would have left n at its zero value —
+// crediting a #0 that the entry never cited, or owing a credit for it.
+// proved by: appending the parsed value anyway — the credit then carries a
+// zero citation (or the owed list asks GitHub who opened #0).
+func TestACitedNumberThatDoesNotFitAnIntIsSkipped(t *testing.T) {
+	big := "999999999999999999999999999999999999999999"
+	entry := "_summary_\n\n**Fixed — a thing.**\n([#" + big + "](https://github.com/azrtydxb/procoder/pull/1)), contributed by\n[@somebody](https://github.com/somebody).\n"
+	got := CreditsIn(entry)
+	if len(got) != 1 || got[0].Handle != "somebody" || len(got[0].Cites) != 0 {
+		t.Fatalf("a citation too large to be a number is skipped, not reinterpreted: %+v", got)
+	}
+
+	called := map[int]bool{}
+	gaps := missingCreditsWith(entry,
+		func() ([]string, error) { return []string{"the-releaser"}, nil },
+		func(n int) (origin, error) { called[n] = true; return origin{login: "x"}, nil },
+	)
+	if called[0] || len(gaps) != 0 {
+		t.Fatalf("an unparseable number is not a credit nor an owed one (resolve asked for: %v, gaps: %v)", called, gaps)
+	}
+}


### PR DESCRIPTION
fmt.Sscanf's result was discarded at both credit-scanning sites in internal/release/credits.go. The citedNumber regex already promised digits, so the only failure is an int overflow — and an ignored Sscanf appended a wrapped value as a citation nobody made. Both sites now skip the number on a parse error.

procoder lint: 0 findings (the two queued errcheck advisories on these lines are gone).

docs: none — the credit rules live in RELEASE.md; what counts as a parseable citation is now said in the code comment at both sites