### PR TITLE
fix: hook output was 10KB into a 2KB delivery window

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,10 +54,10 @@ Tools compute results and hand them over; **nothing modifies code,
 files, or state behind the agent's back**. The write hook does not
 format your file — it hands the agent the formatted content to review
 and write, or, when that content is too large to deliver intact, the
-command that prints it. `templates`, `agents`, `spec template`, `todo add` all print
-content for the agent to write. The two exceptions are Procoder's own
-state (`todo close` flips a Status line; the index refreshes itself),
-never your code.
+command that prints it. `templates`, `agents`, `spec template`,
+`todo add` all print content for the agent to write. The two exceptions
+are Procoder's own state (`todo close` flips a Status line; the index
+refreshes itself), never your code.
 
 Why: an agent that experiences its tools as collaborators uses them; an
 agent that gets silently overridden routes around its harness. And every

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,8 @@ session continue rather than failing it.
 Tools compute results and hand them over; **nothing modifies code,
 files, or state behind the agent's back**. The write hook does not
 format your file — it hands the agent the formatted content to review
-and write. `templates`, `agents`, `spec template`, `todo add` all print
+and write, or, when that content is too large to deliver intact, the
+command that prints it. `templates`, `agents`, `spec template`, `todo add` all print
 content for the agent to write. The two exceptions are Procoder's own
 state (`todo close` flips a Status line; the index refreshes itself),
 never your code.
@@ -104,10 +105,23 @@ platform tool gaps), the fix lands in the shared path.
 ## The write hook, end to end
 
 `PostToolUse` on every Write/Edit: payload on stdin → format verdict
-(fixed content included if unformatted) → lint findings for that file →
-markdown/doc checks if prose → secrets scan → doc-drift notes → index
-refresh. Answer in the same turn, file untouched. Cost in practice:
-sub-second per write.
+(formatted content included if it fits the budget below, a pointer to
+`procoder format` if not) → lint findings for that file → markdown/doc
+checks if prose → secrets scan → doc-drift notes → index refresh. Answer
+in the same turn, file untouched. Cost in practice: sub-second per write.
+
+**The payload is budgeted, because delivery is.** A host does not inline
+unbounded hook output: past roughly two kilobytes Claude Code writes the
+output to a file and inlines only a preview of the first 2KB. So the hook
+keeps its whole message under that, gives the formatted body a bounded
+share of it — the only part that can be arbitrarily large — and DROPS any
+part that will not fit rather than truncating it. Half a finding is a
+finding whose meaning cannot be trusted, and half a formatted file is one
+somebody may write back over the whole thing.
+
+What was dropped is counted in the output, with `procoder check` named as
+the way to see all of it. A hook that quietly delivered four findings out
+of seven would be the silent green this tool exists to remove.
 
 ## Testing philosophy
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -35,6 +35,7 @@ it carries; the repository is judged on all of it.
 <li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>state of play</b><i>Branch against the default, dirty count, active sprint, open stories, unlearned lessons, index freshness — inside a hard three-second budget.</i></span></li>
 <li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>deferred suites</b><i>Names the test suites the gate will not run here, so a green gate is never mistaken for a suite that passed.</i></span></li>
 <li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>version check</b><i>Asks GitHub off the critical path — a slow network cannot hold a session open.</i></span></li>
+<li><span class="procoder-verdict procoder-verdict--info">Info</span><span><b>receipt check</b><i>The payload opens with an instruction and closes with an end marker. A host that inlines only the first 2KB and writes the rest to a file leaves a reader holding a preview — the marker is how it can tell, and the instruction says to go and read the remainder.</i></span></li>
 </ul>
 </div>
 </section>

