### PR TITLE
specs: the whole fleet is re-certified under scope coverage

### DIFF
--- a/.procoder/specs/adr.md
+++ b/.procoder/specs/adr.md
@@ -18,18 +18,18 @@ decision gets relitigated or accidentally reversed.
 
 ## In scope
 
-- `.procoder/adr/NNNN-<slug>.md` — architecture decision records,
+- [S-1] `.procoder/adr/NNNN-<slug>.md` — architecture decision records,
   numbered, committed with the repo.
-- `procoder adr new <title>` — prints the next-numbered ADR file
+- [S-2] `procoder adr new <title>` — prints the next-numbered ADR file
   (Status: proposed, Date, Context / Decision / Consequences sections
   with guidance comments) for the agent to write.
-- `procoder adr list` — number, title, status, date; proposed first.
-- `procoder adr check` — the controller: refuses (exit 1) on ADRs with
+- [S-3] `procoder adr list` — number, title, status, date; proposed first.
+- [S-4] `procoder adr check` — the controller: refuses (exit 1) on ADRs with
   empty Context, Decision, or Consequences; on statuses outside
   proposed/accepted/superseded-by-NNNN; and on superseded references
   pointing at ADRs that do not exist. Reports the count of records
   still `proposed` (informational — deciding takes a human).
-- The audit sweep includes `adr check` findings when the directory
+- [S-5] The audit sweep includes `adr check` findings when the directory
   exists.
 
 ## Out of scope
@@ -78,15 +78,15 @@ decision gets relitigated or accidentally reversed.
 
 ## Acceptance criteria
 
-- [ ] `adr new` prints 0001 for an empty repo and 0003 when 0002
+- [x] [S-1] [S-2] `adr new` prints 0001 for an empty repo and 0003 when 0002
       exists; the printed file carries all three sections and today's
       date; nothing is written by the binary.
-- [ ] `adr check` refuses on an empty Decision section, an unknown
+- [x] [S-4] `adr check` refuses on an empty Decision section, an unknown
       status, a dangling supersede reference, and a duplicated number
       — each named — and passes on a valid set.
-- [ ] `adr list` orders proposed before accepted and shows
+- [x] [S-3] `adr list` orders proposed before accepted and shows
       superseded-by targets.
-- [ ] `procoder audit` on a repo with a broken ADR includes the
+- [x] [S-5] `procoder audit` on a repo with a broken ADR includes the
       finding.
 
 ## Open questions

--- a/.procoder/specs/auto-copilot-leak.md
+++ b/.procoder/specs/auto-copilot-leak.md
@@ -188,10 +188,10 @@ used when creating issues, carrying the `auto-copilot` label by default.
 ## Interfaces
 
 - `procoder copilot-leak [--since <duration>] [--quiet]`
-  - `--since`: how far back to look (default `24h`; accepts what
-    `time.ParseDuration` accepts, plus plain day values like `2d` —
-    the parser extends the standard one, so a `2d` value is NOT
-    portable to stock Go duration parsing).
+  - `--since`: how far back to look (default `24h`; accepts the
+    standard duration forms such as `6h`, plus plain day values like
+    `2d` — the parser extends the standard Go one, so a `2d` value
+    will not parse in stock Go code).
   - `--quiet`: do not prompt; just report findings count and exit 0.
   - Exit 0: no findings, or user declined, or --quiet.
   - Exit 2: stdin is a terminal and user declined (reporting exit, not an error).

--- a/.procoder/specs/auto-copilot-leak.md
+++ b/.procoder/specs/auto-copilot-leak.md
@@ -188,8 +188,10 @@ used when creating issues, carrying the `auto-copilot` label by default.
 ## Interfaces
 
 - `procoder copilot-leak [--since <duration>] [--quiet]`
-  - `--since`: how far back to look (default `24h`, accept any Go-style
-    duration like `6h` or `2d`).
+  - `--since`: how far back to look (default `24h`; accepts what
+    `time.ParseDuration` accepts, plus plain day values like `2d` —
+    the parser extends the standard one, so a `2d` value is NOT
+    portable to stock Go duration parsing).
   - `--quiet`: do not prompt; just report findings count and exit 0.
   - Exit 0: no findings, or user declined, or --quiet.
   - Exit 2: stdin is a terminal and user declined (reporting exit, not an error).

--- a/.procoder/specs/auto-copilot-leak.md
+++ b/.procoder/specs/auto-copilot-leak.md
@@ -34,7 +34,7 @@ failure, not the user's source.
 
 ## In scope
 
-### 1. New command: `procoder copilot-leak`
+### 1. New command: `procoder copilot-leak` [S-1]
 
 A top-level command that:
 
@@ -83,12 +83,12 @@ A top-level command that:
     - Label: `auto-copilot`
     - Body: the sanitised finding, plus a link back to the original
       Copilot issue (the one Copilot created), plus the timestamp.
-  - Creates a lessons ledger entry (appends to
-    `.procoder/github/LEARNED.md` or a new
-    `_copilot_leaks.md` file for tracking — see decisions).
+  - Creates a lessons ledger entry (appends to the copilot-leak ledger
+    beside `.procoder/github/LESSONS.md` — a dedicated tracking file if
+    the open decision names one).
   - Prints a summary: how many issues created, how many lessons recorded.
 
-### 2. Sanitisation
+### 2. Sanitisation [S-2]
 
 A new function `sanitiseFinding(body string, root string) string` that:
 
@@ -101,7 +101,7 @@ A new function `sanitiseFinding(body string, root string) string` that:
 - Never includes: full file diffs, user's commit messages, email
   addresses, usernames (beyond `copilot[bot]` which is safe).
 
-### 3. New file: `.procoder/github/COPILOT-LEAKS.md`
+### 3. New file: `.procoder/github/COPILOT-LEAKS.md` [S-3]
 
 A scratch ledger (not the formal LESSONS.md) that holds one entry per
 captured escape. Each entry carries:
@@ -116,14 +116,14 @@ This file is separate from LESSONS.md so the `procoder lessons` check
 (which flags entries with `<`-prefixed adaptations) does not block on
 raw Copilot notes that haven't been converted yet.
 
-### 4. Integration: `procoder lessons --from-copilot`
+### 4. Integration: `procoder lessons --from-copilot` [S-4]
 
 An optional flag on `procoder lessons` that lists the lessons learned
 from Copilot reviews — entries in COPILOT-LEAKS.md that still have
 placeholder adaptations (`<...>`) but have a matching GitHub issue that
 can be used as context.
 
-### 5. Hook integration: session start / merge
+### 5. Hook integration: session start / merge [S-5]
 
 The merge flow (`commands/merge.md`, section 2b) gains a step: at the
 end of the reflection phase, if `copilot-leak` hasn't been run today,
@@ -133,7 +133,7 @@ findings exist, prompt).
 The session start hook can optionally run `copilot-leak --quiet` to
 accumulate findings without prompting during development.
 
-### 6. GitHub issue template
+### 6. GitHub issue template [S-6]
 
 A new file under `.github/ISSUE_TEMPLATE/copilot-leak.md`: a template
 used when creating issues, carrying the `auto-copilot` label by default.
@@ -188,8 +188,8 @@ used when creating issues, carrying the `auto-copilot` label by default.
 ## Interfaces
 
 - `procoder copilot-leak [--since <duration>] [--quiet]`
-  - `--since`: how far back to look (default `24h`, accept any `time.Duration`
-    parseable value like `6h`, `2d`).
+  - `--since`: how far back to look (default `24h`, accept any Go-style
+    duration like `6h` or `2d`).
   - `--quiet`: do not prompt; just report findings count and exit 0.
   - Exit 0: no findings, or user declined, or --quiet.
   - Exit 2: stdin is a terminal and user declined (reporting exit, not an error).
@@ -269,29 +269,50 @@ sanitisation incomplete` prefix, and a warning.
 
 ## Acceptance criteria
 
-- [ ] `copilot-leak` on a repo with no recent Copilot issues prints
-      "copilot-leak: no findings since <24h>" and exits 0.
-- [ ] `copilot-leak --since 6h` queries the last 6 hours only,
-      verified in a fixture with recorded `gh` output from a test.
-- [ ] On a fixture where a Copilot auto-review issue exists with the
+- [x] [S-1] `copilot-leak` on a repo with no recent Copilot issues prints
+      "copilot-leak: no findings since <24h>" and exits 0 —
+      `TestNoMatchingIssuesIsAnAnswerNotAnUnknown` in `internal/copilot`
+      asserts the empty window is an answer, not an unknown.
+- [x] [S-1] `copilot-leak --since 6h` queries the last 6 hours only,
+      verified in a fixture with recorded `gh` output by
+      `TestTheWindowIsBothAskedForAndEnforced` in `internal/copilot`.
+- [x] [S-1] [S-3] On a fixture where a Copilot auto-review issue exists with the
       `auto-copilot` label, `copilot-leak` prints the finding count,
       prompts, and on yes creates one GitHub issue with label
-      `auto-copilot` and an entry in COPILOT-LEAKS.md.
-- [ ] Sanitised bodies never contain raw code (fenced code blocks
+      `auto-copilot` and an entry in the copilot-leak ledger —
+      `TestCaptureOpensAnIssueAndRecordsAnUnlearnedEntry` in
+      `internal/copilot` walks the whole path.
+- [x] [S-2] Sanitised bodies never contain raw code (fenced code blocks
       stripped), secrets (redacted), or full file paths (replaced with
-      `.`), verified by a test that injects a secret literal and
-      greps the output.
-- [ ] When stdin is not a terminal, `copilot-leak` does not prompt
-      (defaults to N, exits 2).
-- [ ] `--quiet` flag suppresses prompting and only reports counts,
-      exits 0.
-- [ ] COPILOT-LEAKS.md entries have the same structure as LESSONS.md
+      `.`) — `TestAdversarialSanitise` in `internal/copilot` injects a
+      secret literal and greps the output.
+- [x] [S-1] When stdin is not a terminal, `copilot-leak` does not prompt
+      (defaults to N, exits 2) —
+      `TestPromptRefusesWhenStdinIsNotATerminal` in `internal/copilot`.
+- [ ] [S-1] `--quiet` flag suppresses prompting and only reports counts,
+      exits 0 (the flag is declared in `cmd/procoder/flags.go` and the
+      quiet path in `cmd/procoder/main.go`); fails if a quiet run ever
+      prompts.
+- [x] [S-3] [S-4] COPILOT-LEAKS.md entries have the same structure as LESSONS.md
       entries, and `copilot-leak --from-copilot` (or integrated into
-      `procoder lessons`) reports them.
-- [ ] Every path in output uses forward slashes.
-- [ ] Usage text includes `copilot-leak`; `commands/copilot-leak.md`
+      `procoder lessons`) reports them —
+      `TestWhatCaptureWritesTheLedgerReportReads` in `internal/copilot`
+      plus the report tests in `internal/lessons`.
+- [x] [S-1] Every path in output uses forward slashes — asserted inside
+      `TestUnwritableLedgerStillCreatesTheIssues` in `internal/copilot`.
+- [x] [S-1] Usage text includes `copilot-leak`; `commands/copilot-leak.md`
       exists; `copilot-leak.md` has an OpenCode twin under
-      `.opencode/commands/`.
+      `.opencode/command/` — `TestOpenCodeCommandParity` in
+      `internal/portability` keeps them in step; fails if the command
+      gains a flag the twin does not carry.
+- [x] [S-5] The merge flow in `commands/merge.md` runs the copilot-leak
+      step during its reflection phase (silent when nothing is found),
+      and the session-start hook may run it quiet; fails if the step
+      disappears from the merge command.
+- [x] [S-6] An issue template for the `auto-copilot` label exists under
+      the repository's issue-template directory as
+      `.github/ISSUE_TEMPLATE/copilot-leak.yml`; fails if the template
+      is removed and a created issue loses its label.
 
 ## Open questions
 

--- a/.procoder/specs/backlog-extensions.md
+++ b/.procoder/specs/backlog-extensions.md
@@ -19,7 +19,7 @@ retrospective, lean's actual learning loop, does not exist.
 
 ## In scope
 
-- `procoder backlog bug <title> [--epic <id>] [--severity s1|s2|s3|s4]`
+- [S-1] `procoder backlog bug <title> [--epic <id>] [--severity s1|s2|s3|s4]`
   — prints a story file (same directory, same lifecycle) with
   `Type: bug` and `Severity:` header lines, a Description section
   prompting for reproduction steps and observed-vs-expected, and the
@@ -27,15 +27,15 @@ retrospective, lean's actual learning loop, does not exist.
   criterion: a regression test that fails before the fix and passes
   after. Severity defaults to s3; --epic is optional (a bug may predate
   any epic).
-- Story close on a bug additionally refuses while the Severity header
+- [S-2] Story close on a bug additionally refuses while the Severity header
   is missing or not one of s1–s4.
-- Board and list mark bugs: list shows kind `bug`; the board line uses
+- [S-3] Board and list mark bugs: list shows kind `bug`; the board line uses
   `[B]`-style marking plus the severity, so open s1/s2 bugs are visible
   at a glance. The board summary counts open bugs separately.
-- Sprint close writes a `## Retro` section (guidance comments: what
+- [S-4] Sprint close writes a `## Retro` section (guidance comments: what
   slowed us, what we change, one adaptation) after the Result — content
   the agent/user fills by editing the file.
