### PR TITLE
fix: the gate's hint invited the one-liner that eats the first line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ _The write-back that the gate invites is the one that is safe._
 
 **Fixed — the gate's own hint no longer invites a one-liner that deletes
 the file's first line.**
-([#278](https://github.com/azrtydxb/procoder/issues/278)) `procoder format
+([#281](https://github.com/azrtydxb/procoder/pull/281),
+[#278](https://github.com/azrtydxb/procoder/issues/278)) `procoder format
 <file>` has printed the file's bytes on stdout and its verdict on stderr
 since 3.5.0, which made `> file.formatted` safe. It also made
 `procoder format f | tail -n +2` — stripping "the header" — delete the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@ Rules that earn their place:
   handle opened none of what its paragraph cites.
 -->
 
+## Unreleased
+
+_The write-back that the gate invites is the one that is safe._
+
+**Fixed — the gate's own hint no longer invites a one-liner that deletes
+the file's first line.**
+([#278](https://github.com/azrtydxb/procoder/issues/278)) `procoder format
+<file>` has printed the file's bytes on stdout and its verdict on stderr
+since 3.5.0, which made `> file.formatted` safe. It also made
+`procoder format f | tail -n +2` — stripping "the header" — delete the
+file's first REAL line, quietly, with exit 0. On a terminal the verdict
+and the content interleave and look like one stream, so the header appears
+to be there; in a pipe it never was. The hint now says what stdout is,
+names a capture path, and says not to redirect over the input. The command
+also refuses to print an empty payload for a non-empty file, as a backstop
+against the failure this command has actually had twice.
+
 ## 3.5.0 — 2026-09-01
 
 _Every host now holds the same turn end, and the record-keeping outlives the reflow._

--- a/cmd/procoder/format_cmd_test.go
+++ b/cmd/procoder/format_cmd_test.go
@@ -157,3 +157,64 @@ func TestFormatRefusesWhenStdoutIsTheFileBeingRead(t *testing.T) {
 		t.Errorf("the first argument won over the real collision: %q", got)
 	}
 }
+
+// stdout carries the file's bytes and nothing else, in every verdict.
+//
+// This is what makes `procoder format f > f.formatted` safe and
+// `procoder format f | tail -n +2 > f` destructive — and the second is
+// what the gate's own hint used to invite. The banner is on stderr, so
+// stripping "the header line" strips the file's first REAL line: a
+// 25-byte file came back 17 bytes with its title gone, silently, exit 0
+// (#278).
+//
+// proved by: printing the verdict banner to out instead of notes — the
+// byte counts below stop matching the file and every caller redirecting
+// stdout writes a banner into their file.
+func TestStdoutIsTheFileAndNothingElse(t *testing.T) {
+	dir := t.TempDir()
+	clean := filepath.Join(dir, "clean.md")
+	body := "# Title\n\nBody text here.\n"
+	if err := os.WriteFile(clean, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, notes bytes.Buffer
+	if code := formatFiles([]string{clean}, &out, &notes); code != 0 {
+		t.Fatalf("a clean file exited %d: %s", code, notes.String())
+	}
+	if out.String() != body {
+		t.Fatalf("stdout is not the file:\n got  %q\n want %q", out.String(), body)
+	}
+	if notes.Len() == 0 {
+		t.Error("nothing on stderr — the verdict has to reach a person somehow")
+	}
+	// The first line of stdout is content, never a banner. A caller who
+	// drops it loses the file's first line.
+	if strings.HasPrefix(out.String(), "==") {
+		t.Errorf("stdout starts with a banner: %q", strings.SplitN(out.String(), "\n", 2)[0])
+	}
+}
+
+// A non-empty file never produces an empty payload.
+//
+// The failure this command has actually had is printing nothing over a
+// file somebody was redirecting into, while exiting 0. The backstop costs
+// one comparison.
+//
+// proved by: removing the length check in formatFiles — a verdict that
+// somehow yields no content goes back to being written out as success.
+func TestNonEmptyFileNeverPrintsNothing(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.md", "b.go", "c.unknownext"} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("some real content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var out, notes bytes.Buffer
+		formatFiles([]string{path}, &out, &notes)
+		if out.Len() == 0 {
+			t.Errorf("%s: a non-empty file produced an empty payload — a caller redirecting stdout has just lost it (%s)",
+				name, strings.TrimSpace(notes.String()))
+		}
+	}
+}

--- a/cmd/procoder/format_cmd_test.go
+++ b/cmd/procoder/format_cmd_test.go
@@ -172,7 +172,12 @@ func TestFormatRefusesWhenStdoutIsTheFileBeingRead(t *testing.T) {
 // stdout writes a banner into their file.
 func TestStdoutIsTheFileAndNothingElse(t *testing.T) {
 	dir := t.TempDir()
-	clean := filepath.Join(dir, "clean.md")
+	// An extension no formatter claims. A .md file goes through prettier,
+	// so on a machine without it the verdict is Unchecked and this test
+	// would fail for a reason that has nothing to do with the contract it
+	// is named for. Out of scope exercises the same path — stdout is
+	// still the file's bytes — and needs nothing installed.
+	clean := filepath.Join(dir, "notes.unknownext")
 	body := "# Title\n\nBody text here.\n"
 	if err := os.WriteFile(clean, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
@@ -180,7 +185,7 @@ func TestStdoutIsTheFileAndNothingElse(t *testing.T) {
 
 	var out, notes bytes.Buffer
 	if code := formatFiles([]string{clean}, &out, &notes); code != 0 {
-		t.Fatalf("a clean file exited %d: %s", code, notes.String())
+		t.Fatalf("an out-of-scope file exited %d: %s", code, notes.String())
 	}
 	if out.String() != body {
 		t.Fatalf("stdout is not the file:\n got  %q\n want %q", out.String(), body)

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -1633,6 +1633,22 @@ func formatFiles(files []string, out, notes io.Writer) int {
 			// it unsafe to redirect onto any one of these files. Say which.
 			fmt.Fprintf(out, "== %s — these bytes belong in this file; do not redirect a multi-file run over one of them\n", f)
 		}
+		// A non-empty file must never produce an empty payload. Every
+		// verdict above puts the file's own bytes on stdout, so this
+		// cannot happen by design — which is exactly why it is worth
+		// asserting: the failure mode this command has actually had is
+		// printing nothing over a file somebody was redirecting into
+		// (#120, #278), and it exits 0 while doing it. A backstop that
+		// costs one comparison is cheaper than finding out again.
+		if len(content) == 0 {
+			if info, serr := os.Stat(f); serr == nil && info.Size() > 0 {
+				fmt.Fprintf(notes,
+					"== %s — REFUSING to print nothing for a %d-byte file. This is a bug in procoder;\n"+
+						"   the file is untouched. Please report it with this line.\n", f, info.Size())
+				code = 1
+				continue
+			}
+		}
 		if _, err := out.Write(content); err != nil {
 			// A closed stdout (`| head`) is the ordinary case. Say which file did
 			// not make it out and leave a non-zero exit behind, because a format

--- a/cmd/procoder/main.go
+++ b/cmd/procoder/main.go
@@ -1634,12 +1634,13 @@ func formatFiles(files []string, out, notes io.Writer) int {
 			fmt.Fprintf(out, "== %s — these bytes belong in this file; do not redirect a multi-file run over one of them\n", f)
 		}
 		// A non-empty file must never produce an empty payload. Every
-		// verdict above puts the file's own bytes on stdout, so this
-		// cannot happen by design — which is exactly why it is worth
-		// asserting: the failure mode this command has actually had is
-		// printing nothing over a file somebody was redirecting into
-		// (#120, #278), and it exits 0 while doing it. A backstop that
-		// costs one comparison is cheaper than finding out again.
+		// verdict puts SOMETHING that belongs in the file on stdout — the
+		// formatter's output when it is unformatted, the file's own bytes
+		// otherwise — so this cannot happen by design, which is exactly
+		// why it is worth asserting: the failure this command has
+		// actually had is printing nothing over a file somebody was
+		// redirecting into (#120, #278), while exiting 0. A backstop that
+		// costs one comparison is cheaper than finding out a third time.
 		if len(content) == 0 {
 			if info, serr := os.Stat(f); serr == nil && info.Size() > 0 {
 				fmt.Fprintf(notes,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -209,6 +209,30 @@ Prints each file's formatted result (gofmt, ruff, prettier, rustfmt,
 clang-format, shfmt — the project's config always wins) so it can be
 reviewed and written. Never touches the file.
 
+**stdout is the file's bytes and nothing else, in every verdict.** Already
+formatted, out of scope, could not be checked — stdout is still exactly
+what belongs in that file. The verdict line goes to **stderr**, so it can
+be read on a terminal and cannot land in a redirect.
+
+That makes the write-back safe, and it has one shape:
+
+```sh
+procoder format notes.md > notes.md.formatted   # review it, then move it into place
+```
+
+**Do not strip a header line.** There is no header on stdout, so
+`procoder format f | tail -n +2` deletes the file's _first real line_ —
+quietly, with exit 0. It looks like a header on a terminal only because
+stderr and stdout interleave there. This cost two files in a real
+repository before the banner moved to stderr, and the same one-liner
+kept costing first lines afterwards.
+
+**Never redirect over the file being formatted.** `procoder format f > f`
+is refused, because the shell truncates `f` before procoder is even
+started — there is nothing left to read and nothing to print. A multi-file
+run prints a header per file _on stdout_ precisely so it cannot be
+mistaken for one file's content.
+
 #### `procoder lint [--types] [paths...]`
 
 The canonical linter per ecosystem: golangci-lint (Go), ruff check

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -209,10 +209,17 @@ Prints each file's formatted result (gofmt, ruff, prettier, rustfmt,
 clang-format, shfmt — the project's config always wins) so it can be
 reviewed and written. Never touches the file.
 
-**stdout is the file's bytes and nothing else, in every verdict.** Already
-formatted, out of scope, could not be checked — stdout is still exactly
-what belongs in that file. The verdict line goes to **stderr**, so it can
-be read on a terminal and cannot land in a redirect.
+**For a single file, stdout is that file's content and nothing else, in
+every verdict.** Already formatted, out of scope, could not be checked —
+stdout is still exactly what belongs in that file (the formatter's output
+when it needed changes, the file's own bytes otherwise). The verdict line
+goes to **stderr**, so it can be read on a terminal and cannot land in a
+redirect.
+
+A run naming several files is the exception, and a deliberate one: it puts
+a header per file **on stdout**, because five files cannot share one
+stream without them — and because that makes a multi-file run visibly
+unsafe to redirect over any single file. Redirect one file at a time.
 
 That makes the write-back safe, and it has one shape:
 

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -307,8 +307,12 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 		// file's first line, because the banner is on stderr and stdout
 		// is already nothing but the file's bytes (#278). Say what stdout
 		// IS, and name a redirect that cannot land on the input.
-		fmt.Fprintf(stdout, "unformatted  %s  (`procoder format %q` writes the formatted bytes to stdout — no header; capture with `> %s.formatted`, never over the file itself)\n",
-			r.File, r.File, r.File)
+		// Both paths are quoted. An unquoted redirect target breaks on a
+		// path with a space: the redirection lands on the first word and
+		// the rest become extra arguments to procoder format — which is
+		// the shape of footgun this hint exists to close.
+		fmt.Fprintf(stdout, "unformatted  %s  (`procoder format %q` writes the formatted bytes to stdout — no header; capture with `> %q`, never over the file itself)\n",
+			r.File, r.File, r.File+".formatted")
 	}
 	for _, r := range unchecked {
 		fmt.Fprintf(stdout, "UNCHECKED    %s — %s\n", r.File, r.Reason)

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -301,7 +301,14 @@ func RunWith(paths []string, root string, commitMessage string, stdout io.Writer
 	}
 
 	for _, r := range unformatted {
-		fmt.Fprintf(stdout, "unformatted  %s  (run `procoder format %q` for the result)\n", r.File, r.File)
+		// "for the result" invited the wrong thing. It reads as "this
+		// prints a report you extract the content from", and the obvious
+		// extraction — strip the banner line — silently deletes the
+		// file's first line, because the banner is on stderr and stdout
+		// is already nothing but the file's bytes (#278). Say what stdout
+		// IS, and name a redirect that cannot land on the input.
+		fmt.Fprintf(stdout, "unformatted  %s  (`procoder format %q` writes the formatted bytes to stdout — no header; capture with `> %s.formatted`, never over the file itself)\n",
+			r.File, r.File, r.File)
 	}
 	for _, r := range unchecked {
 		fmt.Fprintf(stdout, "UNCHECKED    %s — %s\n", r.File, r.Reason)


### PR DESCRIPTION
Addresses #278.

## The reported bug is fixed; a quieter one was underneath it

The report says `procoder format` on an already-formatted file prints only a header, so the documented write-back truncates the file to zero. That was true before 3.5.0 and **is not true now** — #254 moved the verdict to stderr and put the file's own bytes on stdout in every verdict. I verified both the released 3.5.0 binary and this tree do that.

The data loss did not go away with it. It got quieter:

```console
$ wc -c clean.md
      25 clean.md
$ procoder format clean.md | tail -n +2 > /tmp/f && cp /tmp/f clean.md
$ wc -c clean.md
      17 clean.md          # '# Title' is gone. exit 0.
```

With no header on stdout, stripping "the header line" deletes the file's **first real line**. On a terminal the verdict and the content interleave and look like one stream, so the header still appears to be there; in a pipe it never was. The reporter's diagnosis was stale, the file loss was real, and the mechanism was the opposite of the one described.

## The fix is where the pattern comes from

```diff
-unformatted  f  (run `procoder format "f"` for the result)
+unformatted  f  (`procoder format "f"` writes the formatted bytes to stdout — no header;
+                 capture with `> f.formatted`, never over the file itself)
```

"for the result" reads as *this prints a report you extract content from*, and the obvious extraction is the destructive one.

`docs/commands.md` now states the content-only guarantee, gives the one safe shape, and says plainly that stripping a header line deletes a real one. `procoder format` also refuses to print an empty payload for a non-empty file — by design no verdict can produce one, which is why it is worth asserting: printing nothing over a file somebody was redirecting into is the failure this command has actually had twice (#120, #278).

## Two suggestions deliberately not taken — both your call, not mine

- **A distinct exit code for the no-op case.** ADR 0003 fixes the exit codes at 0, 1 and 2. A fourth changes what every existing caller reads from this command.
- **`--write` / `--in-place`.** AGENTS.md states the opposite contract in plain words: the binary prints, the agent reviews and writes, procoder never touches the file. That is P-CONTROL, not an oversight — a flag reversing it is a decision about what procoder is.

Either is small to add on top if you want it.

## Verified

The documented pattern is now lossless (25 → 25 bytes, title intact). `TestStdoutIsTheFileAndNothingElse` fails if a banner ever reaches stdout; `TestNonEmptyFileNeverPrintsNothing` fails if any verdict yields an empty payload. Full suite green, gate 0 blocking.