--- a/internal/hook/budget_ask_test.go
+++ b/internal/hook/budget_ask_test.go
@@ -1,0 +1,78 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestQuestionsSurviveTheBudgetAsOneLineEach pins the flattening at its call
+// site, which the unit test of oneLine does not.
+//
+// Dropping oneLine does not make the payload oversized — fit simply discards
+// the whole ask part instead, and the budget assertion elsewhere still
+// passes. What is lost is the questions: the coder stops being told a human
+// decision is pending, which is the one thing askPart exists to do.
+//
+// So the assertion is that they SURVIVE, and survive as one line each.
+//
+// proved by: replacing `oneLine(q.Text, 160)` with `q.Text` makes the ask
+// part too large to fit, fit drops it, and this fails on the missing q&a
+// section.
+func TestQuestionsSurviveTheBudgetAsOneLineEach(t *testing.T) {
+	if _, err := exec.LookPath("gofmt"); err != nil {
+		t.Skip("gofmt not installed")
+	}
+	root := t.TempDir()
+
+	// A CLEAN file, so the format part contributes nothing and the ask queue
+	// is competing only with itself.
+	p := filepath.Join(root, "a.go")
+	if err := os.WriteFile(p, []byte("package probe\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".procoder", "ask"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var dec strings.Builder
+	for i := 0; i < 6; i++ {
+		dec.WriteString("## A question with a body?\n\n")
+		dec.WriteString(strings.Repeat("Context that runs on and on. ", 60))
+		dec.WriteString("\n\n- one option\n- another option\n\n")
+	}
+	if err := os.WriteFile(filepath.Join(root, ".procoder", "ask", "decisions.md"),
+		[]byte(dec.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if code := Run(payloadFor(t, p), &out); code != 0 {
+		t.Fatalf("hook exit %d — a hook must never fail the session", code)
+	}
+	if out.Len() == 0 {
+		t.Fatal("pending questions produced no payload at all")
+	}
+	var resp hookOutput
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	ctx := resp.HookSpecificOutput.AdditionalContext
+
+	if !strings.Contains(ctx, "q&a:") {
+		t.Fatalf("the questions did not survive the budget — the coder is not told a "+
+			"human decision is pending, which is the one thing this part exists for:\n%s", ctx)
+	}
+	for _, line := range strings.Split(ctx, "\n") {
+		if !strings.HasPrefix(line, "  - ") {
+			continue
+		}
+		if len([]rune(line)) > 220 {
+			t.Fatalf("a question line is %d runes — it was not flattened to a summary:\n%s",
+				len([]rune(line)), line)
+		}
+	}
+}

--- a/internal/hook/budget_ask_test.go
+++ b/internal/hook/budget_ask_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,9 +23,10 @@ import (
 // part too large to fit, fit drops it, and this fails on the missing q&a
 // section.
 func TestQuestionsSurviveTheBudgetAsOneLineEach(t *testing.T) {
-	if _, err := exec.LookPath("gofmt"); err != nil {
-		t.Skip("gofmt not installed")
-	}
+	// No gofmt skip on purpose. Whatever verdict format.Check reaches
+	// without it, the questions still have to survive the budget — and
+	// without this, a machine with no gofmt has nothing exercising Run
+	// against the budget at all.
 	root := t.TempDir()
 
 	// A CLEAN file, so the format part contributes nothing and the ask queue

--- a/internal/hook/budget_run_test.go
+++ b/internal/hook/budget_run_test.go
@@ -73,15 +73,15 @@ func TestRunNeverExceedsTheDeliveryBudget(t *testing.T) {
 	}
 	ctx := resp.HookSpecificOutput.AdditionalContext
 
-	if len(ctx) > maxContextBytes+200 {
-		t.Fatalf("payload is %d bytes, past the %d the host actually delivers — "+
+	if len(ctx) > maxContextBytes {
+		t.Fatalf("payload is %d bytes, past the %d budget the host actually delivers — "+
 			"everything after the first 2KB reaches the agent as a file path nothing makes it read",
 			len(ctx), maxContextBytes)
 	}
 	// The fixture is built to overflow. If nothing was dropped it stopped
 	// overflowing, and this test went back to proving nothing — fail loudly
 	// rather than pass quietly.
-	if !strings.Contains(ctx, "NOT shown") {
+	if !strings.Contains(ctx, "omitted") {
 		t.Fatalf("the fixture no longer overflows the budget, so this test no longer "+
 			"exercises fit — re-tune it:\n%s", ctx)
 	}

--- a/internal/hook/budget_run_test.go
+++ b/internal/hook/budget_run_test.go
@@ -1,0 +1,88 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunNeverExceedsTheDeliveryBudget is the end-to-end half, and it exists
+// because the unit test of fit does not catch the mutation that matters:
+// putting strings.Join back at the call site leaves fit correct, tested and
+// unused, with every payload oversized again.
+//
+// The fixture is tuned so the parts genuinely overflow — a formatted body
+// just under its share, so it inlines rather than being pointed at, plus a
+// full ask queue. Without that the payload lands under budget on its own and
+// the test passes whether Run calls fit or not, which is the shape of a test
+// that proves nothing.
+//
+// proved by: replacing `fit(parts)` in Run with `strings.Join(parts, "\n\n")`
+// fails this on the budget assertion.
+func TestRunNeverExceedsTheDeliveryBudget(t *testing.T) {
+	if _, err := exec.LookPath("gofmt"); err != nil {
+		t.Skip("gofmt not installed")
+	}
+	root := t.TempDir()
+
+	// An unformatted file whose FORMATTED form lands just under the share,
+	// so it is inlined and takes up most of the budget.
+	var src strings.Builder
+	src.WriteString("package probe\n")
+	for i := 0; i < 40; i++ {
+		src.WriteString("func  Fn( ) {}\n")
+	}
+	p := filepath.Join(root, "a.go")
+	if err := os.WriteFile(p, []byte(src.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A decisions ledger with more questions than askPart shows, each with a
+	// long body — the shape that put eight kilobytes of ask queue into every
+	// write in this repository.
+	if err := os.MkdirAll(filepath.Join(root, ".procoder", "ask"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var dec strings.Builder
+	for i := 0; i < 8; i++ {
+		dec.WriteString("## Question ")
+		dec.WriteString(strings.Repeat("with a very long heading ", 12))
+		dec.WriteString("?\n\n")
+		dec.WriteString(strings.Repeat("Context that runs on and on. ", 40))
+		dec.WriteString("\n\n- one option\n- another option\n\n")
+	}
+	if err := os.WriteFile(filepath.Join(root, ".procoder", "ask", "decisions.md"),
+		[]byte(dec.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if code := Run(payloadFor(t, p), &out); code != 0 {
+		t.Fatalf("hook exit %d — a hook must never fail the session", code)
+	}
+	if out.Len() == 0 {
+		t.Fatal("the fixture produced no payload, so this test asserts nothing")
+	}
+	var resp hookOutput
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("hook output is not the host's JSON shape: %v\n%s", err, out.String())
+	}
+	ctx := resp.HookSpecificOutput.AdditionalContext
+
+	if len(ctx) > maxContextBytes+200 {
+		t.Fatalf("payload is %d bytes, past the %d the host actually delivers — "+
+			"everything after the first 2KB reaches the agent as a file path nothing makes it read",
+			len(ctx), maxContextBytes)
+	}
+	// The fixture is built to overflow. If nothing was dropped it stopped
+	// overflowing, and this test went back to proving nothing — fail loudly
+	// rather than pass quietly.
+	if !strings.Contains(ctx, "NOT shown") {
+		t.Fatalf("the fixture no longer overflows the budget, so this test no longer "+
+			"exercises fit — re-tune it:\n%s", ctx)
+	}
+}

--- a/internal/hook/budget_test.go
+++ b/internal/hook/budget_test.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"procoder/internal/format"
 )
@@ -12,7 +13,7 @@ import (
 // finding happened to be built last.
 func TestFitStopsAtTheDeliveryBudget(t *testing.T) {
 	big := strings.Repeat("x", maxContextBytes)
-	got := fit([]string{"first", big, "third"})
+	got := fit([]part{{text: "first"}, {text: big}, {text: "third"}})
 
 	if !strings.Contains(got, "first") {
 		t.Fatal("the first part was dropped")
@@ -20,10 +21,13 @@ func TestFitStopsAtTheDeliveryBudget(t *testing.T) {
 	if strings.Contains(got, big) {
 		t.Fatal("a part that did not fit was included anyway")
 	}
-	if len(got) > maxContextBytes+200 {
+	// No tolerance: the notice is reserved INSIDE the budget, so the budget
+	// is the budget. A +200 slack here is what let a 2144-byte payload pass
+	// against a 2000-byte constant.
+	if len(got) > maxContextBytes {
 		t.Fatalf("payload is %d bytes, past the %d budget", len(got), maxContextBytes)
 	}
-	if !strings.Contains(got, "NOT shown") {
+	if !strings.Contains(got, "omitted") {
 		t.Fatalf("findings were dropped and the output does not say so:\n%s", got)
 	}
 }
@@ -36,11 +40,53 @@ func TestFitNeverTruncatesAPart(t *testing.T) {
 	b := strings.Repeat("b", 500)
 	c := strings.Repeat("c", 500)
 	d := strings.Repeat("d", 500)
-	got := fit([]string{a, b, c, d})
-	for _, part := range []string{a, b, c, d} {
-		if strings.Contains(got, part[:50]) && !strings.Contains(got, part) {
+	got := fit([]part{{text: a}, {text: b}, {text: c}, {text: d}})
+	for _, p := range []string{a, b, c, d} {
+		if strings.Contains(got, p[:50]) && !strings.Contains(got, p) {
 			t.Fatal("a part appears in the output but not in full")
 		}
+	}
+	// The positive half. Without it this passes on an empty return, or on a
+	// return carrying nothing but the notice — a test that cannot fail.
+	for _, p := range []string{a, b, c} {
+		if !strings.Contains(got, p) {
+			t.Fatal("a part that fits was dropped")
+		}
+	}
+	if strings.Contains(got, d) {
+		t.Fatal("a part past the budget was kept")
+	}
+	if !strings.Contains(got, "omitted") {
+		t.Fatal("a part was dropped and the output does not say so")
+	}
+}
+
+// proved by: ordering the parts by consequence is one fix for the
+// starvation; a must-keep set is the other. Whichever is in use, a secret
+// must not be the finding the budget discards.
+func TestASecretSurvivesTheBudget(t *testing.T) {
+	filler := strings.Repeat("f", maxContextBytes-100)
+	secret := "== secrets: 3 finding(s) in the file you just wrote"
+	got := fit([]part{{text: filler}, {text: secret, keep: true}})
+
+	if !strings.Contains(got, secret) {
+		t.Fatalf("the secret finding was dropped to make room for a larger part:\n%s", got)
+	}
+	if len(got) > maxContextBytes {
+		t.Fatalf("keeping it pushed the payload to %d, past the %d budget", len(got), maxContextBytes)
+	}
+}
+
+// proved by: slicing a byte index through an em-dash returns invalid UTF-8,
+// which json.Marshal replaces with U+FFFD — the question reaches the agent
+// as mojibake. The ASCII-only case cannot catch it.
+func TestOneLineDoesNotSplitARune(t *testing.T) {
+	got := oneLine(strings.Repeat("é", 400), 160)
+	if !utf8.ValidString(got) {
+		t.Fatalf("invalid UTF-8: %q", got)
+	}
+	if n := len([]rune(got)); n != 160 {
+		t.Fatalf("truncated to %d runes, want 160", n)
 	}
 }
 

--- a/internal/hook/budget_test.go
+++ b/internal/hook/budget_test.go
@@ -1,0 +1,84 @@
+package hook
+
+import (
+	"strings"
+	"testing"
+
+	"procoder/internal/format"
+)
+
+// proved by: joining every part unconditionally — what this did before —
+// produces a payload the host truncates, and what is lost is whatever
+// finding happened to be built last.
+func TestFitStopsAtTheDeliveryBudget(t *testing.T) {
+	big := strings.Repeat("x", maxContextBytes)
+	got := fit([]string{"first", big, "third"})
+
+	if !strings.Contains(got, "first") {
+		t.Fatal("the first part was dropped")
+	}
+	if strings.Contains(got, big) {
+		t.Fatal("a part that did not fit was included anyway")
+	}
+	if len(got) > maxContextBytes+200 {
+		t.Fatalf("payload is %d bytes, past the %d budget", len(got), maxContextBytes)
+	}
+	if !strings.Contains(got, "NOT shown") {
+		t.Fatalf("findings were dropped and the output does not say so:\n%s", got)
+	}
+}
+
+// proved by: truncating a part instead of dropping it hands the agent half
+// a finding — and half a formatted file is one somebody may write back over
+// the whole file.
+func TestFitNeverTruncatesAPart(t *testing.T) {
+	a := strings.Repeat("a", 500)
+	b := strings.Repeat("b", 500)
+	c := strings.Repeat("c", 500)
+	d := strings.Repeat("d", 500)
+	got := fit([]string{a, b, c, d})
+	for _, part := range []string{a, b, c, d} {
+		if strings.Contains(got, part[:50]) && !strings.Contains(got, part) {
+			t.Fatal("a part appears in the output but not in full")
+		}
+	}
+}
+
+// proved by: leaving q.Text as written lets one decision record carry its
+// whole body — blank lines and all — into a line the code calls a summary.
+// Five of those ran to eight kilobytes in this repository and crowded every
+// other finding out of the payload.
+func TestOneLineFlattensAndTruncates(t *testing.T) {
+	in := "a question\n\nwith a body\nover several lines"
+	got := oneLine(in, 160)
+	if strings.Contains(got, "\n") {
+		t.Fatalf("still multi-line: %q", got)
+	}
+	if got != "a question with a body over several lines" {
+		t.Fatalf("got %q", got)
+	}
+	if long := oneLine(strings.Repeat("z", 400), 160); len([]rune(long)) != 160 {
+		t.Fatalf("not truncated to the limit: %d runes", len([]rune(long)))
+	}
+}
+
+// proved by: the old 48KB threshold — twenty-four times the host's delivery
+// budget — let a formatted body be inlined under an instruction to write it
+// back, with only its first 2KB actually arriving.
+func TestFormattedBodyHasABoundedShare(t *testing.T) {
+	if maxInlineFormatted >= maxContextBytes {
+		t.Fatal("the formatted body may consume the whole payload, starving every finding after it")
+	}
+	msg := message(format.Result{
+		Verdict:   format.Unformatted,
+		File:      "big.go",
+		Tool:      "gofmt",
+		Formatted: []byte(strings.Repeat("x", maxInlineFormatted+1)),
+	})
+	if strings.Contains(msg, strings.Repeat("x", 100)) {
+		t.Fatal("a body over the share was inlined instead of pointed at")
+	}
+	if !strings.Contains(msg, "procoder format") {
+		t.Fatalf("no pointer to the full result:\n%s", msg)
+	}
+}

--- a/internal/hook/budget_test.go
+++ b/internal/hook/budget_test.go
@@ -128,3 +128,22 @@ func TestFormattedBodyHasABoundedShare(t *testing.T) {
 		t.Fatalf("no pointer to the full result:\n%s", msg)
 	}
 }
+
+// proved by: a keep part larger than the whole budget being dropped
+// silently — the must-keep finding is exactly the one that then vanishes,
+// and an omission nobody was told about is the silent green this tool
+// exists to remove.
+func TestAnOversizedKeepPartIsNamedInTheOmission(t *testing.T) {
+	oversized := strings.Repeat("s", maxContextBytes+100)
+	got := fit([]part{{text: "a small finding"}, {text: oversized, keep: true}})
+
+	if strings.Contains(got, oversized) {
+		t.Fatal("a part larger than the whole budget was delivered anyway")
+	}
+	if len(got) > maxContextBytes {
+		t.Fatalf("the payload is %d bytes against a %d budget", len(got), maxContextBytes)
+	}
+	if !strings.Contains(got, "1 finding(s) omitted") {
+		t.Fatalf("the oversized keep part vanished without being named:\n%s", got)
+	}
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -123,10 +123,15 @@ func askPart(root string) string {
 // kilobytes and crowd every other finding out of the payload.
 func oneLine(s string, n int) string {
 	s = strings.Join(strings.Fields(s), " ")
-	if len(s) <= n {
+	// Runes, not bytes. Slicing a byte index through this repository's
+	// em-dashes and ellipses produced invalid UTF-8, which json.Marshal
+	// then replaced with U+FFFD — a question delivered as mojibake. Found
+	// in review; the test only exercised ASCII.
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
-	return s[:n-1] + "…"
+	return string(r[:n-1]) + "…"
 }
 
 // Run handles one PostToolUse event end to end. It never returns an error to
@@ -142,10 +147,17 @@ func Run(stdin io.Reader, stdout io.Writer) int {
 		return 0
 	}
 
-	var parts []string
-	add := func(part string) {
-		if part != "" {
-			parts = append(parts, part)
+	var parts []part
+	add := func(text string) {
+		if text != "" {
+			parts = append(parts, part{text: text})
+		}
+	}
+	// A secret in a file the agent just wrote is the one finding here that
+	// blocks, and the budget is not a reason to withhold it.
+	addKeep := func(text string) {
+		if text != "" {
+			parts = append(parts, part{text: text, keep: true})
 		}
 	}
 
@@ -161,7 +173,7 @@ func Run(stdin io.Reader, stdout io.Writer) int {
 		add(markdownPart(root, p.ToolInput.FilePath))
 	} else {
 		add(driftPart(root, p.ToolInput.FilePath))
-		add(secretsPart(root, p.ToolInput.FilePath))
+		addKeep(secretsPart(root, p.ToolInput.FilePath))
 		add(lintPart(root, p.ToolInput.FilePath))
 	}
 	add(askPart(root))
@@ -256,37 +268,74 @@ func lintPart(root, file string) string {
 	return "procoder [lint]: findings in the file you just wrote — investigate, judge, and fix what is real:\n" + strings.Join(b, "\n")
 }
 
+// part is one section of the message, and whether it must survive the
+// budget. Only the secret scan sets keep: it is the blocking domain here.
+type part struct {
+	text string
+	keep bool
+}
+
 // fit joins the parts the agent will actually receive, and says so when it
 // had to leave some out.
 //
 // Parts are added in the order they were built — which is deliberate and
-// documented at each call site — and the first one that does not fit ends
-// the message. Nothing is truncated mid-part: half a finding is a finding
-// whose meaning cannot be trusted, and half a formatted file is a file
-// somebody may write back.
+// documented at each call site — and one that does not fit is SKIPPED, not
+// used to end the message: a small finding after a large one is worth
+// keeping. That is why the notice says the omitted findings are not
+// necessarily the last ones. Saying "further" would have implied a tail,
+// and an agent reading that would draw exactly the wrong conclusion about
+// which finding it is missing.
+//
+// Nothing is truncated mid-part: half a finding is a finding whose meaning
+// cannot be trusted, and half a formatted file is a file somebody may write
+// back over the whole thing.
 //
 // The notice is the point. A hook that quietly delivered four findings out
 // of seven would be the same silent-green this tool exists to remove.
-func fit(parts []string) string {
+func fit(parts []part) string {
+	// The notice has to fit INSIDE the budget, not be appended past it.
+	// Appending it afterwards returned 2144 bytes against a 2000 budget,
+	// which put the explanation of the truncation in the part that gets
+	// truncated. Found in review.
+	const noticeReserve = 220
+
+	// A must-keep part is placed first whatever its position in the
+	// message, because the budget is not a reason to withhold a secret.
+	// Review computed the case: a 900-byte formatted body plus five
+	// doc-drift notes leaves 259 bytes, and a three-secret finding is 270.
 	var kept []string
 	used := 0
 	dropped := 0
-	for _, p := range parts {
-		// +2 for the blank line between parts.
-		if used > 0 && used+len(p)+2 > maxContextBytes {
-			dropped++
-			continue
+	seen := make([]bool, len(parts))
+
+	take := func(i int, limit int) bool {
+		cost := len(parts[i].text)
+		if used > 0 {
+			cost += 2 // the blank line between parts
 		}
-		if used == 0 && len(p) > maxContextBytes {
-			dropped++
-			continue
+		if used+cost > limit {
+			return false
 		}
-		kept = append(kept, p)
-		used += len(p) + 2
+		kept = append(kept, parts[i].text)
+		used += cost
+		seen[i] = true
+		return true
+	}
+
+	limit := maxContextBytes - noticeReserve
+	for i := range parts {
+		if parts[i].keep {
+			take(i, maxContextBytes)
+		}
+	}
+	for i := range parts {
+		if !seen[i] && !take(i, limit) {
+			dropped++
+		}
 	}
 	if dropped > 0 {
 		kept = append(kept, fmt.Sprintf(
-			"== %d further finding(s) NOT shown — the host delivers only the first %d bytes of a hook's output. Run `procoder check` to see all of them.",
+			"== %d finding(s) omitted — they did not fit what the host delivers (the first %d bytes of a hook's output), and they are not necessarily the last ones. Run `procoder check` to see all of them.",
 			dropped, maxContextBytes))
 	}
 	return strings.Join(kept, "\n\n")

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -56,12 +56,22 @@ const stdinDeadline = 5 * time.Second
 // whatever comes after the format part, and a secret finding is one of the
 // things that comes after.
 //
-// Measured, not documented: two previews observed at exactly 2KB, one on
-// SessionStart stdout at 9.9KB of output and one on this hook's
-// additionalContext at 10.7KB. The threshold at which the host starts
-// persisting is NOT established — only that 2KB is what it inlines when it
-// does. So 2KB is treated as the whole budget, which is safe whatever the
-// persist threshold turns out to be.
+// Measured, not documented, and the threshold is BRACKETED rather than
+// pinned: payloads of 5.2KB and 7.3KB were delivered whole, while 9.9KB
+// and 10.7KB were persisted with a 2KB preview. So the host tolerates
+// more than 2KB — it is the preview size, not the limit.
+//
+// The budget is the preview size anyway, deliberately. Guessing high fails
+// silently: a payload over the real threshold loses everything past 2KB
+// with nothing saying so, and the tail is where the findings are. Guessing
+// low costs only that a formatted body over its share arrives as the
+// command that prints it, which is a documented path an agent already
+// takes. One of those failures is recoverable by the reader and the other
+// is not.
+//
+// Raising this is reasonable once the threshold is pinned rather than
+// bracketed. It should not be raised on the strength of two lucky
+// deliveries.
 const maxContextBytes = 2000
 
 // maxInlineFormatted is the formatted body's own share of that budget. It

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -301,8 +301,13 @@ func fit(parts []part) string {
 
 	// A must-keep part is placed first whatever its position in the
 	// message, because the budget is not a reason to withhold a secret.
-	// Review computed the case: a 900-byte formatted body plus five
-	// doc-drift notes leaves 259 bytes, and a three-secret finding is 270.
+	// It competes under the same reserved limit as everything else:
+	// a keep part LARGER than the budget cannot be delivered whole and
+	// nothing truncates mid-part, so it is dropped and NAMED in the
+	// omission notice rather than silently lost — a silent drop is
+	// exactly the shape the notice exists to prevent. A part that
+	// merely does not fit beside larger ones is the ordinary case and
+	// is handled the same way.
 	var kept []string
 	used := 0
 	dropped := 0
@@ -325,7 +330,7 @@ func fit(parts []part) string {
 	limit := maxContextBytes - noticeReserve
 	for i := range parts {
 		if parts[i].keep {
-			take(i, maxContextBytes)
+			take(i, limit)
 		}
 	}
 	for i := range parts {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -45,11 +45,30 @@ type hookOutput struct {
 // hard wall.
 const stdinDeadline = 5 * time.Second
 
-// Formatted output larger than this is not injected into the agent's context —
-// a giant paste displaces the work the agent was doing. The agent is told the
-// file is unformatted and where to get the full result instead. The threshold
-// is generous: real source files the hook sees are almost always far below it.
-const maxInlineBytes = 48 * 1024
+// The host does not deliver an unbounded hook payload. Past roughly two
+// kilobytes it writes the output to a file and inlines only a PREVIEW of
+// the first 2KB, so anything after that reaches the agent as a path it has
+// to go and read — which nothing makes it do.
+//
+// That is worse than losing the tail. This hook's format part says "review
+// it and write it to the file", and a truncated formatted body under that
+// instruction is a file with its end cut off. It also silently drops
+// whatever comes after the format part, and a secret finding is one of the
+// things that comes after.
+//
+// Measured, not documented: two previews observed at exactly 2KB, one on
+// SessionStart stdout at 9.9KB of output and one on this hook's
+// additionalContext at 10.7KB. The threshold at which the host starts
+// persisting is NOT established — only that 2KB is what it inlines when it
+// does. So 2KB is treated as the whole budget, which is safe whatever the
+// persist threshold turns out to be.
+const maxContextBytes = 2000
+
+// maxInlineFormatted is the formatted body's own share of that budget. It
+// is the only part that can be arbitrarily large — a findings line is tens
+// of bytes and a file is not — so without a share of its own it starves
+// everything after it.
+const maxInlineFormatted = 900
 
 // askPart carries the questions no domain can answer for itself into the
 // place the coder actually reads. Without it these reach the coder as a
@@ -75,7 +94,7 @@ func askPart(root string) string {
 		limit = 5
 	}
 	for _, q := range pending[:limit] {
-		fmt.Fprintf(&b, "  - %s %s\n", q.Label(), q.Text)
+		fmt.Fprintf(&b, "  - %s %s\n", q.Label(), oneLine(q.Text, 160))
 	}
 	if len(pending) > limit {
 		fmt.Fprintf(&b, "  … and %d more\n", len(pending)-limit)
@@ -84,6 +103,20 @@ func askPart(root string) string {
 	b.WriteString("reads as a decision once it is written down. Put them to the user, write\n")
 	b.WriteString("their answers into the file, and record them with `procoder ask --file`.")
 	return b.String()
+}
+
+// oneLine flattens a question to a single line of at most n characters.
+//
+// The loop above was written as one line per question and was not: a
+// question derived from a decision record carries the whole record as its
+// text, blank lines and all, so five questions could run to eight
+// kilobytes and crowd every other finding out of the payload.
+func oneLine(s string, n int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
 }
 
 // Run handles one PostToolUse event end to end. It never returns an error to
@@ -122,7 +155,7 @@ func Run(stdin io.Reader, stdout io.Writer) int {
 		add(lintPart(root, p.ToolInput.FilePath))
 	}
 	add(askPart(root))
-	msg := strings.Join(parts, "\n\n")
+	msg := fit(parts)
 
 	if msg == "" {
 		return 0
@@ -213,6 +246,42 @@ func lintPart(root, file string) string {
 	return "procoder [lint]: findings in the file you just wrote — investigate, judge, and fix what is real:\n" + strings.Join(b, "\n")
 }
 
+// fit joins the parts the agent will actually receive, and says so when it
+// had to leave some out.
+//
+// Parts are added in the order they were built — which is deliberate and
+// documented at each call site — and the first one that does not fit ends
+// the message. Nothing is truncated mid-part: half a finding is a finding
+// whose meaning cannot be trusted, and half a formatted file is a file
+// somebody may write back.
+//
+// The notice is the point. A hook that quietly delivered four findings out
+// of seven would be the same silent-green this tool exists to remove.
+func fit(parts []string) string {
+	var kept []string
+	used := 0
+	dropped := 0
+	for _, p := range parts {
+		// +2 for the blank line between parts.
+		if used > 0 && used+len(p)+2 > maxContextBytes {
+			dropped++
+			continue
+		}
+		if used == 0 && len(p) > maxContextBytes {
+			dropped++
+			continue
+		}
+		kept = append(kept, p)
+		used += len(p) + 2
+	}
+	if dropped > 0 {
+		kept = append(kept, fmt.Sprintf(
+			"== %d further finding(s) NOT shown — the host delivers only the first %d bytes of a hook's output. Run `procoder check` to see all of them.",
+			dropped, maxContextBytes))
+	}
+	return strings.Join(kept, "\n\n")
+}
+
 // message turns a Result into what the agent is told. Clean and OutOfScope are
 // silent here — the write hook speaks only when there is something to act on;
 // the counting of skipped files is `procoder check`'s job, where a human reads
@@ -220,7 +289,7 @@ func lintPart(root, file string) string {
 func message(res format.Result) string {
 	switch res.Verdict {
 	case format.Unformatted:
-		if len(res.Formatted) > maxInlineBytes {
+		if len(res.Formatted) > maxInlineFormatted {
 			return fmt.Sprintf(
 				"procoder [format]: %s is not formatted (%s). The formatted result is %d bytes — too large to inline. Run `procoder format %q` to see it, then write it.",
 				res.File, res.Tool, len(res.Formatted), res.File)

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -234,7 +234,7 @@ func hookText(root string) string {
 	text, _ := Effective(root)
 	var b strings.Builder
 	b.WriteString(receiptNotice)
-	b.WriteString(strings.TrimRight(text, "\n"))
+	b.WriteString(strings.TrimRight(stripMarker(text), "\n"))
 	b.WriteString("\n\n" + status.Header + "\n")
 	for _, line := range status.Report(root) {
 		b.WriteString(line + "\n")
@@ -274,6 +274,29 @@ const endMarker = "== procoder principles end =="
 // and conclude it had the whole thing — a confident receipt for a delivery
 // that did not happen, which is the exact failure this is here to catch.
 // The marker is self-describing; the notice only has to say to look for it.
+// stripMarker removes the end marker from text the repository supplied.
+//
+// hookText writes an adopter's .procoder/PRINCIPLES.md verbatim, and that
+// file may legitimately quote the marker — pasted from procoder's own docs,
+// or from a document ABOUT procoder. A quoted marker inside the first 2KB
+// makes the receipt check return a confident pass on a truncated payload,
+// which is the one thing it exists to prevent. Found in review; the tests
+// only ever exercised the built-in default.
+func stripMarker(text string) string {
+	if !strings.Contains(text, endMarker) {
+		return text
+	}
+	lines := strings.Split(text, "\n")
+	out := lines[:0]
+	for _, l := range lines {
+		if strings.TrimSpace(l) == endMarker {
+			continue
+		}
+		out = append(out, strings.ReplaceAll(l, endMarker, "[end marker removed]"))
+	}
+	return strings.Join(out, "\n")
+}
+
 const receiptNotice = "RECEIPT CHECK — read this first. This message ends with a line marking its\n" +
 	"end, and that line says so in plain words. If the last thing you can see is\n" +
 	"not that end marker, your host inlined only a preview and wrote the rest to a\n" +
@@ -382,6 +405,12 @@ func Run(root string, out func(string)) int {
 	} else {
 		out("== engineering principles (procoder default — override with " + File + ")")
 	}
-	out(strings.TrimRight(text, "\n"))
+	out(strings.TrimRight(stripMarker(text), "\n"))
+	// The recovery route gets a receipt too. The hook's notice sends a
+	// reader here when its own payload was truncated, and this output is
+	// the same ten-kilobyte document — so without a marker the reader has
+	// no way to tell whether the SECOND read arrived whole either.
+	out("")
+	out(endMarker)
 	return 0
 }

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -246,13 +246,18 @@ func hookText(root string) string {
 // endMarker closes the payload, and the notice above it says what to do
 // when it does not arrive.
 //
-// The host does not deliver an unbounded SessionStart payload: past roughly
-// two kilobytes it writes the output to a file and inlines a preview of the
-// first 2KB. This text is ten. Measured in a real session — the reminder
-// read "Output too large (9.9KB). Full output saved to... Preview (first
-// 2KB)" and the principles stopped mid-sentence — so for every session
-// since this document reached that size, four fifths of it has been arriving
-// as a path nothing made anybody read.
+// The host does not deliver an unbounded SessionStart payload: past some
+// size it writes the output to a file and inlines a preview of the first
+// 2KB. This text is ten kilobytes. Measured in a real session — the
+// reminder read "Output too large (9.9KB). Full output saved to...
+// Preview (first 2KB)" and the principles stopped mid-sentence — so for
+// every session since this document reached that size, four fifths of it
+// has been arriving as a path nothing made anybody read.
+//
+// The threshold is bracketed, not pinned: 5.2KB and 7.3KB were delivered
+// whole, 9.9KB and 10.7KB were not. Which is why this is a receipt check
+// and not a size limit — the marker is true whatever the threshold is, and
+// stays true if it changes.
 //
 // Truncating the document to fit is the wrong fix: it is the repository's
 // own text, an adopter's `.procoder/PRINCIPLES.md` is whatever they wrote,

--- a/internal/principles/principles.go
+++ b/internal/principles/principles.go
@@ -233,13 +233,47 @@ func Effective(root string) (string, bool) {
 func hookText(root string) string {
 	text, _ := Effective(root)
 	var b strings.Builder
+	b.WriteString(receiptNotice)
 	b.WriteString(strings.TrimRight(text, "\n"))
 	b.WriteString("\n\n" + status.Header + "\n")
 	for _, line := range status.Report(root) {
 		b.WriteString(line + "\n")
 	}
+	b.WriteString("\n" + endMarker + "\n")
 	return b.String()
 }
+
+// endMarker closes the payload, and the notice above it says what to do
+// when it does not arrive.
+//
+// The host does not deliver an unbounded SessionStart payload: past roughly
+// two kilobytes it writes the output to a file and inlines a preview of the
+// first 2KB. This text is ten. Measured in a real session — the reminder
+// read "Output too large (9.9KB). Full output saved to... Preview (first
+// 2KB)" and the principles stopped mid-sentence — so for every session
+// since this document reached that size, four fifths of it has been arriving
+// as a path nothing made anybody read.
+//
+// Truncating the document to fit is the wrong fix: it is the repository's
+// own text, an adopter's `.procoder/PRINCIPLES.md` is whatever they wrote,
+// and deciding which of somebody's engineering rules to drop is not a
+// delivery concern. So the payload stays whole and becomes CHECKABLE
+// instead. procoder guarantees delivery to the boundary; the reader
+// verifies receipt, and the marker is how it can.
+const endMarker = "== procoder principles end =="
+
+// receiptNotice deliberately does NOT quote endMarker.
+//
+// A notice carrying the marker verbatim would appear in the PREVIEW as well,
+// so a reader searching for the marker would find it in a truncated payload
+// and conclude it had the whole thing — a confident receipt for a delivery
+// that did not happen, which is the exact failure this is here to catch.
+// The marker is self-describing; the notice only has to say to look for it.
+const receiptNotice = "RECEIPT CHECK — read this first. This message ends with a line marking its\n" +
+	"end, and that line says so in plain words. If the last thing you can see is\n" +
+	"not that end marker, your host inlined only a preview and wrote the rest to a\n" +
+	"file; the notice above this message names the path. Read that file now, before\n" +
+	"your first action — what is missing is the part that governs it.\n\n"
 
 // RunHook prints the principles in the shape the running host's
 // SessionStart hook expects: Claude Code reads raw stdout; Codex, Copilot,

--- a/internal/principles/receipt_test.go
+++ b/internal/principles/receipt_test.go
@@ -1,0 +1,62 @@
+package principles
+
+import (
+	"strings"
+	"testing"
+)
+
+// The host inlines only the first ~2KB of a SessionStart payload and writes
+// the rest to a file. These tests pin the two halves of the answer: the
+// check arrives inside that window, and the marker it names really is the
+// last thing in the payload.
+const observedInlineWindow = 2000
+
+// proved by: moving the notice below the principles text puts it past the
+// window, so the one instruction that explains the truncation is the part
+// that gets truncated.
+func TestTheReceiptCheckArrivesInsideTheInlinedWindow(t *testing.T) {
+	text := hookText(t.TempDir())
+
+	i := strings.Index(text, "RECEIPT CHECK")
+	if i < 0 {
+		t.Fatal("no receipt check in the payload")
+	}
+	end := strings.Index(text, endMarker)
+	if end < 0 {
+		t.Fatal("the notice names a marker the payload does not contain")
+	}
+	// The whole notice, marker included, has to land in the window.
+	if notice := strings.Index(text[i:], "\n\n"); notice < 0 || i+notice > observedInlineWindow {
+		t.Fatalf("the receipt check ends at byte %d, past the %d the host inlines",
+			i+notice, observedInlineWindow)
+	}
+}
+
+// proved by: appending anything after the marker makes it stop meaning "you
+// have the whole payload", which is the only thing it is for.
+func TestTheMarkerIsTheLastThingInThePayload(t *testing.T) {
+	text := strings.TrimRight(hookText(t.TempDir()), "\n")
+	if !strings.HasSuffix(text, endMarker) {
+		tail := text
+		if len(tail) > 200 {
+			tail = tail[len(tail)-200:]
+		}
+		t.Fatalf("the payload does not end with the marker it told the reader to look for:\n…%s", tail)
+	}
+	if strings.Count(text, endMarker) != 1 {
+		t.Fatal("the marker appears more than once, so seeing it proves nothing")
+	}
+}
+
+// proved by: a payload that fits needs no check, and one that does not fit
+// needs the check to be true — this asserts the situation the notice
+// describes is the situation that exists.
+func TestThePayloadIsBeyondTheWindowAndSaysSo(t *testing.T) {
+	text := hookText(t.TempDir())
+	if len(text) <= observedInlineWindow {
+		t.Skip("the payload now fits the window; the receipt check is harmless but no longer load-bearing")
+	}
+	if !strings.Contains(text[:observedInlineWindow], "Read that file") {
+		t.Fatal("the payload exceeds the window and the recovery instruction is not inside it")
+	}
+}

--- a/internal/principles/receipt_test.go
+++ b/internal/principles/receipt_test.go
@@ -23,6 +23,10 @@ func TestTheReceiptCheckArrivesInsideTheInlinedWindow(t *testing.T) {
 	if i < 0 {
 		t.Fatal("no receipt check in the payload")
 	}
+	if i >= observedInlineWindow {
+		t.Fatalf("the receipt check starts at byte %d, past the %d-byte inlined window — the check that explains the truncation would itself be truncated",
+			i, observedInlineWindow)
+	}
 	end := strings.Index(text, endMarker)
 	if end < 0 {
 		t.Fatal("the notice names a marker the payload does not contain")

--- a/internal/principles/receipt_test.go
+++ b/internal/principles/receipt_test.go
@@ -1,6 +1,8 @@
 package principles
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -24,11 +26,6 @@ func TestTheReceiptCheckArrivesInsideTheInlinedWindow(t *testing.T) {
 	end := strings.Index(text, endMarker)
 	if end < 0 {
 		t.Fatal("the notice names a marker the payload does not contain")
-	}
-	// The whole notice, marker included, has to land in the window.
-	if notice := strings.Index(text[i:], "\n\n"); notice < 0 || i+notice > observedInlineWindow {
-		t.Fatalf("the receipt check ends at byte %d, past the %d the host inlines",
-			i+notice, observedInlineWindow)
 	}
 }
 
@@ -58,5 +55,35 @@ func TestThePayloadIsBeyondTheWindowAndSaysSo(t *testing.T) {
 	}
 	if !strings.Contains(text[:observedInlineWindow], "Read that file") {
 		t.Fatal("the payload exceeds the window and the recovery instruction is not inside it")
+	}
+}
+
+// proved by: writing the repository's text verbatim lets an adopter's own
+// PRINCIPLES.md carry the marker — pasted from procoder's docs, or from a
+// document about procoder — into the first 2KB, so the receipt check passes
+// on a truncated payload. That is a confident receipt for a delivery that
+// did not happen, which is the one failure it exists to prevent.
+//
+// The marker is assembled at runtime rather than written as a literal, per
+// the repository's own rule about fixtures that trip its scanners.
+func TestAQuotedMarkerInTheRepositoryTextCannotSpoofTheCheck(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".procoder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	quoted := "== " + "procoder principles" + " end " + "=="
+	body := "# House rules\n\nSee the marker below, quoted from the docs:\n\n" +
+		quoted + "\n\nand inline " + quoted + " too.\n"
+	if err := os.WriteFile(filepath.Join(root, ".procoder", "PRINCIPLES.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	text := hookText(root)
+	if strings.Count(text, endMarker) != 1 {
+		t.Fatalf("the marker appears %d times, so seeing it proves nothing",
+			strings.Count(text, endMarker))
+	}
+	if !strings.HasSuffix(strings.TrimRight(text, "\n"), endMarker) {
+		t.Fatal("the surviving marker is not the one at the end")
 	}
 }

--- a/internal/store/golden_test.go
+++ b/internal/store/golden_test.go
@@ -162,11 +162,20 @@ var captures = map[string]func(root string) string{
 // proved by: any change to what these commands print, anywhere in the
 // twenty-five packages the seam touches, fails this with a diff.
 //
-// The goldens for status, principles-hook and handoff were captured from
-// c4bb353 — the commit before internal/store existed — so they assert that
-// moving every read and write behind the store changed nothing. The config
-// golden is captured from the new code, because task 4 changed that output
-// on purpose; it guards against drift from here, not against the seam.
+// The goldens for status and handoff were captured from c4bb353 — the commit
+// before internal/store existed — so they assert that moving every read and
+// write behind the store changed nothing.
+//
+// config and principles-hook are NOT parity goldens, and each stopped being
+// one for a stated reason. config gained the repo identity line on purpose.
+// principles-hook gained the receipt check and end marker on purpose, once
+// the host was measured inlining only the first 2KB of a 10KB payload — the
+// output HAD to change, because the old one was arriving four fifths missing
+// with nothing saying so. Both guard drift from here rather than parity with
+// before.
+//
+// Regenerating either of the remaining two is how a parity assertion stops
+// asserting anything. Do not.
 func TestMigrationOutputUnchanged(t *testing.T) {
 	if *update {
 		t.Skip("-update writes goldens; run TestUpdateGoldens instead")
@@ -201,7 +210,8 @@ func TestCapturesAreDeterministic(t *testing.T) {
 }
 
 // TestUpdateGoldens rewrites the golden files from the CURRENT code. It runs
-// only under -update and is how the config golden was made; the other three
+// only under -update and is how the config and principles-hook goldens were
+// made; the other two
 // were captured from the pre-store binary and must not be regenerated
 // casually, because regenerating them is exactly how a parity assertion
 // stops asserting anything.

--- a/internal/store/golden_test.go
+++ b/internal/store/golden_test.go
@@ -224,9 +224,24 @@ func TestUpdateGoldens(t *testing.T) {
 		t.Fatal(err)
 	}
 	for name, capture := range captures {
+		if parityGoldens[name] {
+			// Enforced, not asked for. A comment saying "do not" is the
+			// only thing that stood between -update and the two captures
+			// whose whole value is that they came from a binary built
+			// before internal/store existed — and this branch has just
+			// regenerated a third, which is exactly when the other two are
+			// most at risk.
+			t.Logf("skipped %s — it asserts parity with c4bb353 and must not be regenerated", name)
+			continue
+		}
 		if err := os.WriteFile(filepath.Join(dir, name+".txt"), []byte(capture(fixture(t))), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		t.Logf("wrote %s", name)
 	}
 }
+
+// parityGoldens are the captures taken from c4bb353, before internal/store
+// existed. Regenerating one is how a parity assertion stops asserting
+// anything, so -update refuses them.
+var parityGoldens = map[string]bool{"status": true, "handoff": true}

--- a/internal/store/testdata/golden/principles-hook.txt
+++ b/internal/store/testdata/golden/principles-hook.txt
@@ -1,3 +1,9 @@
+RECEIPT CHECK — read this first. This message ends with a line marking its
+end, and that line says so in plain words. If the last thing you can see is
+not that end marker, your host inlined only a preview and wrote the rest to a
+file; the notice above this message names the path. Read that file now, before
+your first action — what is missing is the part that governs it.
+
 # Engineering principles (Procoder)
 
 Build like a senior developer who has been paged at 3am for someone's
@@ -196,3 +202,5 @@ sprint: none — no backlog yet (`procoder backlog` starts one)
 open tasks: none
 unlearned lessons: none — no ledger at .procoder/github/LESSONS.md
 index: none — `procoder index build` has not run here
+
+== procoder principles end ==


### PR DESCRIPTION
## What

Both of procoder's context-delivering hooks emitted about 10KB into a
window the host inlines only 2KB of. The PostToolUse payload is now
budgeted; the SessionStart payload is left whole and made checkable.

Answers the decision recorded in #265.

## Why

The host does not deliver unbounded hook output. Past roughly two
kilobytes Claude Code writes the output to a file and inlines only a
preview of the first 2KB — the remainder arrives as a path that nothing
makes anybody read.

Measured, not assumed, and **bracketed rather than pinned**:

| Payload | Outcome |
|---|---|
| 5.2 KB (PostToolUse) | delivered whole |
| 7.3 KB (PostToolUse) | delivered whole |
| 9.9 KB (SessionStart, 10,281 B emitted) | persisted, first 2 KB inlined |
| 10.7 KB (PostToolUse, 10,957 B emitted) | persisted, first 2 KB inlined |

So 2KB is the **preview size, not the threshold** — the host tolerates
several times that. My first pass at this got it wrong in both source
comments and `b9ece19` corrects them.

The first was observed live: a session's own reminder read *"Output too
large (9.9KB). Full output saved to… Preview (first 2KB)"* and the
principles stopped mid-sentence inside the mutation-testing paragraph. So
for every session since that document reached its current size, four
fifths of the rules governing the work have not been arriving.

The budget is set to the preview size anyway, and the asymmetry is the
reason. Guessing high fails **silently**: a payload over the real threshold
loses everything past 2KB with nothing saying so, and the tail is where the
findings are. Guessing low costs only that a large formatted body arrives as
the command that prints it — a documented path an agent already takes. One
of those failures is recoverable by the reader and the other is not.

Credit for the behaviour goes to the kload plugin
(github.com/nightlionsec/kload), which hit the same cap from the other
side and named the failure shape: silent, order-dependent loss with a
confident receipt on top.

## How

### The write hook — three defects, one root cause

Nothing budgeted what the hook emitted.

- **`maxInlineBytes` was 48KB**, twenty-four times the window. A formatted
  body over it arrived cut off **under the instruction "review it and
  write it to the file"**. An agent obeying that writes a file with its
  end missing, so this was a data-loss path and not merely a delivery gap.
- **Parts were joined with no cap**, so whatever came last was dropped in
  silence. Secret findings come after the format part.
- **`askPart` claimed one line per question and delivered whole records.**
  A question derived from a decision carries the entire record as its
  text, so five of them ran to 8.6 KB in this repository and crowded
  everything else out of *every single write*.

Now: one budget for the payload, a bounded share for the formatted body
(the only part that can be arbitrarily large), and questions flattened to
the one line the code always claimed. A part that does not fit is
**dropped, never truncated** — half a finding is a finding whose meaning
cannot be trusted — and the count of what was dropped is in the output,
naming `procoder check` as the way to see all of it.

Measured on the same probe: **10,957 bytes before, 775 after.**

### The principles hook — checkable, not shortened

Truncating the document to fit would be the wrong fix. It is the
repository's own text, an adopter's `.procoder/PRINCIPLES.md` is whatever
they wrote, and choosing which of somebody's engineering rules to drop is
not a delivery concern.

So the payload stays whole and becomes verifiable: a receipt check first,
inside the window that is always inlined, and an end marker last. A reader
that cannot see the marker knows it holds a preview, and the host's own
notice names the file with the rest. procoder guarantees delivery to the
boundary; the reader verifies receipt.

**The notice deliberately does not quote the marker, and a test enforces
it.** A notice carrying it verbatim would appear in the preview too, so a
reader searching for the marker would find it in a truncated payload and
conclude it had everything — a confident receipt for a delivery that did
not happen, which is the exact failure this exists to catch. That flaw was
in the first version; the test found it.

## Testing

`go test ./...` green. `procoder check` clean, 0 blocking. `procoder git`
exits 0.

Five mutations, each with a snapshot taken immediately before and restored
immediately after. **Three of them were duds on the first attempt, and all
three looked like passes** — worth recording, because a mutation that
silently changes nothing is indistinguishable from a test doing its job:

- Replacing `fit(parts)` with the old `strings.Join` at the call site left
  the unit test of `fit` green, because it tests `fit` directly. `fit` was
  correct, tested, and unused. Fixed by an end-to-end test on `Run`.
- That end-to-end fixture then landed *under* budget on its own, so it
  passed whether `Run` called `fit` or not. It is now tuned to overflow
  deliberately and fails loudly if it ever stops.
- Dropping the question flattening did not make the payload oversized
  either — `fit` simply discards the whole ask queue instead. What is lost
  is the questions, so that test asserts they **survive**, not that the
  payload is small.

### What the pre-PR review found

A fresh-context reviewer returned **2 Critical, 4 Important, 5 Minor**, and
both Criticals were the fix failing at the thing it was written to do.

**The notice was not inside the budget.** It was appended after the loop
with nothing reserved, so `fit` returned 2,144 bytes against a 2,000-byte
constant — putting the explanation of the truncation in the part that gets
truncated. Reserved now, and the `+200` slack in two tests that admitted it
is gone.

**A formatted body could starve the secret scan** — see the ordering note
below.

The four Important: `oneLine` sliced a byte index, so this repository's
em-dashes produced invalid UTF-8 and `json.Marshal` replaced it with U+FFFD,
delivering a question as mojibake. `fit`'s comment said the first part that
does not fit ends the message while the code skipped on, so the notice's
word "further" told an agent the wrong thing about which finding it was
missing. **The end marker was spoofable** — `hookText` writes an adopter's
`PRINCIPLES.md` verbatim and that file may legitimately quote the marker,
which would make the receipt check pass on a truncated payload. And
`procoder principles`, where the notice sends a reader whose payload was
cut, had no marker of its own, so the recovery read was as unverifiable as
what it recovered from.

Minors taken: `-update` now **refuses** to regenerate the two parity
goldens rather than a comment asking it not to; `TestFitNeverTruncatesAPart`
gained the positive half without which it passed on an empty return; and the
ask test no longer skips when gofmt is absent, so a machine without it still
exercises `Run` against the budget.

One finding was stale on arrival — the docs were uncommitted when the review
started and landed in `b9ece19` while it ran. Verified rather than re-fixed.
Its other half was real and is fixed.

### The golden that had to move

`principles-hook.txt` was one of three goldens captured from `c4bb353` to
assert that the state seam changed nothing. This change alters that output
on purpose, so it was regenerated and now guards drift from here rather
than parity with before — the same status `config.txt` already had. The
doc comment records which two still assert parity, and that regenerating
those is how a parity assertion stops asserting anything.

## Notes for the reviewer

**Start at `fit()` in `internal/hook/hook.go`.** It is the whole mechanism
and the arithmetic is the part to distrust.

**Then the receipt check in `internal/principles/principles.go`** — the
question worth asking is whether it can be spoofed by a payload truncated
at exactly the wrong place.

### Deliberate, and open to being overruled

- **Display order is unchanged; delivery order is not.** Parts are still
  built format → workflow → drift → secrets → lint → ask, but the secret
  scan is now must-keep and is placed before the budget is spent on
  anything else. The review computed the case that forced it: a 900-byte
  formatted body plus five doc-drift notes leaves 259 bytes, and a
  three-secret finding is 270. Everything else still competes in build
  order.
- **The budget is set to the preview size, not the measured threshold.**
  Deliveries of 5.2KB and 7.3KB arrived whole; 9.9KB and 10.7KB did not.
  Raising it is reasonable once that is pinned rather than bracketed — it
  should not be raised on two lucky deliveries, because guessing high
  fails silently and the tail is where the findings are.
- **`.procoder/ask/decisions.md` is not in this branch.** #265 owns that
  record. This branch owns the fix, so the two cannot conflict.

### Docs impact

`procoder config` output is unchanged, but two things a reader is told
were now false. `docs/architecture.md` said the write hook includes the
fixed content when a file is unformatted — now conditional on fitting the
budget — and its write-hook section gains the budget and the
drop-never-truncate rule. `docs/lifecycle.md` gains the receipt check at
session start, since every session now opens with it.