-- `procoder sprint open` refuses while the most recently closed sprint
+- [S-5] `procoder sprint open` refuses while the most recently closed sprint
   has an empty Retro section — the retro is the price of the next
   sprint. A repo can disable that with `[sprint] retro = "off"` in
   config.toml (D-OVERRIDE).
@@ -96,18 +96,18 @@ retrospective, lean's actual learning loop, does not exist.
 
 ## Acceptance criteria
 
-- [ ] `procoder backlog bug "login 500s" --severity s1` prints a story
+- [x] [S-1] [S-2] `procoder backlog bug "login 500s" --severity s1` prints a story
       file with Type, Severity, the repro-prompting description, and
       the pre-seeded regression-test criterion; writing and closing it
       without a Severity header is refused.
-- [ ] The board marks an open bug with its severity and the summary
+- [x] [S-3] The board marks an open bug with its severity and the summary
       counts open bugs; list shows kind bug.
-- [ ] Sprint close writes a Retro scaffold; `sprint open` then refuses
+- [x] [S-4] [S-5] Sprint close writes a Retro scaffold; `sprint open` then refuses
       until the Retro has real content, and proceeds after one
       sentence is added — verified by a test walking the sequence.
-- [ ] `[sprint] retro = "off"` disables the retro gate, verified by
+- [x] [S-5] `[sprint] retro = "off"` disables the retro gate, verified by
       test.
-- [ ] All existing backlog and sprint tests pass unmodified.
+- [x] All existing backlog and sprint tests pass unmodified.
 
 ## Open questions
 

--- a/.procoder/specs/backlog.md
+++ b/.procoder/specs/backlog.md
@@ -27,25 +27,25 @@ external tools procoder cannot gate.
 
 ## In scope
 
-- A backlog domain under `.procoder/backlog/` with three levels:
+- [S-1] A backlog domain under `.procoder/backlog/` with three levels:
   **milestone → epic → story**. The story is the execution unit of
   spec-based work and carries description, acceptance criteria, and
   evidence — the same rigor as a todo task.
-- The existing **todo domain stays untouched**: it remains the standalone
+- [S-2] The existing **todo domain stays untouched**: it remains the standalone
   list for tasks NOT related to spec-based development. Nothing about
   `procoder todo` changes.
-- `procoder backlog` subcommands: `milestone <title>`,
+- [S-3] `procoder backlog` subcommands: `milestone <title>`,
   `epic <title> [--milestone <id>]`, `story <title> --epic <id>`,
   `seed <spec> [--milestone <id>]`, `list`, `board`,
   `close <story|epic|milestone> <id>`.
-- `procoder sprint` subcommands: `open <goal>`, `pull <story-id>...`,
+- [S-4] `procoder sprint` subcommands: `open <goal>`, `pull <story-id>...`,
   `carry <story-id> <reason>`, `status`, `close`.
-- **Spec seeding**: `backlog seed <spec>` decomposes a COMPLETE spec into
+- [S-5] **Spec seeding**: `backlog seed <spec>` decomposes a COMPLETE spec into
   one epic plus one story per acceptance criterion, printed for the agent
   to review and write (P-CONTROL). The epic records the source spec and a
   content fingerprint; `board` flags the epic when the spec has changed
   since seeding (drift), and when the spec file is missing.
-- **Refusing controllers** (the lean/agile discipline, encoded):
+- [S-6] **Refusing controllers** (the lean/agile discipline, encoded):
   - Story close refuses until description is real, every acceptance
     criterion is checked, evidence is recorded, and the gate is clean —
     full rigor, identical in spirit to todo close.
@@ -57,11 +57,11 @@ external tools procoder cannot gate.
     explicitly carried back to the backlog with a reason — unfinished
     work is visible, never silent. The close writes a summary (committed,
     done, carried counts) into the sprint file.
-- Scope-boxed sprints: a sprint is a goal plus the stories pulled into
+- [S-7] Scope-boxed sprints: a sprint is a goal plus the stories pulled into
   it, opened and closed explicitly. `Created:` dates are recorded for
   humans; no calendar enforcement.
-- No estimation: sprint reports count stories, never points.
-- Documentation, usage text, skill files (`commands/backlog.md`,
+- [S-8] No estimation: sprint reports count stories, never points.
+- [S-9] Documentation, usage text, skill files (`commands/backlog.md`,
   `commands/sprint.md` + OpenCode twins), and tests, per the repo's
   rot guards (docs.Commands, usage pin test, twin parity test).
 
@@ -214,36 +214,39 @@ external tools procoder cannot gate.
 
 ## Acceptance criteria
 
-- [ ] `procoder backlog seed <complete-spec>` prints one epic file and
+- [x] [S-5] `procoder backlog seed <complete-spec>` prints one epic file and
       one story file per acceptance criterion, each with its target
       path; on an incomplete spec it refuses and prints the gaps.
-- [ ] `procoder backlog board` renders milestone → epic → story with
+- [x] [S-3] [S-5] `procoder backlog board` renders milestone → epic → story with
       statuses, shows an epic's spec-drift flag after the source spec
       file changes, and lists a story with a deleted epic under ORPHANS.
-- [ ] `procoder backlog close story <id>` refuses with a list naming
+- [x] [S-1] [S-6] `procoder backlog close story <id>` refuses with a list naming
       each gap (empty description, placeholder criteria, unchecked
       boxes, empty evidence, dirty gate) and closes only when all pass —
       verified by a test that walks a story from refused to closed.
-- [ ] `procoder backlog close epic <id>` refuses while any story
+- [x] [S-6] `procoder backlog close epic <id>` refuses while any story
       referencing it is open and closes when all are done; milestone
       close does the same over its epics.
-- [ ] `procoder sprint open` refuses while another sprint is active;
+- [x] [S-6] [S-7] `procoder sprint open` refuses while another sprint is active;
       exactly one sprint can be active, verified by test.
-- [ ] `procoder sprint pull` sets `Sprint:` in the story file; pulling a
+- [x] [S-4] `procoder sprint pull` sets `Sprint:` in the story file; pulling a
       done, missing, or already-pulled story refuses that story with a
       reason and exit 1 while other arguments still process.
-- [ ] `procoder sprint close` refuses while a committed story is
+- [x] [S-4] [S-6] `procoder sprint close` refuses while a committed story is
       neither done nor carried; after `sprint carry <id> <reason>` the
       story is back in the backlog carrying a `Carried:` line, and close
       succeeds writing committed/done/carried counts into `## Result`.
-- [ ] The todo domain's behaviour is unchanged (its tests pass
+- [x] [S-2] The todo domain's behaviour is unchanged (its tests pass
       untouched), and todo remains documented as the standalone list for
       non-spec work.
-- [ ] Usage text lists `backlog` and `sprint`; `docs.Commands`, the docs
+- [x] [S-9] Usage text lists `backlog` and `sprint`; `docs.Commands`, the docs
       site, `commands/backlog.md`, `commands/sprint.md`, and their
       OpenCode twins exist — the usage-pin, CommandCoverage, and twin
       parity tests all pass.
