### PR TITLE
release: 3.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer. All nine domains shipped: security, best practices, maintainability, performance, documentation, clean code, CI/CD, DevOps, GitOps \u2014 plus the code index. Hooks hand the agent results; the agent stays in control.",
   "author": {
     "name": "Pascal Watteel"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "procoder",
   "metadata": {
     "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
-    "version": "3.5.0"
+    "version": "3.6.0"
   },
   "plugins": [
     {

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "commands": "./commands/",
   "skills": "./commands/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Rules that earn their place:
   handle opened none of what its paragraph cites.
 -->
 
-## Unreleased
+## 3.6.0 — 2026-09-09
 
 _Every command can be called instead of spawned, and two ways procoder
 could cost you something are closed._

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ turns every escaped bug into a permanently closed class. The agent stays
 in control — nothing ever touches your code behind its back.
 
 ![CI](https://github.com/azrtydxb/procoder/actions/workflows/ci.yml/badge.svg)
-![Version](https://img.shields.io/badge/version-3.5.0-7C3AED)
+![Version](https://img.shields.io/badge/version-3.6.0-7C3AED)
 ![License](https://img.shields.io/badge/license-Apache--2.0-7C3AED)
 ![Agents](https://img.shields.io/badge/works%20with-20%2B%20agents-7C3AED)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ bug's whole class, and one contract that works across every AI coding
 agent. The agent stays in control; nothing ever touches your code behind
 its back.
 
-Current version: **3.5.0**
+Current version: **3.6.0**
 
 ```mermaid
 flowchart LR

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "procoder",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A harness that gives AI coders the tools and skills to work like a senior developer",
   "license": "Apache-2.0",
   "repository": {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: procoder
-version: 3.5.0
+version: 3.6.0
 description: A harness that gives AI coders the tools and skills to work like a senior developer
 entry: __init__.py
 provides_hooks:


### PR DESCRIPTION
`procoder release 3.6.0` reports ready:

```
release 3.6.0 is ready — tag it:
  git tag -a v3.6.0 -m "3.6.0"
```

Nine version files and the changelog heading. The entries themselves landed with the changes they describe.

## What is in it

**Added** — every command answers over a local socket (#272). `procoder serve`, one envelope, typed results beside the human bytes, jobs for the nine long-running commands, and the executing four behind their own opt-in door. `[service] mode` is `off` by default, so nothing changes for a repository that upgrades.

**Fixed** — a single-agent repository is no longer blocked for the eleven hosts it does not use (#280 / #279).

**Fixed** — the gate's hint no longer invites a one-liner that deletes a file's first line (#281 / #278).

## Version

Minor over 3.5.0. New command, new config keys, changed gate output — RELEASE.md counts "what a command prints" as at least a minor bump. `AGENTS.md` is untouched, so `ContractVersion` stays at **3** and no adopter's agent is governed differently.

## After merge

Tag the merged commit and push; the release job builds the five platform binaries and `SHA256SUMS` from the tag. Nothing is built locally.