### PR TITLE
docs: the fixes made for a review are the code nobody reviews

### DIFF
--- a/.procoder/github/LESSONS.md
+++ b/.procoder/github/LESSONS.md
@@ -443,3 +443,32 @@ closes #209` — and after merging a PR that claimed to close more than
   reading for "is this race fixed" is a different question from reading for
   "does this shape appear anywhere".
 
+## 2026-09-02 hook delivery budget (self) — the fixes for a review are the code nobody reviews
+
+- Class: judgment
+
+- Adaptation: the pre-PR review of #266 found that a formatted body could
+  starve the secret scan. The fix was a must-keep path, and that path
+  shipped with two defects of its own: keep parts were placed against the
+  FULL budget rather than the reserved one, so the omission notice could
+  push the payload past the constant it existed to enforce; and a keep part
+  larger than the whole budget was dropped without being counted, so the one
+  finding declared un-droppable vanished silently. Copilot found both on the
+  PR.
+
+  Neither is subtle. They are in eleven lines written in direct response to
+  a review finding, on the path that finding said was the important one —
+  and nothing read them, because the reviewer had already run. A review is a
+  snapshot of the diff as it was; everything written to satisfy it is newer
+  than the review.
+
+  The same session had already shown the fix. During #249 a verification
+  pass over the fix diff caught a race reintroduced ONE COMMIT after the
+  original was fixed. That pass was not run here.
+
+  The rule: an exception path added to satisfy a finding — a must-keep, a
+  bypass, a special case — is the least-reviewed code in the change. Read
+  those hunks last and hardest, or re-run the reviewer over the fix diff.
+  REVIEW.md now carries it, alongside the budget-excludes-its-own-overhead
+  shape that was the concrete form it took here.
+

--- a/.procoder/github/LESSONS.md
+++ b/.procoder/github/LESSONS.md
@@ -450,7 +450,7 @@ closes #209` — and after merging a PR that claimed to close more than
 - Adaptation: the pre-PR review of #266 found that a formatted body could
   starve the secret scan. The fix was a must-keep path, and that path
   shipped with two defects of its own: keep parts were placed against the
-  FULL budget rather than the reserved one, so the omission notice could
+  _full_ budget rather than the reserved one, so the omission notice could
   push the payload past the constant it existed to enforce; and a keep part
   larger than the whole budget was dropped without being counted, so the one
   finding declared un-droppable vanished silently. Copilot found both on the
@@ -463,7 +463,7 @@ closes #209` — and after merging a PR that claimed to close more than
   than the review.
 
   The same session had already shown the fix. During #249 a verification
-  pass over the fix diff caught a race reintroduced ONE COMMIT after the
+  pass over the fix diff caught a race reintroduced _one commit_ after the
   original was fixed. That pass was not run here.
 
   The rule: an exception path added to satisfy a finding — a must-keep, a

--- a/.procoder/github/REVIEW.md
+++ b/.procoder/github/REVIEW.md
@@ -48,6 +48,19 @@ Check every hunk for:
   the terminator variants, the case the happy path skips.
 - Test fixtures that trip our own scanners: assemble marker/secret-like
   content at runtime, never as a literal.
+- THE FIXES MADE FOR AN EARLIER FINDING, read as new code. A pre-PR review
+  runs once, on the diff as it was; whatever is written to satisfy its
+  findings then ships unreviewed. An exception path added to satisfy a
+  finding — a must-keep, a bypass, a special case — is the least-reviewed
+  code in the change and sits on the path the finding said was important.
+  Read those hunks last and hardest, or run the reviewer again over the fix
+  diff.
+- A BUDGET THAT EXCLUDES ITS OWN OVERHEAD. A size limit whose error
+  message, notice, separator, or envelope is added after the limit is
+  applied does not hold: the overflow lands in the very thing that was
+  meant to explain it. Reserve the overhead inside the limit, and assert
+  the assembled result against the constant with no slack — a tolerance in
+  the test is how the overflow passes.
 - CHECK-THEN-ACT on a shared file: a stat (or a read, or an exists test)
   followed by a remove, rename, or create, with nothing binding the two to
   the same file. Between them another process can replace what was


### PR DESCRIPTION
The reflection step #266 shipped without.

Copilot found two real defects on that PR, and **both were in code written to satisfy an earlier finding**. The pre-PR review found that a formatted body could starve the secret scan; the fix was a must-keep path, and that path shipped with two defects of its own. Keep parts were placed against the *full* budget rather than the reserved one, so the omission notice could push the payload past the very constant it exists to enforce. And a keep part larger than the budget was dropped without being counted — so the one finding declared un-droppable vanished silently, which is the exact shape the notice was added to prevent.

Neither is subtle. They are eleven lines written in direct response to a review finding, on the path that finding said was the important one, and nothing read them — because the reviewer had already run. A review is a snapshot of the diff as it was; everything written to satisfy it is newer than the review.

The same session had already demonstrated the fix and then not applied it: during #249 a verification pass over the fix diff caught a race reintroduced one commit after the original was fixed. That pass was not run for #266.

## What changes

Two rubric lines in `.procoder/github/REVIEW.md`, because the general shape and the concrete one are both worth looking for:

- **The fixes made for an earlier finding, read as new code.** An exception path added to satisfy a review — a must-keep, a bypass, a special case — is the least-reviewed code in the change. Read those hunks last and hardest, or re-run the reviewer over the fix diff.
- **A budget that excludes its own overhead.** A size limit whose notice, separator or envelope is added after the limit is applied does not hold, and the overflow lands in the thing meant to explain it. Reserve the overhead inside the limit and assert with no slack — a tolerance in the test is how the overflow passes, which is how it passed here.

Plus the ledger entry. `procoder lessons`: 42 lessons, 0 unlearned.

## Testing

`procoder check` clean, 0 blocking. `procoder lessons` reports the new entry as learned. No code changes — this is the rubric and the ledger.