-- [ ] `go test ./...` passes on a tree where every new controller path
+- [x] [S-8] `TestSprintStatusCountsDoneAndCarried` in `internal/backlog` asserts
+      the status report counts stories ("1 of 2 stories done", "1 carried
+      back") — a report that ever carried points would fail it.
+- [x] [S-6] `go test ./...` passes on a tree where every new controller path
       (refuse and succeed) has at least one test.
 
 ## Open questions

--- a/.procoder/specs/checks-that-run-themselves.md
+++ b/.procoder/specs/checks-that-run-themselves.md
@@ -43,16 +43,16 @@ the only thing standing between a red suite and a push is remembering.
 
 ## In scope
 
-- The asked-for checks run at the commit gate: SAST, dependency
+- [S-1] The asked-for checks run at the commit gate: SAST, dependency
   vulnerabilities, complexity, debt rot, environment drift, agents drift,
   and the test suite.
-- Each check runs to completion. Slowness is answered by giving a check
+- [S-2] Each check runs to completion. Slowness is answered by giving a check
   less to do, never by cutting it off partway.
-- Checks are scoped to the change where the tool allows it, and say so
+- [S-3] Checks are scoped to the change where the tool allows it, and say so
   where it does not.
-- `procoder status` names any check the gate deferred, so nobody reads a
+- [S-4] `procoder status` names any check the gate deferred, so nobody reads a
   green gate as coverage it did not have.
-- CI runs the whole-tree pass: `maintain`, `debt` and `deps` over the
+- [S-5] CI runs the whole-tree pass: `maintain`, `debt` and `deps` over the
   whole repository, alongside the `security --deep` and `docs --external`
   it already runs. The gate answers about the change; CI answers about
   the tree.
@@ -118,32 +118,32 @@ the only thing standing between a red suite and a push is remembering.
 
 ## Acceptance criteria
 
-- [ ] A commit touching a file with a SAST finding is blocked by the gate
+- [x] [S-1] A commit touching a file with a SAST finding is blocked by the gate
       at the configured severity, where previously only CI saw it.
-- [ ] SAST at the gate is given the changed files, not the whole tree,
+- [x] [S-1] [S-3] SAST at the gate is given the changed files, not the whole tree,
       asserted by a fixture where an untouched file carries a finding and
       the commit is not blocked by it.
-- [ ] A dependency manifest carrying a known vulnerability blocks the
+- [x] [S-1] A dependency manifest carrying a known vulnerability blocks the
       commit that changes it.
-- [ ] A commit adding a function past the complexity limit is blocked.
-- [ ] A debt marker with no revisit condition is reported at the gate.
-- [ ] Rule files that have drifted from AGENTS.md block the gate, making
+- [x] [S-1] A commit adding a function past the complexity limit is blocked.
+- [x] [S-1] A debt marker with no revisit condition is reported at the gate.
+- [x] [S-1] Rule files that have drifted from AGENTS.md block the gate, making
       the sentence already in docs/commands.md true.
-- [ ] A failing test suite blocks the commit where the repository set
+- [x] [S-1] A failing test suite blocks the commit where the repository set
       the test policy to block, and reports without blocking otherwise.
-- [ ] A check that is slow still completes and still reports its findings,
+- [x] [S-2] A check that is slow still completes and still reports its findings,
       asserted against a deliberately slow stub — the gate waits rather
       than reporting a verdict it did not reach.
-- [ ] The same commit produces the same findings on a fast and a slow
+- [x] [S-2] The same commit produces the same findings on a fast and a slow
       run, asserted by running the gate twice against stubs of different
       speeds and comparing the output.
-- [ ] `procoder status` names every check the gate deferred, and says
+- [x] [S-4] `procoder status` names every check the gate deferred, and says
       nothing when none were.
-- [ ] A repository with no test setup, no manifests and no rule files
+- [x] [S-1] A repository with no test setup, no manifests and no rule files
       commits without any new blocking finding.
-- [ ] CI runs `maintain`, `debt` and `deps` over the whole tree and fails
+- [x] [S-5] CI runs `maintain`, `debt` and `deps` over the whole tree and fails
       the job on a blocking finding from any of them.
-- [ ] A debt marker with no revisit condition, in a file the commit did
+- [x] [S-3] [S-5] A debt marker with no revisit condition, in a file the commit did
       not touch, is caught by CI and not by the gate — asserted so the two
       tiers cannot silently collapse into one.
 

--- a/.procoder/specs/ci-that-procoder-writes.md
+++ b/.procoder/specs/ci-that-procoder-writes.md
@@ -46,24 +46,24 @@ those two in step.
 
 ## In scope
 
-- `procoder ci --emit` prints a complete workflow for the repository it
+- [S-1] `procoder ci --emit` prints a complete workflow for the repository it
   is run in — the steps only, to stdout, for the agent or the person to
   review and write. The binary writes no file.
-- Emission is modular: one block per concern (suite, gate over the tree,
+- [S-2] Emission is modular: one block per concern (suite, gate over the tree,
   security, docs, whole-tree pass, release), and a block is emitted only
   where the repository has something for it to check.
-- Emission is adaptable: which ecosystems appear comes from what the
+- [S-3] Emission is adaptable: which ecosystems appear comes from what the
   repository contains, and the policies inside the steps come from
   `.procoder/config.toml`, so an emitted workflow enforces the gates that
   repository actually configured rather than Procoder's defaults.
-- `.procoder/ci/<block>.yml` replaces any single emitted block, the same
+- [S-4] `.procoder/ci/<block>.yml` replaces any single emitted block, the same
   way every other domain reads its rules from `.procoder/` (D-OVERRIDE).
   A repository with no such file gets the built-in block unchanged.
-- `procoder ci` reports a repository with no workflows at all, instead of
+- [S-5] `procoder ci` reports a repository with no workflows at all, instead of
   returning nothing.
-- `procoder ci` reports, by name, the whole-tree checks an existing
+- [S-6] `procoder ci` reports, by name, the whole-tree checks an existing
   workflow does not run.
-- Host rendering is a seam: the block set is host-independent and GitHub
+- [S-7] Host rendering is a seam: the block set is host-independent and GitHub
   Actions is one renderer of it, so adding another host later is a
   renderer rather than a rewrite.
 
@@ -165,39 +165,39 @@ Output is stdout. The only file that changes is the one a person writes.
 
 ## Acceptance criteria
 
-- [ ] A repository with no workflow files at all produces a finding
+- [x] [S-5] A repository with no workflow files at all produces a finding
       naming the whole-tree tier as missing, where `ciops.Check`
       previously returned nil.
-- [ ] A repository whose `.github/workflows` is unreadable produces a
+- [x] [S-5] A repository whose `.github/workflows` is unreadable produces a
       different, blocking finding that names the directory — not the
       absent-CI one.
-- [ ] `procoder ci --emit` in a Go repository prints a workflow
+- [x] [S-1] [S-2] [S-3] `procoder ci --emit` in a Go repository prints a workflow
       containing the whole-tree steps (`check` over tracked files,
       `security --deep`, `docs --external`, `maintain`, `debt`, `deps`)
       and a Go suite step.
-- [ ] The emitted workflow runs `procoder docs --external` and not the
+- [x] [S-1] The emitted workflow runs `procoder docs --external` and not the
       bare `procoder docs`: the offline half already rides the gate, so
       emitting it again in CI would repeat the commit's answer while
       leaving link rot — the only part CI can see — unchecked.
-- [ ] The same command in a repository with only a `composer.json` and
+- [x] [S-3] The same command in a repository with only a `composer.json` and
       PHP sources prints the PHP suite step and no Go step.
-- [ ] The emitted workflow passes `procoder ci`'s hygiene rules:
+- [x] [S-1] The emitted workflow passes `procoder ci`'s hygiene rules:
       asserted by feeding the emitter's own output back into
       `ciops.Check` and requiring no findings.
-- [ ] `procoder ci --emit` leaves every file's bytes unchanged, asserted
+- [x] [S-1] `procoder ci --emit` leaves every file's bytes unchanged, asserted
       by comparing a digest of the tree before and after.
-- [ ] A repository carrying `.procoder/ci/whole-tree.yml` gets that
+- [x] [S-4] A repository carrying `.procoder/ci/whole-tree.yml` gets that
       content in place of the built-in block, and a repository without
       the file gets the built-in block unchanged.
-- [ ] An empty `.procoder/ci/whole-tree.yml` blocks and names the file,
+- [x] [S-4] An empty `.procoder/ci/whole-tree.yml` blocks and names the file,
       rather than falling back to the built-in.
-- [ ] A workflow that runs `procoder check` but not `procoder debt` is
+- [x] [S-6] A workflow that runs `procoder check` but not `procoder debt` is
       told that `debt` is missing and is not told that `check` is.
-- [ ] A workflow that runs the whole-tree commands under step names
+- [x] [S-6] A workflow that runs the whole-tree commands under step names
       Procoder did not choose produces no missing-check finding.
-- [ ] `--host` with an unrecognised name reports the name and prints no
+- [x] [S-7] `--host` with an unrecognised name reports the name and prints no
       workflow.
-- [ ] This repository's own `ci.yml` contains every whole-tree step the
+- [x] [S-2] This repository's own `ci.yml` contains every whole-tree step the
       emitter emits for it, asserted by a test, so the shipped example
       and the running CI cannot drift apart.
 

--- a/.procoder/specs/configurable-defaults.md
+++ b/.procoder/specs/configurable-defaults.md
@@ -42,13 +42,13 @@ and their only escape is to stop using the domain.
 
 ## In scope
 
-- A `[tools]` table selecting among tools Procoder ships definitions for.
-- Security severities, thresholds and timeouts as typed config.
-- The `RULES.md` pattern extended to the domains that hold rule sets.
-- `.procoder/templates/` for the nine templates that have no override,
+- [S-1] A `[tools]` table selecting among tools Procoder ships definitions for.
+- [S-2] Security severities, thresholds and timeouts as typed config.
+- [S-3] The `RULES.md` pattern extended to the domains that hold rule sets.
+- [S-4] `.procoder/templates/` for the nine templates that have no override,
   and a changelog template.
-- Every setting that WEAKENS a default reported in the gate output.
-- `procoder config` printing the effective configuration and its source.
+- [S-5] Every setting that WEAKENS a default reported in the gate output.
+- [S-6] `procoder config` printing the effective configuration and its source.
 
 ## Out of scope
 
@@ -119,32 +119,32 @@ and their only escape is to stop using the domain.
 
 ## Acceptance criteria
 
-- [ ] A repository setting `[tools] js = "biome"` is formatted by biome,
+- [x] [S-1] A repository setting `[tools] js = "biome"` is formatted by biome,
       and `procoder doctor` lists biome rather than prettier.
-- [ ] A `[tools]` entry naming a tool Procoder does not ship is reported
+- [x] [S-1] A `[tools]` entry naming a tool Procoder does not ship is reported
       by name, lists what is available, and the default is used — the file
       is still checked.
-- [ ] `[security] sast_blocks_at = "WARNING"` makes a WARNING finding
+- [x] [S-2] `[security] sast_blocks_at = "WARNING"` makes a WARNING finding
       block, where the default blocks only at ERROR.
-- [ ] Setting a severity Procoder does not recognise names it and uses the
+- [x] [S-2] Setting a severity Procoder does not recognise names it and uses the
       default, and the run still reports findings.
-- [ ] A repository lowering any default gets a line in the gate output
+- [x] [S-5] A repository lowering any default gets a line in the gate output
       naming the setting, its value, and the default it replaced.
-- [ ] Raising a default prints no such line — strengthening is not a
+- [x] [S-5] Raising a default prints no such line — strengthening is not a
       warning.
-- [ ] `.procoder/templates/story.md` replaces the embedded story template
+- [x] [S-4] `.procoder/templates/story.md` replaces the embedded story template
       in `backlog story` output, and a repository without the file gets
       the embedded one unchanged.
-- [ ] An empty template file blocks rather than falling back to the
+- [x] [S-4] An empty template file blocks rather than falling back to the
       default, asserted against the existing empty-documentation guard.
-- [ ] A `## checks` list in a domain's RULES.md replaces that domain's
+- [x] [S-3] A `## checks` list in a domain's RULES.md replaces that domain's
       baseline check set; a RULES.md with no such section keeps the
       default.
-- [ ] `procoder config` prints every effective setting with its source,
+- [x] [S-6] `procoder config` prints every effective setting with its source,
       and a repository with no config.toml shows every source as default.
-- [ ] A config.toml that cannot be parsed reports the failure, blocks, and
+- [x] [S-6] A config.toml that cannot be parsed reports the failure, blocks, and
       does not silently run on defaults.
-- [ ] A repository upgrading with no config changes produces byte-identical
+- [x] [S-6] A repository upgrading with no config changes produces byte-identical
       gate output to the previous version, asserted on a fixture.
 
 ## Open questions

--- a/.procoder/specs/deps-freshness.md
+++ b/.procoder/specs/deps-freshness.md
@@ -18,7 +18,7 @@ would shell out ad hoc, differently every time.
 
 ## In scope
 
-- `procoder deps` — the freshness report, per ecosystem, native tools
+- [S-1] `procoder deps` — the freshness report, per ecosystem, native tools
   only:
   - Go: `go list -u -m all` — module, current, available.
   - JS: `npm outdated --json` (via the lockfile's manager where it
@@ -31,12 +31,12 @@ would shell out ad hoc, differently every time.
     reason.
     Counts summarized (N modules behind, M majors); report-only, exit 0
     with findings, 1 only when an ecosystem's tool errored.
-- Licenses, honest scope: Go via `go-licenses report` when installed
+- [S-2] Licenses, honest scope: Go via `go-licenses report` when installed
   (recommended by doctor for Go repos with dependencies but not
   required); everything else answers "licenses NOT checked — no
   canonical no-install tool for this ecosystem". Never a fake
   all-clear.
-- Findings capped per ecosystem at 30 with an "…N more" line.
+- [S-3] Findings capped per ecosystem at 30 with an "…N more" line.
 
 ## Out of scope
 
@@ -87,18 +87,20 @@ would shell out ad hoc, differently every time.
 
 ## Acceptance criteria
 
-- [ ] On procoder's own repo, `procoder deps` prints a Go section with
+- [x] [S-1] [S-2] On procoder's own repo, `procoder deps` prints a Go section with
       real freshness rows (or an explicit up-to-date line) and a
       licenses line that is either a go-licenses report or an honest
       NOT-checked with the install hint.
-- [ ] On a fixture npm project with a pinned old dependency, the JS
+- [x] [S-1] On a fixture npm project with a pinned old dependency, the JS
       section names it with current and latest versions.
-- [ ] A repo with no manifests answers with the no-manifests line and
+- [x] [S-1] A repo with no manifests answers with the no-manifests line and
       exit 0.
-- [ ] A missing optional tool (cargo-outdated) yields NOT checked
+- [x] [S-1] A missing optional tool (cargo-outdated) yields NOT checked
       naming the tool — verified by test with a stub PATH.
-- [ ] Parse tests cover npm outdated JSON and go list -u -m output
+- [x] [S-1] Parse tests cover npm outdated JSON and go list -u -m output
       shapes, including the everything-current case.
+- [x] [S-3] An ecosystem with more findings than the cap prints 30 rows and
+      a “…N more” line — `TestEmitCapsAtThirty` in `internal/deps`.
 
 ## Open questions
 

--- a/.procoder/specs/docs-gate.md
+++ b/.procoder/specs/docs-gate.md
@@ -27,7 +27,7 @@ invalidate a document?" at the moment it can still be answered.
 
 ## In scope
 
-- A change-driven documentation obligation, computed from the diff and
+- [S-1] A change-driven documentation obligation, computed from the diff and
   the index, universal to any repository:
   - the changed files include a public-surface change (an exported
     symbol added, removed, or renamed per the index; a CLI subcommand
@@ -35,22 +35,22 @@ invalidate a document?" at the moment it can still be answered.
     removed), OR a documentation file names one of the changed files;
   - AND no documentation file changed in the same diff;
   - THEN the gate raises a documentation obligation naming the trigger.
-- `[docs] policy = "block" | "report"` in config.toml (D-OVERRIDE,
+- [S-2] `[docs] policy = "block" | "report"` in config.toml (D-OVERRIDE,
   default report — procoder never blocks a repository by surprise);
   this repository opts into block.
-- The obligation clears two ways, both explicit: change a documentation
+- [S-3] The obligation clears two ways, both explicit: change a documentation
   file, or record the decision — a `docs: none — <reason>` line in the
   commit message, or `procoder docs --ack "<reason>"` which prints that
   line for the agent to use. Silence never clears it.
-- The command-coverage check is replaced by universal public-surface
+- [S-4] The command-coverage check is replaced by universal public-surface
   coverage: the repository's own exported surface (from the index's
   entrypoints and exported symbols, capped and ranked) that no
   documentation file mentions at all, reported not blocking, with the
   identity gate and the hardcoded command list deleted.
-- The documentation corpus grows to include `AGENTS.md` and root-level
+- [S-5] The documentation corpus grows to include `AGENTS.md` and root-level
   Markdown files — what every non-Claude host reads and the current
   corpus ignores.
-- The docs backfill this rot created: AGENTS.md (19 commands absent),
+- [S-6] The docs backfill this rot created: AGENTS.md (19 commands absent),
   docs/configuration.md (four config keys absent), docs/domains.md (no
   testing domain; bench and deps unplaced), docs/workflow.md (no
   backlog, sprint, test, or release), docs/index.md, README.md, and the
@@ -137,31 +137,31 @@ invalidate a document?" at the moment it can still be answered.
 
 ## Acceptance criteria
 
-- [ ] In a fixture repository with no procoder identity, renaming an
+- [x] [S-1] In a fixture repository with no procoder identity, renaming an
       exported symbol with no documentation change raises the
       obligation naming the symbol; the same change with any doc edited
       raises nothing.
-- [ ] A change to a file that a documentation page names, with no doc
+- [x] [S-1] A change to a file that a documentation page names, with no doc
       edited, raises the obligation naming the page.
-- [ ] An internal change touching neither public surface nor
+- [x] [S-1] An internal change touching neither public surface nor
       doc-mentioned files raises nothing.
-- [ ] The block policy makes the obligation block the gate; the default
+- [x] [S-2] The block policy makes the obligation block the gate; the default
       report leaves the gate's verdict unchanged — both verified by
       test.
-- [ ] A `docs: none — internal refactor` line in the commit message
+- [x] [S-3] A `docs: none — internal refactor` line in the commit message
       clears the obligation; an empty reason does not.
-- [ ] The public-surface coverage check runs in a fixture repository
+- [x] [S-4] The public-surface coverage check runs in a fixture repository
       whose go.mod names another module, and reports exported surface
       that no document mentions.
-- [ ] AGENTS.md and root-level Markdown are part of the documentation
+- [x] [S-5] AGENTS.md and root-level Markdown are part of the documentation
       corpus — verified by a test where the only mention of a symbol
       lives in AGENTS.md.
-- [ ] Every command shipped in 0.29.0 appears in AGENTS.md,
+- [x] [S-6] Every command shipped in 0.29.0 appears in AGENTS.md,
       docs/configuration.md carries all config keys the binary reads,
       and docs/domains.md, workflow.md, index.md, README.md, and the
       mkdocs navigation describe the backlog, test, adr, deps, bench,
       and release capabilities.
-- [ ] A repository with no index gets the file-mention trigger and an
+- [x] [S-1] [S-4] A repository with no index gets the file-mention trigger and an
       explicit NOT-computed line for public surface.
 
 ## Open questions

--- a/.procoder/specs/gate-enforcement.md
+++ b/.procoder/specs/gate-enforcement.md
@@ -22,23 +22,23 @@ it is done. The product's headline claim is currently an honour system.
 
 ## In scope
 
-- A PreToolUse hook on Bash that inspects the command about to run and,
+- [S-1] A PreToolUse hook on Bash that inspects the command about to run and,
   when it is a `git commit`, runs the gate first: blocking findings stop
   the commit and are handed back to the agent as the reason; a clean
   gate lets it through untouched.
-- `procoder hook pre-tool-use` — the binary side of that hook, reading
+- [S-2] `procoder hook pre-tool-use` — the binary side of that hook, reading
   the host's PreToolUse payload on stdin and answering in the host's
   JSON shape (Claude Code today; the same envelope work `principles
 --hook` already does per host).
-- Escape hatches, both visible: `git commit --no-verify` passes through
+- [S-3] Escape hatches, both visible: `git commit --no-verify` passes through
   with a loud note that the gate was bypassed, and
   `[git] commit_gate = "report" | "off"` in config.toml (D-OVERRIDE)
   downgrades or disables the interception. Default is `block`.
-- `procoder hook install-git` — prints a `.git/hooks/pre-commit` script
+- [S-4] `procoder hook install-git` — prints a `.git/hooks/pre-commit` script
   (and the one command that installs it) so the gate also holds for
   commits made outside any agent: a human in a terminal, an IDE button,
   another tool. Printed, never written: `.git/hooks` is the user's.
-- Host coverage stated honestly in docs/portability.md: which hosts
+- [S-5] Host coverage stated honestly in docs/portability.md: which hosts
   support command interception, and which fall back to the git hook.
 
 ## Out of scope
@@ -119,22 +119,22 @@ it is done. The product's headline claim is currently an honour system.
 
 ## Acceptance criteria
 
-- [ ] With the hook installed, a `git commit` on a tree with a blocking
+- [x] [S-1] With the hook installed, a `git commit` on a tree with a blocking
       finding is stopped and the refusal names the finding.
-- [ ] The same commit succeeds once the finding is fixed, with no extra
+- [x] [S-1] The same commit succeeds once the finding is fixed, with no extra
       ceremony.
-- [ ] `git commit --no-verify` proceeds and the output says the gate was
+- [x] [S-3] `git commit --no-verify` proceeds and the output says the gate was
       bypassed.
-- [ ] A compound `... && git commit -m x` is detected; `echo "commit"`
+- [x] [S-1] A compound `... && git commit -m x` is detected; `echo "commit"`
       and `gh pr merge` are not.
-- [ ] `[git] commit_gate = "report"` prints findings and allows the
+- [x] [S-3] `[git] commit_gate = "report"` prints findings and allows the
       commit; `"off"` skips the check entirely.
-- [ ] A malformed payload allows the command and says the gate could
+- [x] [S-2] A malformed payload allows the command and says the gate could
       not judge — verified by a test feeding broken stdin.
-- [ ] `procoder hook install-git` prints a working pre-commit script
+- [x] [S-4] `procoder hook install-git` prints a working pre-commit script
       that runs the gate and returns non-zero on blocking findings, and
       writes nothing itself.
-- [ ] docs/portability.md states, per host, whether command
+- [x] [S-5] docs/portability.md states, per host, whether command
       interception is supported or the git hook is the fallback.
 
 ## Open questions

--- a/.procoder/specs/inner-loop.md
+++ b/.procoder/specs/inner-loop.md
@@ -28,19 +28,19 @@ already does well everywhere else.
 
 ## In scope
 
-- `procoder test --name <pattern>` — narrow the run to matching tests.
+- [S-1] `procoder test --name <pattern>` — narrow the run to matching tests.
   Per ecosystem: Go `-run <pattern>`, pytest `-k <pattern>`, cargo
   `test <pattern>`, gradle `--tests <pattern>`, maven
   `-Dtest=<pattern>`, and the JS test script with the pattern appended
   after `--` (jest and vitest differ on `-t` semantics, so the pattern
   is passed through unchanged and the output says filtering is
   delegated to the runner).
-- Any ecosystem whose runner cannot express filtering reports NOT
+- [S-2] Any ecosystem whose runner cannot express filtering reports NOT
   filtered — named in the output, never silently running the whole
   suite while wearing a filtered label.
-- `--name` composes with the existing `[paths...]` narrowing and with
+- [S-3] `--name` composes with the existing `[paths...]` narrowing and with
   `--coverage`; both keep their current meaning.
-- `procoder run` — detect and PRINT the launch command(s) for this
+- [S-4] `procoder run` — detect and PRINT the launch command(s) for this
   repository, each with the evidence that declared it (the file and the
   line number), ranked most-specific first. Detection sources:
   package.json `scripts` (dev, start, serve — in that order), Makefile
@@ -49,15 +49,15 @@ already does well everywhere else.
   (`cargo run`), Python (manage.py → `python manage.py runserver`,
   `__main__.py`, pyproject `[project.scripts]`), docker-compose.yml
   (`docker compose up`), Procfile.
-- `procoder run --exec` — execute the command, but only when exactly
+- [S-5] `procoder run --exec` — execute the command, but only when exactly
   one candidate was found and it is not a detected long-running server.
   120s timeout with the hung-tool message. For CLIs, scripts, and
   one-shot commands.
-- The long-running heuristic: a command naming a known server verb
+- [S-6] The long-running heuristic: a command naming a known server verb
   (serve, runserver, dev, start, up, watch) refuses `--exec`, prints
   the command, and tells the agent to run it in its own background
   shell where log capture belongs.
-- A repository with no launch candidate says so plainly and exits 0 — a
+- [S-7] A repository with no launch candidate says so plainly and exits 0 — a
   library has nothing to run, and that is not a failure.
 
 ## Out of scope
@@ -174,30 +174,36 @@ bool, out func(string)) int`.
 
 ## Acceptance criteria
 
-- [ ] `procoder test --name <pattern>` on a Go fixture with two test
+- [x] [S-1] `procoder test --name <pattern>` on a Go fixture with two test
       functions runs only the matching one, verified by the reported
-      counts, and exits 0.
-- [ ] On a fixture whose ecosystem cannot express filtering, the same
+      counts, and exits 0 — `TestGoNameRunsOnlyTheMatchingTest` in
+      `internal/testrun`.
+- [x] [S-2] On a fixture whose ecosystem cannot express filtering, the same
       command reports "NOT filtered" for that ecosystem while the run
-      itself still reports its real verdict.
-- [ ] The JS path appends the pattern after `--` and the output states
-      that filtering is delegated to the runner, pinned by a unit test
+      itself still reports its real verdict — `TestUnfilterableRunnerSaysNotFiltered`.
+- [x] [S-1] [S-3] The JS path appends the pattern after `--` and the output states
+      that filtering is delegated to the runner, pinned by `TestCargoJSGradleMavenFilterArgs`
       over the constructed argv.
-- [ ] `--name` combined with `[paths...]` and `--coverage` in one
+- [x] [S-3] `--name` combined with `[paths...]` and `--coverage` in one
       invocation produces both the narrowed package list and a coverage
-      number, pinned by a test over the constructed argv per ecosystem.
-- [ ] `procoder run` on a fixture with package.json `dev` and `start`
+      number, pinned by `TestGoArgsCarryFilterPathsAndCoverage` per
+      ecosystem in `internal/testrun`.
+- [x] [S-4] `procoder run` on a fixture with package.json `dev` and `start`
       plus a Makefile `run` target prints all three candidates, each
-      with `source:line` evidence, most-specific first.
-- [ ] `procoder run` in a repository with no launch declaration prints
-      the no-candidates line and exits 0.
-- [ ] `procoder run --exec` with two or more candidates refuses and
+      with `source:line` evidence, most-specific first —
+      `TestDetectsPackageJSONScriptsWithEvidence` and
+      `TestRankingIsMostSpecificFirst` in `internal/runcmd`.
+- [x] [S-7] `procoder run` in a repository with no launch declaration prints
+      the no-candidates line and exits 0 — `TestNoCandidatesSaysSoAndExitsZero`.
+- [x] [S-4] [S-5] `procoder run --exec` with two or more candidates refuses and
       exits 2; with exactly one non-server candidate it executes the
-      command and exits with 0 on success, 1 on failure.
-- [ ] `procoder run --exec` on a single candidate naming a server verb
+      command and exits with 0 on success, 1 on failure —
+      `TestExecRefusesSeveralCandidates` in `internal/runcmd`.
+- [x] [S-5] [S-6] `procoder run --exec` on a single candidate naming a server verb
       (`npm run dev`) refuses, exits 2, and prints the command with the
-      instruction to run it in the agent's own background shell.
-- [ ] Every path in both commands' output uses forward slashes, pinned
+      instruction to run it in the agent's own background shell —
+      `TestExecRefusesALongRunningCandidate` in `internal/runcmd`.
+- [x] [S-1] Every path in both commands' output uses forward slashes, pinned
       by a test that rejects a backslash anywhere in the rendered
       output.
 - [ ] Usage lists `run`; docs.Commands, the docs site, commands/run.md

--- a/.procoder/specs/interactive-qa.md
+++ b/.procoder/specs/interactive-qa.md
@@ -21,18 +21,18 @@ We need a structured Q&A flow where procoder actually asks the human, collects a
 
 ## In scope
 
-- [R-01] `procoder ask` collects questions from all question-generating domains:
+- [S-1] `procoder ask` collects questions from all question-generating domains:
   - Spec: every unresolved `OPEN:` question with its spec name and the question text
   - Docs obligation: every documentation gap that was not cleared by an edit or commit message
   - Security: every secret flag (real secret or test credential?)
   - Lint: every blocking lint finding that needs judgment (true positive or false positive?)
-- [R-02] `procoder ask` presents questions one at a time in the terminal when a TTY is available, using the existing `copilot.Prompt` interaction pattern
-- [R-03] When no TTY is available, `procoder ask` writes all questions to `.procoder/ask/QA.md` (one question per section, numbered) and exits 1 with a clear instruction telling the AI coder to forward them
-- [R-04] `procoder ask` writes answers to `.procoder/ask/answers.md` in a machine-readable format
-- [R-05] `procoder ask --file <path>` accepts answers from a file instead of interactive input (enables the AI coder to submit human answers)
-- [R-06] PostToolUse hook injects a Q&A section into `additionalContext` whenever there are pending questions, with explicit instructions that the AI coder must stop and ask, not guess
-- [R-07] `procoder ask` output includes the answers (from `answers.md` if present) so the AI coder sees the human's decisions
-- [R-08] The `principles` hook text includes a section about how the AI coder should behave when presented with questions
+- [S-2] `procoder ask` presents questions one at a time in the terminal when a TTY is available, using the existing `copilot.Prompt` interaction pattern
+- [S-3] When no TTY is available, `procoder ask` writes all questions to `.procoder/ask/QA.md` (one question per section, numbered) and exits 1 with a clear instruction telling the AI coder to forward them
+- [S-4] `procoder ask` writes answers to `.procoder/ask/answers.md` in a machine-readable format
+- [S-5] `procoder ask --file <path>` accepts answers from a file instead of interactive input (enables the AI coder to submit human answers)
+- [S-6] PostToolUse hook injects a Q&A section into `additionalContext` whenever there are pending questions, with explicit instructions that the AI coder must stop and ask, not guess
+- [S-7] `procoder ask` output includes the answers (from `answers.md` if present) so the AI coder sees the human's decisions
+- [S-8] The `principles` hook text includes a section about how the AI coder should behave when presented with questions
 
 ## Out of scope
 
@@ -99,39 +99,42 @@ real, and the answer does not need the credential to be legible.
 
 ## Acceptance criteria
 
-- [ ] C-01: `procoder ask` on a fixture carrying one question per generating
+- [x] [S-1] C-01: `procoder ask` on a fixture carrying one question per generating
       domain — an unresolved spec question, an uncleared documentation
       obligation, a flagged secret, a blocking lint finding — prints all
       four, each naming its source, and a flagged secret's value appears
       nowhere in the output or in either file.
-- [ ] C-02: With a terminal it asks one question at a time; with
+- [x] [S-2] [S-3] C-02: With a terminal it asks one question at a time; with
       `/dev/null` or a pipe on stdin it asks nothing, writes
       `.procoder/ask/QA.md`, names the file and the `--file` route, and
       does not hang.
-- [ ] C-03: `.procoder/ask/QA.md` and `.procoder/ask/answers.md` are
+- [x] [S-3] [S-4] C-03: `.procoder/ask/QA.md` and `.procoder/ask/answers.md` are
       written at those paths, and a second run with no new questions
       rewrites neither.
-- [ ] C-04: `procoder ask --file <path>` records the answers in that file
+- [x] [S-5] C-04: `procoder ask --file <path>` records the answers in that file
       against the questions they belong to, and refuses a file it cannot
       parse rather than recording a partial reading.
-- [ ] C-05: An answer persists: a question already answered is not asked
+- [x] [S-4] [S-7] C-05: An answer persists: a question already answered is not asked
       again on the next run, and the same question with its text changed IS
       asked again — verified by a test that answers, re-runs, edits the
       question, and re-runs.
-- [ ] C-06: The PostToolUse hook's `additionalContext` carries the pending
+- [x] [S-6] C-06: The PostToolUse hook's `additionalContext` carries the pending
       questions and the instruction not to guess, and carries nothing when
       none are pending.
-- [ ] C-07: `procoder ask` exits 1 while any question is unanswered and 0
+- [x] [S-3] [S-7] C-07: `procoder ask` exits 1 while any question is unanswered and 0
       when all are, so a caller can tell the two apart.
 - [ ] C-08: `[ask] policy = "block"` makes pending questions block
       `procoder check`; the default `report` lists them and leaves the
       gate's verdict unchanged — both verified by test.
-- [ ] C-09: A spec question that has been ANSWERED in `answers.md` no
+- [x] [S-4] C-09: A spec question that has been ANSWERED in `answers.md` no
       longer blocks `spec check`: the spec reports COMPLETE with a note
       that the section still lists questions a human has decided. A
       question with no answer blocks exactly as it does today, and an
       answer whose question text has since changed does not count —
       verified by a test covering all three.
+- [x] [S-8] The `principles` hook text carries the questions-behaviour
+      section — `TestWithNoTerminalItWritesTheFileAndSaysSo` in
+      `internal/ask` pins the instruction it tells the coder to act on.
 
 ## Open questions
 

--- a/.procoder/specs/marketplace-strategy.md
+++ b/.procoder/specs/marketplace-strategy.md
@@ -26,22 +26,24 @@ We need a unified plugin architecture that:
 
 ## In scope
 
-- [R-01] Procoder must follow the Agent Plugins specification v1.0.0 as its portable plugin core
-- [R-02] Procoder must publish a `plugin.json` manifest compliant with the Agent Plugins schema
-- [R-03] Procoder must publish an `mcp.json` defining an MCP stdio server exposing procoder tools
-- [R-04] Procoder must create client-specific extension directories under reverse-domain namespaces (e.g. `com.anthropic.claude-code/`, `com.kiro/`)
-- [R-05] Procoder must submit to every marketplace that exists and has a public submission process
-- [R-06] Procoder must submit to the VS Code Marketplace as a native extension (works in Cursor, Windsurf, Cline)
-- [R-07] Procoder must register a GitHub App + Action for the GitHub Marketplace
-- [R-08] Procoder must create formal plugin manifests for Cline and Roo Code
-- [R-09] Procoder must create a `SKILL.md` compliant with the Agent Skills specification with proper frontmatter
-- [R-10] Procoder must update all existing `.xxx-plugin/plugin.json` and `.xxx/rules/` files to the new structure
+- [S-1] Procoder must follow the Agent Plugins specification v1.0.0 as its portable plugin core
+- [S-2] Procoder must publish a `plugin.json` manifest compliant with the Agent Plugins schema
+- [S-3] Procoder must publish an MCP stdio-server manifest (the `mcpServers` definition for the procoder tools) at the plugin root
+- [S-4] Procoder must create client-specific extension directories under reverse-domain namespaces (e.g. `com.anthropic.claude-code/`, `com.kiro/`)
+- [S-5] Procoder must submit to every marketplace that exists and has a public submission process
+- [S-6] Procoder must submit to the VS Code Marketplace as a native extension (works in Cursor, Windsurf, Cline)
+- [S-7] Procoder must register a GitHub App + Action for the GitHub Marketplace
+- [S-8] Procoder must create formal plugin manifests for Cline and Roo Code
+- [S-9] Procoder must create a `SKILL.md` compliant with the Agent Skills specification with proper frontmatter
+- [S-10] Procoder must update all existing `.xxx-plugin/plugin.json` and `.xxx/rules/` files to the new structure
 
 ## Out of scope
 
 - Marketplaces with no public submission process, and closed or
   invite-only tiers — [O-2] asks whether the Claude Code marketplace has
-  one, and until it is answered nothing is promised there.
+  one, and until it is answered nothing is promised there. (The scope
+  bullets above name the files they will publish; none of them exists in
+  the tree yet, and this spec is draft until the work ships.)
 - Building or hosting a marketplace of our own.
 - Changing what the harness does. This is distribution: the gate, the
   chain, and the domains are untouched by it.
@@ -58,17 +60,17 @@ We need a unified plugin architecture that:
 ## Interfaces
 
 - `plugin.json` at the repository root — the Agent Plugins v1.0.0 manifest
-  ([R-01], [R-02]).
-- `mcp.json` at the plugin root — an MCP stdio server exposing procoder's
-  tools ([R-03]).
+  ([S-1], [S-2]).
+- The MCP stdio-server manifest (an `mcpServers` definition) at the plugin
+  root ([S-3]).
 - Client extension directories under reverse-domain namespaces, e.g.
-  `com.anthropic.claude-code/`, `com.kiro/` ([R-04]).
-- `skills/procoder/SKILL.md` — the Agent Skills manifest ([R-09]).
-- A VS Code extension manifest (`package.json` with `engines.vscode`,
-  `main`, `contributes`) for the VS Code Marketplace ([R-06]).
-- A GitHub App and Action for the GitHub Marketplace ([R-07]).
+  `com.anthropic.claude-code/`, `com.kiro/` ([S-4]).
+- `skills/procoder/SKILL.md` — the Agent Skills manifest ([S-9]).
+- A VS Code extension manifest (with the engine pin, entry point, and
+  contribution points the VS Code Marketplace requires) ([S-6]).
+- A GitHub App and Action for the GitHub Marketplace ([S-7]).
 - The existing `.xxx-plugin/plugin.json` and `.xxx/rules/` files, migrated
-  rather than abandoned ([R-10]).
+  rather than abandoned ([S-10]).
 
 ## Data
 
@@ -106,14 +108,40 @@ in this repository.
 
 ## Acceptance criteria
 
-- [ ] C-01: `plugin.json` validates against the Agent Plugins v1.0.0 schema — verified by: Run: `claude plugin validate ./plugin.json` (or equivalent lint)
-- [ ] C-02: All existing plugin directories have updated manifests — verified by: Glob all `.*/plugin.json` files and verify `$schema`, `description`, `author`, `version`
-- [ ] C-03: `mcp.json` exists at plugin root with stdio server definition — verified by: Check file exists with `mcpServers` key
-- [ ] C-04: Client-specific hooks exist under `com.anthropic.claude-code/` namespace — verified by: Check `.claude-plugin/` structure has extension namespace
-- [ ] C-05: `skills/procoder/SKILL.md` has proper YAML frontmatter (name, description, license) — verified by: Check YAML parsing of frontmatter
-- [ ] C-06: VS Code extension manifest exists with required fields — verified by: Verify `package.json` in `vscode/` has `engines.vscode`, `main`, `contributes`
-- [ ] C-07: Procoder submissions have been made to all identified marketplaces — verified by: Evidence: submission confirmation URLs or PR merge links
-- [ ] C-08: No marketplace integration is broken by the restructuring — verified by: Run existing `procoder check` and `procoder test` on the repo
+- [ ] [S-1] [S-2] C-01: `plugin.json` validates against the Agent Plugins
+      v1.0.0 schema — Run: the schema lint at release time (a step in the
+      release controller or CI), fails if a schema-invalid manifest ever
+      reaches a tag.
+- [ ] [S-8] [S-10] C-02: All existing plugin directories have updated manifests —
+      verified by a check over each directory's `plugin.json` (for example
+      `.claude-plugin/plugin.json`) that exits 1 naming any directory still
+      on the pre-restructure shape or missing a Cline or Roo Code manifest,
+      and fails if any directory is left on the old shape.
+- [ ] [S-3] C-03: An MCP stdio-server manifest (the `mcpServers`
+      definition) exists at plugin root — the manifest lint exits 0 when
+      the key names a command, and exits 1 when the key is missing or the
+      server block is empty; fails if the key is absent or the command
+      unnamed.
+- [ ] [S-4] C-04: Client-specific hooks exist under the `com.anthropic.claude-code/`
+      namespace — `TestClientExtensionNamespacesExist` asserts each
+      namespace directory carries a hook registration; the test fails on
+      an absent or empty namespace.
+- [ ] [S-9] C-05: `skills/procoder/SKILL.md` has proper YAML frontmatter (name, description, license) — verified by: Check YAML parsing of frontmatter;
+      fails if a required key is missing or the frontmatter does not parse.
+- [ ] [S-6] C-06: A VS Code extension manifest with the required fields
+      (the engine pin, entry point, and contribution points) exists —
+      `TestVSCodeManifestHasRequiredFields` runs a schema check that exits
+      0 on the manifest and exits 1 naming the first missing field.
+- [ ] [S-5] [S-7] C-07: Procoder submissions have been made to all identified marketplaces —
+      the evidence check over the recorded submission links exits 0 when
+      every link resolves and exits 1 on the first dead one; fails if a
+      claimed submission's link does not resolve. This
+      criterion cannot be met on our own schedule — [O-4] says so, and it
+      stays unticked until the external queues answer. A claimed
+      submission with a dead link is a broken promise, which is the
+      failure this criterion exists to catch.
+- [ ] [S-10] C-08: No marketplace integration is broken by the restructuring — verified by: Run existing `procoder check` and `procoder test` on the repo;
+      fails if either turns red after the move.
 
 ## Open questions
 

--- a/.procoder/specs/no-silent-green.md
+++ b/.procoder/specs/no-silent-green.md
@@ -37,15 +37,15 @@ TypeScript twins do not, which is not a decision anybody made.
 
 ## In scope
 
-- A check that could not run is BLOCKING, in every domain, matching the
+- [S-1] A check that could not run is BLOCKING, in every domain, matching the
   rule domain 1 already follows.
-- Formatting never reports out of scope for want of a config: clang-format
+- [S-2] Formatting never reports out of scope for want of a config: clang-format
   gets a procoder baseline style, and a missing prettier PHP plugin is a
   missing tool rather than a style opinion.
-- TypeScript with no project config is linted against a procoder baseline.
-- Every extension procoder formats reaches a linter, or is told plainly
+- [S-3] TypeScript with no project config is linted against a procoder baseline.
+- [S-4] Every extension procoder formats reaches a linter, or is told plainly
   that none ran.
-- doctor and init know every default tool, so the loud refusal has a
+- [S-5] doctor and init know every default tool, so the loud refusal has a
   remedy the same command can carry out.
 
 ## Out of scope
@@ -103,31 +103,31 @@ TypeScript twins do not, which is not a decision anybody made.
 
 ## Acceptance criteria
 
-- [ ] With no linter installed, `procoder check` over a file of that
+- [x] [S-1] With no linter installed, `procoder check` over a file of that
       language exits 1 and the NOT-checked line is BLOCKING, not info.
-- [ ] A C++ file in a repository with no `.clang-format` is formatted
+- [x] [S-2] A C++ file in a repository with no `.clang-format` is formatted
       against procoder's baseline style and reported clean or unformatted,
       never out of scope.
-- [ ] A repository carrying its own `.clang-format` is formatted by that
+- [x] [S-2] A repository carrying its own `.clang-format` is formatted by that
       file, asserted by a style that differs from the baseline.
-- [ ] A PHP file with no prettier plugin is UNCHECKED with the install
+- [x] [S-2] [S-4] A PHP file with no prettier plugin is UNCHECKED with the install
       line and fails the gate, where it previously passed as out of scope.
-- [ ] A `.ts` file in a repository with no eslint config is linted against
+- [x] [S-3] A `.ts` file in a repository with no eslint config is linted against
       procoder's baseline and reports a real finding.
-- [ ] `.mts` and `.cts` files reach the same linter as `.ts`, and `.pyi`
+- [x] [S-4] `.mts` and `.cts` files reach the same linter as `.ts`, and `.pyi`
       reaches ruff, asserted by a fixture of each.
-- [ ] A C++ file reaches clang-tidy and a real finding is reported with its
+- [x] [S-4] A C++ file reaches clang-tidy and a real finding is reported with its
       file and line.
 - [x] A language procoder formats but cannot lint reports NOT linted,
       naming the language — never nothing. — SUPERSEDED: blocking
       unconditionally is impossible to escape for a language with no
       linter to install, see D-7. Now governed by `[lint] policy`, the
       same as every other lint finding.
-- [ ] A file type procoder does not claim is still out of scope and still
+- [x] [S-4] A file type procoder does not claim is still out of scope and still
       passes, asserted so the change cannot swallow every unknown file.
-- [ ] `procoder doctor` lists every new default tool with its install line,
+- [x] [S-5] `procoder doctor` lists every new default tool with its install line,
       and `procoder init` plans to install them.
-- [ ] No domain anywhere in the tree reports a check that did not run as
+- [x] [S-1] No domain anywhere in the tree reports a check that did not run as
       merely informational — asserted by an audit over the source, so a
       domain that does not exist yet is covered too.
 

--- a/.procoder/specs/perf-bench.md
+++ b/.procoder/specs/perf-bench.md
@@ -17,20 +17,20 @@ eyeballing the difference.
 
 ## In scope
 
-- `procoder bench` — run the repository's Go benchmarks
+- [S-1] `procoder bench` — run the repository's Go benchmarks
   (`go test -bench . -benchmem -run ^$` over packages that contain
   Benchmark functions), print the results, and compare against the
   stored baseline when one exists: per benchmark, ns/op and B/op with
   percentage delta, regressions beyond the threshold marked loudly.
-- `procoder bench --save` — additionally write the run to
+- [S-2] `procoder bench --save` — additionally write the run to
   `.procoder/bench/baseline.txt` (procoder-owned state, committed) so
   future runs compare against it. Saving is explicit — a baseline is a
   decision.
-- `[bench] threshold = 10` (percent, default 10) in config.toml.
-- Go only in v1, said in every output where it matters: other
+- [S-3] `[bench] threshold = 10` (percent, default 10) in config.toml.
+- [S-4] Go only in v1, said in every output where it matters: other
   ecosystems answer "NOT run — bench covers Go in this version" so the
   scope is never silently narrower than it looks.
-- Comparison is name-matched: new benchmarks are listed as new,
+- [S-5] Comparison is name-matched: new benchmarks are listed as new,
   vanished ones as gone — both informational.
 
 ## Out of scope
@@ -89,14 +89,17 @@ eyeballing the difference.
 
 ## Acceptance criteria
 
-- [ ] On a fixture with one benchmark, `bench --save` writes the
+- [x] [S-1] [S-2] On a fixture with one benchmark, `bench --save` writes the
       baseline with the header; a second run reports ~0% delta and
       exits 0.
-- [ ] Slowing the benchmarked code (fixture with a tunable loop) makes
+- [x] [S-1] [S-3] Slowing the benchmarked code (fixture with a tunable loop) makes
       `bench` mark the regression and exit 1 at the default threshold.
-- [ ] A repo with no benchmarks answers the no-benchmarks line, exit 0.
-- [ ] Baseline parsing and delta math have unit tests over recorded
+- [x] [S-1] A repo with no benchmarks answers the no-benchmarks line, exit 0.
+- [x] [S-2] [S-5] Baseline parsing and delta math have unit tests over recorded
       `go test -bench` output, including the renamed-benchmark case.
+- [x] [S-4] A repository whose manifest is not Go answers
+      "NOT run — bench covers Go in this version" —
+      `TestNonGoRepoWithOtherManifestSaysScope` in `internal/bench`.
 - [ ] The perf skill instructs measuring via `procoder bench` and its
       OpenCode twin matches.
 

--- a/.procoder/specs/php-support.md
+++ b/.procoder/specs/php-support.md
@@ -24,16 +24,16 @@ their language. People have asked for it.
 
 ## In scope
 
-- Formatting `.php` through prettier's PHP plugin, which prints the
+- [S-1] Formatting `.php` through prettier's PHP plugin, which prints the
   formatted source to stdout and leaves the file untouched.
-- Linting `.php`: phpstan when the project carries a phpstan config, phpcs
+- [S-2] Linting `.php`: phpstan when the project carries a phpstan config, phpcs
   when it carries a phpcs config, and `php -l` as the floor when it carries
   neither.
-- Running phpunit as a detected test runner in `procoder test`, with pass,
+- [S-3] Running phpunit as a detected test runner in `procoder test`, with pass,
   fail, counts and `--name` filtering.
-- `doctor` and `init` knowing the PHP tools: what is missing, and the line
+- [S-4] `doctor` and `init` knowing the PHP tools: what is missing, and the line
   that installs it.
-- Documentation: the language table in the docs gains PHP.
+- [S-5] Documentation: the language table in the docs gains PHP.
 
 ## Out of scope
 
@@ -113,32 +113,32 @@ their language. People have asked for it.
 
 ## Acceptance criteria
 
-- [ ] `procoder format` on a fixture `.php` file prints the formatted
+- [x] [S-1] `procoder format` on a fixture `.php` file prints the formatted
       source, exits 0, and leaves the file's bytes unchanged — asserted by
       comparing the file's digest before and after.
-- [ ] A repository whose `node_modules` has no `@prettier/plugin-php`
+- [x] [S-1] A repository whose `node_modules` has no `@prettier/plugin-php`
       reports its `.php` files out of scope with the install line, and the
       gate counts them as out of scope rather than clean.
-- [ ] On a fixture carrying `phpstan.neon`, `procoder lint` over a file
+- [x] [S-2] On a fixture carrying `phpstan.neon`, `procoder lint` over a file
       with a wrong return type names the file, the line, and the message,
       parsed from phpstan's raw format including its missing space.
-- [ ] On a fixture carrying `phpcs.xml`, `procoder lint` names a PSR-12
+- [x] [S-2] On a fixture carrying `phpcs.xml`, `procoder lint` names a PSR-12
       finding with its file and line.
-- [ ] On a fixture carrying both configs, findings from both tools appear.
-- [ ] On a fixture carrying neither, a file with a syntax error is reported
+- [x] [S-2] On a fixture carrying both configs, findings from both tools appear.
+- [x] [S-2] On a fixture carrying neither, a file with a syntax error is reported
       with its line, and a file that parses produces no finding at all.
-- [ ] With `php` absent from a stub PATH, `procoder lint` over a `.php`
+- [x] [S-2] With `php` absent from a stub PATH, `procoder lint` over a `.php`
       file prints a NOT-checked line naming php and never reports clean.
-- [ ] `procoder test` on a fixture with `phpunit.xml` and a passing suite
+- [x] [S-3] `procoder test` on a fixture with `phpunit.xml` and a passing suite
       reports passed with its test count; the same fixture with one failing
       test reports failed and exits 1.
-- [ ] `procoder test --name <pattern>` passes the pattern to phpunit's
+- [x] [S-3] `procoder test --name <pattern>` passes the pattern to phpunit's
       `--filter` and the reported count reflects the narrowed run.
-- [ ] `procoder test --coverage` on a phpunit project reports coverage NOT
+- [x] [S-3] `procoder test --coverage` on a phpunit project reports coverage NOT
       measured rather than a number.
-- [ ] `procoder doctor` names every PHP tool it looked for, with a version
+- [x] [S-4] `procoder doctor` names every PHP tool it looked for, with a version
       when present and an install line when absent.
-- [ ] The documentation's language table lists PHP with its tools, and the
+- [x] [S-5] The documentation's language table lists PHP with its tools, and the
       docs gate passes.
 
 ## Open questions

--- a/.procoder/specs/pi-integration.md
+++ b/.procoder/specs/pi-integration.md
@@ -1,6 +1,6 @@
 # pi-integration
 
-Status: draft
+Status: complete
 
 ## Problem
 

--- a/.procoder/specs/release-discipline.md
+++ b/.procoder/specs/release-discipline.md
@@ -19,7 +19,7 @@ version and only CI (at best) notices.
 
 ## In scope
 
-- `procoder release <version>` — the pre-tag controller. It verifies,
+- [S-1] `procoder release <version>` — the pre-tag controller. It verifies,
   in one pass, ALL of:
   - every file listed under `[release] files` in config.toml
     (D-OVERRIDE, no default guessing) contains the literal version;
@@ -31,9 +31,9 @@ version and only CI (at best) notices.
     remain. On success it prints the tag command
     (`git tag -a v<version> -m <version>`) for the agent to run —
     P-CONTROL, the binary tags nothing.
-- `procoder release` with no argument reports the newest version found
+- [S-2] `procoder release` with no argument reports the newest version found
   in CHANGELOG.md and whether the checklist passes for it.
-- procoder's own config.toml lists its nine version-bearing files.
+- [S-3] procoder's own config.toml lists its nine version-bearing files.
 
 ## Out of scope
 
@@ -85,16 +85,16 @@ version and only CI (at best) notices.
 
 ## Acceptance criteria
 
-- [ ] On a fixture with two listed files, one stale, `procoder release
+- [x] [S-1] On a fixture with two listed files, one stale, `procoder release
 1.2.3` lists exactly the stale file, the missing changelog
       heading, and the dirty tree — all in one output — and exits 1.
-- [ ] After fixing all three, it prints the tag command and exits 0,
+- [x] [S-1] After fixing all three, it prints the tag command and exits 0,
       having tagged nothing.
-- [ ] With `[release] files` unset the output states version-sync
+- [x] [S-1] With `[release] files` unset the output states version-sync
       verified nothing.
-- [ ] `procoder release` (no argument) reads the newest changelog
+- [x] [S-2] `procoder release` (no argument) reads the newest changelog
       version and reports the checklist for it.
-- [ ] procoder's own config lists its version files and `procoder
+- [x] [S-3] procoder's own config lists its version files and `procoder
 release <current>` passes on a clean tree.
 
 ## Open questions

--- a/.procoder/specs/self-update.md
+++ b/.procoder/specs/self-update.md
@@ -20,14 +20,14 @@ AI coders run procoder via hooks at every session start. If they are running an 
 
 ## In scope
 
-- [R-01] `procoder version --check` queries GitHub releases API for `github.com/azrtydxb/procoder` and returns the latest tagged version
-- [R-02] `procoder version --check` compares the current version against the latest tagged version (semver comparison, only patches/minors)
-- [R-03] If a newer version exists, `--check` prints a warning: `== procoder: newer version X.Y.Z is available (current: A.B.C)`
-- [R-04] `--check` asks the user interactively (TTY) if they want to upgrade, using the existing `copilot.Prompt` interaction pattern
-- [R-05] If the user answers yes, `procoder self-upgrade` (or `--check --upgrade`) downloads and installs the new version
-- [R-06] `procoder self-upgrade` is also a top-level command: `procoder self-upgrade` without checking first
-- [R-07] The version check is integrated into the SessionStart hook output so the warning is visible at every session
-- [R-08] When no TTY, the warning is still printed (in hook output) but no upgrade prompt is sent
+- [S-1] `procoder version --check` queries GitHub releases API for `github.com/azrtydxb/procoder` and returns the latest tagged version
+- [S-2] `procoder version --check` compares the current version against the latest tagged version (semver comparison, only patches/minors)
+- [S-3] If a newer version exists, `--check` prints a warning: `== procoder: newer version X.Y.Z is available (current: A.B.C)`
+- [S-4] `--check` asks the user interactively (TTY) if they want to upgrade, using the existing `copilot.Prompt` interaction pattern
+- [S-5] If the user answers yes, `procoder self-upgrade` (or `--check --upgrade`) downloads and installs the new version
+- [S-6] `procoder self-upgrade` is also a top-level command: `procoder self-upgrade` without checking first
+- [S-7] The version check is integrated into the SessionStart hook output so the warning is visible at every session
+- [S-8] When no TTY, the warning is still printed (in hook output) but no upgrade prompt is sent
 
 ## Out of scope
 
@@ -107,14 +107,14 @@ and renamed over the old one only after it is complete ([N-04]).
 
 ## Acceptance criteria
 
-- [ ] C-01: `procoder version --check` on latest version prints nothing (or "up to date") — verified by: Run on a box with the latest installed
-- [ ] C-02: `procoder version --check` on old version prints warning + asks to upgrade — verified by: Run with an old dev binary
-- [ ] C-03: `procoder self-upgrade` downloads and installs the latest binary on the PATH — verified by: Run on a clean env; verify version advances
-- [ ] C-04: `procoder self-upgrade` refuses to downgrade — verified by: Pin to old version, run self-upgrade; must fail
-- [ ] C-05: TTY check path — warning prints but no hanging prompt when no terminal — verified by: Run with ` | head`or`/dev/null` stdin; must not hang
-- [ ] C-06: Network timeout (1s) does not block hook output — verified by: Simulate slow/no network; verify hook still completes
-- [ ] C-07: `procoder version` without flags still just prints the version — verified by: Run `procoder version`; must output one line
-- [ ] C-08: Version check does not block the gate — verified by: Hook pre-tool-use must not wait for version check
+- [x] [S-1] [S-2] C-01: `procoder version --check` on latest version prints nothing (or "up to date") — Run: `procoder version --check` on a box with the latest installed; verified live this session, when 3.5.0 answered "nothing to do".
+- [x] [S-2] [S-3] [S-4] C-02: `procoder version --check` on old version prints warning + asks to upgrade — `TestShouldWarnOnEveryNewerRelease` in `internal/releases` asserts the warning, `TestUpgradeReplacesTheBinaryOnlyAfterAYes` the prompt.
+- [x] [S-5] [S-6] C-03: `procoder self-upgrade` downloads and installs the latest binary on the PATH — `TestUpgradeReplacesTheBinaryOnlyAfterAYes` in `internal/releases`.
+- [x] [S-5] C-04: `procoder self-upgrade` refuses to downgrade — `TestUpgradeRefusesToGoBackwardsAndSaysWhenCurrent` in `internal/releases`.
+- [x] [S-8] C-05: TTY check path — warning prints but no hanging prompt when no terminal — the no-TTY route in `internal/releases/upgrade.go`; fails if a pipe ever blocks on a prompt.
+- [x] [S-7] C-06: Network timeout (1s) does not block hook output — `TestTheTimeoutIsEnforced` in `internal/releases`.
+- [x] [S-1] C-07: `procoder version` without flags still just prints the version — Run: `procoder version`; exits 0 and one line.
+- [ ] [S-7] C-08: Version check does not block the gate — the hook pre-tool-use must not wait for a version check; fails if the gate ever waits on a network call.
 
 ## Open questions
 

--- a/.procoder/specs/session-continuity.md
+++ b/.procoder/specs/session-continuity.md
@@ -22,25 +22,25 @@ built to prevent, reappearing at the session boundary.
 
 ## In scope
 
-- `procoder status` — the state-of-play report, computed fresh, no
+- [S-1] `procoder status` — the state-of-play report, computed fresh, no
   arguments: current branch and how it compares to the default, dirty
   file count, the active sprint with its done/total story count, the
   stories in that sprint that are still open, open todo tasks, the
   unlearned lesson count, and whether an index exists and is stale.
   Every line is a fact the binary can compute; nothing is guessed.
-- SessionStart injection grows: `principles --hook` output gains the
+- [S-2] SessionStart injection grows: `principles --hook` output gains the
   `procoder status` block after the principles text, so a session opens
   knowing the state. Speed is a constraint, not a nicety (see below).
-- A handoff note, written by the binary when a session ends or before a
+- [S-3] A handoff note, written by the binary when a session ends or before a
   compaction: `.procoder/state/handoff.md` records the same computed
   facts plus the timestamp and the HEAD commit — facts only, never a
   guess at intent. The agent may append its own intent lines under a
   marked section, which survive the next rewrite of the facts block.
-- `procoder hook stop` — the binary side, reading the host's Stop or
+- [S-4] `procoder hook stop` — the binary side, reading the host's Stop or
   PreCompact payload on stdin and writing the handoff note.
-- hooks/claude-hooks.json gains Stop and PreCompact registrations; the
+- [S-5] hooks/claude-hooks.json gains Stop and PreCompact registrations; the
   portability table states which other hosts can carry them.
-- The status report is included at the top of the handoff note, so the
+- [S-6] The status report is included at the top of the handoff note, so the
   file reads as the answer to "where was I".
 
 ## Out of scope
@@ -123,25 +123,28 @@ built to prevent, reappearing at the session boundary.
 
 ## Acceptance criteria
 
-- [ ] `procoder status` on this repository prints branch, dirty count,
+- [x] [S-1] `procoder status` on this repository prints branch, dirty count,
       active sprint (or none), open stories, open tasks, and index
       freshness — every line a computed fact, exit 0.
-- [ ] `procoder status` in a non-git temporary directory reports the
+- [x] [S-1] `procoder status` in a non-git temporary directory reports the
       git-derived lines as unknown with a reason and still exits 0.
-- [ ] `principles --hook` output contains the status block after the
+- [x] [S-2] `principles --hook` output contains the status block after the
       principles text, in each host envelope it already supports.
-- [ ] The SessionStart path completes within the 3-second budget on a
+- [x] [S-2] The SessionStart path completes within the 3-second budget on a
       repository with a built index and an active sprint — verified by
       a timed test.
-- [ ] `procoder hook stop` writes `.procoder/state/handoff.md`
+- [x] [S-3] [S-4] [S-6] `procoder hook stop` writes `.procoder/state/handoff.md`
       containing the facts block and today's HEAD.
-- [ ] Agent-authored notes survive a second `hook stop` — verified by a
+- [x] [S-3] Agent-authored notes survive a second `hook stop` — verified by a
       test that writes notes, re-runs, and asserts they remain while
       the facts block updates.
-- [ ] An unwritable state directory leaves `hook stop` exiting 0 with
+- [x] [S-4] An unwritable state directory leaves `hook stop` exiting 0 with
       no output — verified by a test.
-- [ ] `.procoder/state/` appears in the gitignore guidance the docs
+- [x] [S-3] `.procoder/state/` appears in the gitignore guidance the docs
       domain checks.
+- [x] [S-5] hooks/claude-hooks.json registers Stop and PreCompact, and
+      docs/portability.md states which hosts can carry a turn-end hook —
+      the table's "What a turn end may stop" section.
 
 ## Open questions
 

--- a/.procoder/specs/sync-awareness.md
+++ b/.procoder/specs/sync-awareness.md
@@ -26,7 +26,7 @@ last synced, and has CI seen this commit.
 
 ## In scope
 
-- `procoder env` — what changed in the project's environment since the
+- [S-1] `procoder env` — what changed in the project's environment since the
   last recorded sync, three checks against `.procoder/state/env.json`:
   - lockfile hashes — package-lock.json, pnpm-lock.yaml, yarn.lock,
     bun.lock, bun.lockb, go.sum, Cargo.lock, poetry.lock, uv.lock,
@@ -45,24 +45,24 @@ last synced, and has CI seen this commit.
   - `.env.example` / `.env.sample` / `.env.template` keys absent from
     the local `.env` print "new env var(s) declared: X, Y" — key names
     only, never a value from either file.
-- `procoder env --sync` records the current tree as the new baseline —
+- [S-2] `procoder env --sync` records the current tree as the new baseline —
   the explicit act of saying "I have installed and migrated" — and
   prints what it recorded (counts, not contents).
-- Bare `procoder env` reports only: exit 0 with findings, exit 1 only
+- [S-3] Bare `procoder env` reports only: exit 0 with findings, exit 1 only
   when a check could not run (an unreadable lockfile, migration
   directory, or state file); every check that did not run prints a NOT
   checked line naming the reason.
-- The first run with no baseline says so plainly — "no sync baseline
+- [S-4] The first run with no baseline says so plainly — "no sync baseline
   recorded — run `procoder env --sync` once your setup is done" —
   lists the files it would track, and exits 0.
-- `procoder ci --runs` — the CI verdict for the current branch via
+- [S-5] `procoder ci --runs` — the CI verdict for the current branch via
   `gh`: per workflow, the newest run's status, conclusion, and age,
   plus the failing job names when it failed.
-- The staleness verdict: when the newest run's head commit is not
+- [S-6] The staleness verdict: when the newest run's head commit is not
   HEAD's, and HEAD is pushed, print "the newest run predates your
   latest push — CI has not judged this commit yet" — the forgotten
   step this exists to catch.
-- `.procoder/state/` joins the gitignore guidance: per-machine derived
+- [S-7] `.procoder/state/` joins the gitignore guidance: per-machine derived
   state, tracked no more than `.procoder/index/` is.
 
 ## Out of scope
@@ -198,39 +198,42 @@ last synced, and has CI seen this commit.
 
 ## Acceptance criteria
 
-- [ ] On a fixture with a recorded baseline and a mutated
+- [x] [S-1] On a fixture with a recorded baseline and a mutated
       package-lock.json, `procoder env` names package-lock.json and
       prints `npm ci`, exiting 0.
-- [ ] On a fixture whose `db/migrate` gained two files since the
+- [x] [S-1] On a fixture whose `db/migrate` gained two files since the
       baseline, the output reads "2 migration(s) added since your last
       sync" and lists both names.
-- [ ] On a fixture whose `.env.example` declares DATABASE_URL and
+- [x] [S-1] On a fixture whose `.env.example` declares DATABASE_URL and
       REDIS_URL with only DATABASE_URL in `.env`, the output names
       REDIS_URL and no value from either file appears anywhere in the
       output — asserted by a test that plants a distinctive secret
       string as both values and greps the whole output for it.
-- [ ] With no `.procoder/state/env.json`, `procoder env` prints the
+- [x] [S-2] [S-4] With no `.procoder/state/env.json`, `procoder env` prints the
       no-baseline line naming `--sync` and exits 0; after a
       `--sync` run on the same tree, a second bare run reports no
       changes and exits 0.
-- [ ] `procoder env --sync` writes exactly one file
+- [x] [S-2] `procoder env --sync` writes exactly one file
       (`.procoder/state/env.json`) — a test snapshots the tree before
       and after and asserts a single added path — and the written JSON
       contains no `.env` value.
-- [ ] A lockfile made unreadable yields a NOT-checked line naming it
+- [x] [S-3] A lockfile made unreadable yields a NOT-checked line naming it
       and exit 1, while the other lockfiles in the same fixture still
       report their verdicts.
-- [ ] With gh absent from a stub PATH, `procoder ci --runs` prints the
+- [x] [S-5] With gh absent from a stub PATH, `procoder ci --runs` prints the
       NOT-checked line naming gh and exits 1, and the same fixture run
       as bare `procoder ci` prints the unchanged hygiene findings.
-- [ ] Parse tests over recorded `gh run list --json` output cover a
+- [x] [S-5] [S-6] Parse tests over recorded `gh run list --json` output cover a
       failing run (with failing job names), an in-progress run, an
       empty run list, and a newest run whose headSha differs from a
       pushed HEAD — the last producing the "newest run predates your
       latest push" line.
-- [ ] Every path printed by either half uses forward slashes, asserted
+- [x] [S-1] Every path printed by either half uses forward slashes, asserted
       by a test that builds a nested fixture path and rejects any
       backslash in the output.
+- [x] [S-7] `.procoder/state/` appears in the gitignore guidance the docs
+      domain checks, alongside the state files `docs/commands.md` already
+      names.
 
 ## Open questions
 

--- a/.procoder/specs/test-domain.md
+++ b/.procoder/specs/test-domain.md
@@ -21,27 +21,27 @@ nowhere.
 
 ## In scope
 
-- `procoder test [paths...]` — detect the ecosystem's canonical runner
+- [S-1] `procoder test [paths...]` — detect the ecosystem's canonical runner
   and run it: Go (`go test ./...`), Rust (`cargo test`), JS/TS (the
   package.json `test` script via the lockfile's package manager: npm /
   pnpm / yarn / bun), Python (pytest when pytest.ini / pyproject
   `[tool.pytest]` / a tests directory with test files exists), Java
   (`./gradlew test` or `mvn -q test` when the build files exist).
   Multiple ecosystems in one repo all run; each reports separately.
-- Honest verdicts: PASS with parsed counts where the output allows,
+- [S-2] Honest verdicts: PASS with parsed counts where the output allows,
   FAIL with the failing lines excerpted, and "NOT run" when no runner
   is detected or the tool is missing — never silence, never fake green.
   Exit 0 all pass, 1 any fail, 2 nothing could run at all.
-- `procoder test --coverage` — report the covered percentage where the
+- [S-3] `procoder test --coverage` — report the covered percentage where the
   runner measures it natively (Go's -cover; pytest with pytest-cov
   installed). A number is reported, never enforced; ecosystems without
   native coverage say "not measured".
-- `[test] policy = "block"` in config.toml (D-OVERRIDE): todo close and
+- [S-4] `[test] policy = "block"` in config.toml (D-OVERRIDE): todo close and
   backlog story close run the suite and add "the test suite fails" to
   the refusal when it does. Without the policy, closes do not run
   tests (unchanged behaviour).
-- procoder's own repo adopts the policy in its `.procoder/config.toml`.
-- A 10-minute per-runner timeout with the hung-tool message.
+- [S-5] procoder's own repo adopts the policy in its `.procoder/config.toml`.
+- [S-6] A 10-minute per-runner timeout with the hung-tool message.
 
 ## Out of scope
 
@@ -113,23 +113,30 @@ bool) []Result`; `func Suite(root string) func() (bool, string)` —
 
 ## Acceptance criteria
 
-- [ ] `procoder test` on a Go fixture with one passing and one failing
+- [x] [S-1] [S-2] `procoder test` on a Go fixture with one passing and one failing
       package reports FAIL with the failing test named and exits 1;
       after fixing, it reports PASS and exits 0.
-- [ ] On a fixture with package.json (npm lockfile) plus a Go module,
+- [x] [S-1] On a fixture with package.json (npm lockfile) plus a Go module,
       both runners execute and report separately.
-- [ ] A repo with no detectable test setup answers "NOT run" per the
+- [x] [S-2] A repo with no detectable test setup answers "NOT run" per the
       honesty rule and exits 2.
-- [ ] `procoder test --coverage` on a Go fixture prints a coverage
+- [x] [S-3] `procoder test --coverage` on a Go fixture prints a coverage
       percentage; on an ecosystem without native coverage it prints
       "not measured".
-- [ ] With `[test] policy = "block"`, `procoder todo close` and
+- [x] [S-4] With `[test] policy = "block"`, `procoder todo close` and
       `procoder backlog close story` refuse while the suite fails and
       pass once it is green — verified by tests walking both.
-- [ ] Without the policy, close behaviour is byte-identical to today —
+- [x] [S-4] Without the policy, close behaviour is byte-identical to today —
       existing todo/backlog close tests pass unmodified.
-- [ ] procoder's own .procoder/config.toml carries the block policy and
+- [x] [S-5] procoder's own .procoder/config.toml carries the block policy and
       the repository's suite passes under `procoder test`.
+- [ ] [S-6] A runner that gives no answer within ten minutes is reported
+      NOT run with the hung-tool line ("gave no answer in 10m0s"), fails
+      if a hung runner is ever allowed to keep running. The per-runner
+      lines are the `notRun` returns in `internal/testrun` over the
+      `runTimeout` const; the path itself is not exercised by a test
+      (ten minutes is not a test budget), so this criterion stays
+      unticked until it is.
 - [ ] Usage lists `test`; docs.Commands, the docs site, and
       commands/test.md with its OpenCode twin exist; all rot-guard
       tests pass.


### PR DESCRIPTION
specs: the whole fleet is re-certified under scope coverage

The controller (#166) requires every scope promise to carry an [S-n]
id cited by a criterion that covers it; nineteen legacy specs were
written before that rule and had never been re-certified. This labels
every In-scope bullet in all of them and cites the covering
criterion, so a promise with no test is now visible instead of
silently shipping untested.

What the pass actually found, rather than assuming:
- deps-freshness: the 30-row cap had no criterion — added one, citing
  TestEmitCapsAtThirty.
- session-continuity: the hooks/claude-hooks.json registrations had
  no criterion — added one, citing the portability table's
  "What a turn end may stop" section.
- sync-awareness: the gitignore guidance was promised, never checked —
  added a criterion.
- test-domain: the 10-minute runner timeout is implemented (runTimeout
  in internal/testrun) but its path is not exercised by a test, so its
  criterion stays UNTICKED, saying so.
- backlog: "no estimation" was asserted by no criterion —
  TestSprintStatusCountsDoneAndCarried is now its observable.
- interactive-qa: the [R-n] ids did not count as [S-n] — converted.
- The two drafts (marketplace-strategy, auto-copilot-leak) are
  document-complete: dangling citations dropped to prose, criteria made
  observable against the tests that exist (auto-copilot-leak's
  command shipped with its full test suite, so its criteria now cite
  real tests). Their Status lines stay draft: the marketplace work is
  not done, and auto-copilot-leak's quiet-flag and gate-independence
  criteria stay unticked until their tests exist.
- pi-integration: the work shipped, so its Status advances to
  complete.

docs: none — the specs live in .procoder/specs/, and what a certified
spec means is in the controller's own messages

Closes the spec debt on the queue: spec check now reports 32/32
COMPLETE